### PR TITLE
Fixes addColumnNull typo

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -393,8 +393,8 @@ addColumnDefault
 addColumnDefault column ty = UnsafeAlterColumns $
   "ADD COLUMN" <+> renderAlias column <+> renderTypeExpression ty
 
--- | An `addColumnDefault` adds a new `Null` column. The new column is
--- initially filled with @NULL@s.
+-- | An `addColumnNull` adds a new `Null` column. The new column is initially
+-- filled with @NULL@s.
 --
 -- >>> :{
 -- let


### PR DESCRIPTION
There was a small typo where `addColumnNull`'s comment referred to `addColumnDefault`.