### PR TITLE
Add double quotes around aliases

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL.hs
@@ -80,7 +80,7 @@
 -- We can easily see the generated SQL is unsuprising looking.
 --
 -- >>> renderDefinition setup
--- "CREATE TABLE users (id serial, name text NOT NULL, CONSTRAINT pk_users PRIMARY KEY (id)); CREATE TABLE emails (id serial, user_id int NOT NULL, email text, CONSTRAINT pk_emails PRIMARY KEY (id), CONSTRAINT fk_user_id FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE);"
+-- "CREATE TABLE \"users\" (\"id\" serial, \"name\" text NOT NULL, CONSTRAINT \"pk_users\" PRIMARY KEY (\"id\")); CREATE TABLE \"emails\" (\"id\" serial, \"user_id\" int NOT NULL, \"email\" text, CONSTRAINT \"pk_emails\" PRIMARY KEY (\"id\"), CONSTRAINT \"fk_user_id\" FOREIGN KEY (\"user_id\") REFERENCES \"users\" (\"id\") ON DELETE CASCADE ON UPDATE CASCADE);"
 --
 -- Notice that @setup@ starts with an empty schema @'[]@ and produces @Schema@.
 -- In our `createTable` commands we included `TableConstraint`s to define
@@ -94,7 +94,7 @@
 -- :}
 --
 -- >>> renderDefinition teardown
--- "DROP TABLE emails; DROP TABLE users;"
+-- "DROP TABLE \"emails\"; DROP TABLE \"users\";"
 --
 -- Next, we'll write `Manipulation`s to insert data into our two tables.
 -- A `Manipulation` is an `insertRow` (or other inserts), `update`
@@ -127,9 +127,9 @@
 -- :}
 --
 -- >>> renderManipulation insertUser
--- "INSERT INTO users (id, name) VALUES (DEFAULT, ($1 :: text)) ON CONFLICT DO NOTHING RETURNING id AS fromOnly;"
+-- "INSERT INTO \"users\" (\"id\", \"name\") VALUES (DEFAULT, ($1 :: text)) ON CONFLICT DO NOTHING RETURNING \"id\" AS \"fromOnly\";"
 -- >>> renderManipulation insertEmail
--- "INSERT INTO emails (id, user_id, email) VALUES (DEFAULT, ($1 :: int4), ($2 :: text)) ON CONFLICT DO NOTHING;"
+-- "INSERT INTO \"emails\" (\"id\", \"user_id\", \"email\") VALUES (DEFAULT, ($1 :: int4), ($2 :: text)) ON CONFLICT DO NOTHING;"
 --
 -- Next we write a `Query` to retrieve users from the database. We're not
 -- interested in the ids here, just the usernames and email addresses. We
@@ -149,7 +149,7 @@
 -- :}
 --
 -- >>> renderQuery getUsers
--- "SELECT u.name AS userName, e.email AS userEmail FROM users AS u INNER JOIN emails AS e ON (u.id = e.user_id)"
+-- "SELECT \"u\".\"name\" AS \"userName\", \"e\".\"email\" AS \"userEmail\" FROM \"users\" AS \"u\" INNER JOIN \"emails\" AS \"e\" ON (\"u\".\"id\" = \"e\".\"user_id\")"
 --
 -- Now that we've defined the SQL side of things, we'll need a Haskell type
 -- for users. We give the type `Generics.SOP.Generic` and

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -110,7 +110,7 @@ CREATE statements
 -- renderDefinition $
 --   createTable #tab (int `As` #a :* real `As` #b :* Nil) Nil
 -- :}
--- "CREATE TABLE tab (a int, b real);"
+-- "CREATE TABLE \"tab\" (\"a\" int, \"b\" real);"
 createTable
   :: ( KnownSymbol table
      , columns ~ (col ': cols)
@@ -136,7 +136,7 @@ createTable table columns constraints = UnsafeDefinition $
 -- renderDefinition
 --   (createTableIfNotExists #tab (int `As` #a :* real `As` #b :* Nil) Nil :: Definition Schema Schema)
 -- :}
--- "CREATE TABLE IF NOT EXISTS tab (a int, b real);"
+-- "CREATE TABLE IF NOT EXISTS \"tab\" (\"a\" int, \"b\" real);"
 createTableIfNotExists
   :: ( Has table schema (constraints :=> columns)
      , SOP.SListI columns
@@ -225,7 +225,7 @@ renderColumn (Column column) = renderAlias column
 --       (int & notNull) `As` #b :* Nil )
 --     ( check (Column #a :* Column #b :* Nil) (#a .> #b) `As` #inequality :* Nil )
 -- :}
--- "CREATE TABLE tab (a int NOT NULL, b int NOT NULL, CONSTRAINT inequality CHECK ((a > b)));"
+-- "CREATE TABLE \"tab\" (\"a\" int NOT NULL, \"b\" int NOT NULL, CONSTRAINT \"inequality\" CHECK ((\"a\" > \"b\")));"
 check
   :: NP (Column columns) subcolumns
   -> Condition '[table ::: ColumnsToRelation subcolumns] 'Ungrouped '[]
@@ -244,7 +244,7 @@ check _cols condition = UnsafeTableConstraintExpression $
 --       int `As` #b :* Nil )
 --     ( unique (Column #a :* Column #b :* Nil) `As` #uq_a_b :* Nil )
 -- :}
--- "CREATE TABLE tab (a int, b int, CONSTRAINT uq_a_b UNIQUE (a, b));"
+-- "CREATE TABLE \"tab\" (\"a\" int, \"b\" int, CONSTRAINT \"uq_a_b\" UNIQUE (\"a\", \"b\"));"
 unique
   :: SOP.SListI subcolumns
   => NP (Column columns) subcolumns
@@ -264,7 +264,7 @@ unique columns = UnsafeTableConstraintExpression $
 --       (text & notNull) `As` #name :* Nil )
 --     ( primaryKey (Column #id :* Nil) `As` #pk_id :* Nil )
 -- :}
--- "CREATE TABLE tab (id serial, name text NOT NULL, CONSTRAINT pk_id PRIMARY KEY (id));"
+-- "CREATE TABLE \"tab\" (\"id\" serial, \"name\" text NOT NULL, CONSTRAINT \"pk_id\" PRIMARY KEY (\"id\"));"
 primaryKey
   :: (SOP.SListI subcolumns, AllNotNull subcolumns)
   => NP (Column columns) subcolumns
@@ -313,7 +313,7 @@ primaryKey columns = UnsafeTableConstraintExpression $
 --          OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )
 -- in renderDefinition setup
 -- :}
--- "CREATE TABLE users (id serial, name text NOT NULL, CONSTRAINT pk_users PRIMARY KEY (id)); CREATE TABLE emails (id serial, user_id int NOT NULL, email text, CONSTRAINT pk_emails PRIMARY KEY (id), CONSTRAINT fk_user_id FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE);"
+-- "CREATE TABLE \"users\" (\"id\" serial, \"name\" text NOT NULL, CONSTRAINT \"pk_users\" PRIMARY KEY (\"id\")); CREATE TABLE \"emails\" (\"id\" serial, \"user_id\" int NOT NULL, \"email\" text, CONSTRAINT \"pk_emails\" PRIMARY KEY (\"id\"), CONSTRAINT \"fk_user_id\" FOREIGN KEY (\"user_id\") REFERENCES \"users\" (\"id\") ON DELETE CASCADE ON UPDATE CASCADE);"
 foreignKey
   :: ForeignKeyed schema table reftable subcolumns refsubcolumns
   => NP (Column columns) subcolumns
@@ -390,7 +390,7 @@ DROP statements
 -- | `dropTable` removes a table from the schema.
 --
 -- >>> renderDefinition $ dropTable #muh_table
--- "DROP TABLE muh_table;"
+-- "DROP TABLE \"muh_table\";"
 dropTable
   :: KnownSymbol table
   => Alias table -- ^ table to remove
@@ -416,7 +416,7 @@ alterTable table alteration = UnsafeDefinition $
 -- | `alterTableRename` changes the name of a table from the schema.
 --
 -- >>> renderDefinition $ alterTableRename #foo #bar
--- "ALTER TABLE foo RENAME TO bar;"
+-- "ALTER TABLE \"foo\" RENAME TO \"bar\";"
 alterTableRename
   :: (KnownSymbol table0, KnownSymbol table1)
   => Alias table0 -- ^ table to rename
@@ -445,7 +445,7 @@ newtype AlterTable
 --   definition = alterTable #tab (addConstraint #positive (check (Column #col :* Nil) (#col .> 0)))
 -- in renderDefinition definition
 -- :}
--- "ALTER TABLE tab ADD CONSTRAINT positive CHECK ((col > 0));"
+-- "ALTER TABLE \"tab\" ADD CONSTRAINT \"positive\" CHECK ((\"col\" > 0));"
 addConstraint
   :: KnownSymbol alias
   => Alias alias
@@ -467,7 +467,7 @@ addConstraint alias constraint = UnsafeAlterTable $
 --   definition = alterTable #tab (dropConstraint #positive)
 -- in renderDefinition definition
 -- :}
--- "ALTER TABLE tab DROP CONSTRAINT positive;"
+-- "ALTER TABLE \"tab\" DROP CONSTRAINT \"positive\";"
 dropConstraint
   :: KnownSymbol constraint
   => Alias constraint
@@ -493,7 +493,7 @@ class AddColumn ty where
   --   definition = alterTable #tab (addColumn #col2 (text & default_ "foo"))
   -- in renderDefinition definition
   -- :}
-  -- "ALTER TABLE tab ADD COLUMN col2 text DEFAULT E'foo';"
+  -- "ALTER TABLE \"tab\" ADD COLUMN \"col2\" text DEFAULT E'foo';"
   --
   -- >>> :{
   -- let
@@ -505,7 +505,7 @@ class AddColumn ty where
   --   definition = alterTable #tab (addColumn #col2 text)
   -- in renderDefinition definition
   -- :}
-  -- "ALTER TABLE tab ADD COLUMN col2 text;"
+  -- "ALTER TABLE \"tab\" ADD COLUMN \"col2\" text;"
   addColumn
     :: KnownSymbol column
     => Alias column -- ^ column to add
@@ -532,7 +532,7 @@ instance {-# OVERLAPPABLE #-} AddColumn ('NoDef :=> 'Null ty)
 --   definition = alterTable #tab (dropColumn #col2)
 -- in renderDefinition definition
 -- :}
--- "ALTER TABLE tab DROP COLUMN col2;"
+-- "ALTER TABLE \"tab\" DROP COLUMN \"col2\";"
 dropColumn
   :: KnownSymbol column
   => Alias column -- ^ column to remove
@@ -552,7 +552,7 @@ dropColumn column = UnsafeAlterTable $
 --   definition = alterTable #tab (renameColumn #foo #bar)
 -- in renderDefinition definition
 -- :}
--- "ALTER TABLE tab RENAME COLUMN foo TO bar;"
+-- "ALTER TABLE \"tab\" RENAME COLUMN \"foo\" TO \"bar\";"
 renameColumn
   :: (KnownSymbol column0, KnownSymbol column1)
   => Alias column0 -- ^ column to rename
@@ -589,7 +589,7 @@ newtype AlterColumn (ty0 :: ColumnType) (ty1 :: ColumnType) =
 --   definition = alterTable #tab (alterColumn #col (setDefault 5))
 -- in renderDefinition definition
 -- :}
--- "ALTER TABLE tab ALTER COLUMN col SET DEFAULT 5;"
+-- "ALTER TABLE \"tab\" ALTER COLUMN \"col\" SET DEFAULT 5;"
 setDefault
   :: Expression '[] 'Ungrouped '[] ty -- ^ default value to set
   -> AlterColumn (constraint :=> ty) ('Def :=> ty)
@@ -606,7 +606,7 @@ setDefault expression = UnsafeAlterColumn $
 --   definition = alterTable #tab (alterColumn #col dropDefault)
 -- in renderDefinition definition
 -- :}
--- "ALTER TABLE tab ALTER COLUMN col DROP DEFAULT;"
+-- "ALTER TABLE \"tab\" ALTER COLUMN \"col\" DROP DEFAULT;"
 dropDefault :: AlterColumn ('Def :=> ty) ('NoDef :=> ty)
 dropDefault = UnsafeAlterColumn $ "DROP DEFAULT"
 
@@ -622,7 +622,7 @@ dropDefault = UnsafeAlterColumn $ "DROP DEFAULT"
 --   definition = alterTable #tab (alterColumn #col setNotNull)
 -- in renderDefinition definition
 -- :}
--- "ALTER TABLE tab ALTER COLUMN col SET NOT NULL;"
+-- "ALTER TABLE \"tab\" ALTER COLUMN \"col\" SET NOT NULL;"
 setNotNull
   :: AlterColumn (constraint :=> 'Null ty) (constraint :=> 'NotNull ty)
 setNotNull = UnsafeAlterColumn $ "SET NOT NULL"
@@ -637,7 +637,7 @@ setNotNull = UnsafeAlterColumn $ "SET NOT NULL"
 --   definition = alterTable #tab (alterColumn #col dropNotNull)
 -- in renderDefinition definition
 -- :}
--- "ALTER TABLE tab ALTER COLUMN col DROP NOT NULL;"
+-- "ALTER TABLE \"tab\" ALTER COLUMN \"col\" DROP NOT NULL;"
 dropNotNull
   :: AlterColumn (constraint :=> 'NotNull ty) (constraint :=> 'Null ty)
 dropNotNull = UnsafeAlterColumn $ "DROP NOT NULL"
@@ -655,6 +655,6 @@ dropNotNull = UnsafeAlterColumn $ "DROP NOT NULL"
 --     alterTable #tab (alterColumn #col (alterType (numeric & notNull)))
 -- in renderDefinition definition
 -- :}
--- "ALTER TABLE tab ALTER COLUMN col TYPE numeric NOT NULL;"
+-- "ALTER TABLE \"tab\" ALTER COLUMN \"col\" TYPE numeric NOT NULL;"
 alterType :: TypeExpression ty -> AlterColumn ty0 ty
 alterType ty = UnsafeAlterColumn $ "TYPE" <+> renderTypeExpression ty

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -797,7 +797,7 @@ unsafeAggregateDistinct fun x = UnsafeExpression $ mconcat
 --   expression = sum_ #col
 -- in renderExpression expression
 -- :}
--- "sum(col)"
+-- "sum(\"col\")"
 sum_
   :: PGNum ty
   => Expression relations 'Ungrouped params (nullity ty)
@@ -811,7 +811,7 @@ sum_ = unsafeAggregate "sum"
 --   expression = sumDistinct #col
 -- in renderExpression expression
 -- :}
--- "sum(DISTINCT col)"
+-- "sum(DISTINCT \"col\")"
 sumDistinct
   :: PGNum ty
   => Expression relations 'Ungrouped params (nullity ty)
@@ -842,7 +842,7 @@ instance PGAvg 'PGinterval 'PGinterval
 --   expression = bitAnd #col
 -- in renderExpression expression
 -- :}
--- "bit_and(col)"
+-- "bit_and(\"col\")"
 bitAnd
   :: PGIntegral int
   => Expression relations 'Ungrouped params (nullity int)
@@ -856,7 +856,7 @@ bitAnd = unsafeAggregate "bit_and"
 --   expression = bitOr #col
 -- in renderExpression expression
 -- :}
--- "bit_or(col)"
+-- "bit_or(\"col\")"
 bitOr
   :: PGIntegral int
   => Expression relations 'Ungrouped params (nullity int)
@@ -870,7 +870,7 @@ bitOr = unsafeAggregate "bit_or"
 --   expression = bitAndDistinct #col
 -- in renderExpression expression
 -- :}
--- "bit_and(DISTINCT col)"
+-- "bit_and(DISTINCT \"col\")"
 bitAndDistinct
   :: PGIntegral int
   => Expression relations 'Ungrouped params (nullity int)
@@ -884,7 +884,7 @@ bitAndDistinct = unsafeAggregateDistinct "bit_and"
 --   expression = bitOrDistinct #col
 -- in renderExpression expression
 -- :}
--- "bit_or(DISTINCT col)"
+-- "bit_or(DISTINCT \"col\")"
 bitOrDistinct
   :: PGIntegral int
   => Expression relations 'Ungrouped params (nullity int)
@@ -898,7 +898,7 @@ bitOrDistinct = unsafeAggregateDistinct "bit_or"
 --   expression = boolAnd #col
 -- in renderExpression expression
 -- :}
--- "bool_and(col)"
+-- "bool_and(\"col\")"
 boolAnd
   :: Expression relations 'Ungrouped params (nullity 'PGbool)
   -- ^ what to aggregate
@@ -911,7 +911,7 @@ boolAnd = unsafeAggregate "bool_and"
 --   expression = boolOr #col
 -- in renderExpression expression
 -- :}
--- "bool_or(col)"
+-- "bool_or(\"col\")"
 boolOr
   :: Expression relations 'Ungrouped params (nullity 'PGbool)
   -- ^ what to aggregate
@@ -924,7 +924,7 @@ boolOr = unsafeAggregate "bool_or"
 --   expression = boolAndDistinct #col
 -- in renderExpression expression
 -- :}
--- "bool_and(DISTINCT col)"
+-- "bool_and(DISTINCT \"col\")"
 boolAndDistinct
   :: Expression relations 'Ungrouped params (nullity 'PGbool)
   -- ^ what to aggregate
@@ -937,7 +937,7 @@ boolAndDistinct = unsafeAggregateDistinct "bool_and"
 --   expression = boolOrDistinct #col
 -- in renderExpression expression
 -- :}
--- "bool_or(DISTINCT col)"
+-- "bool_or(DISTINCT \"col\")"
 boolOrDistinct
   :: Expression relations 'Ungrouped params (nullity 'PGbool)
   -- ^ what to aggregate
@@ -958,7 +958,7 @@ countStar = UnsafeExpression $ "count(*)"
 --   expression = count #col
 -- in renderExpression expression
 -- :}
--- "count(col)"
+-- "count(\"col\")"
 count
   :: Expression relations 'Ungrouped params ty
   -- ^ what to count
@@ -971,7 +971,7 @@ count = unsafeAggregate "count"
 --   expression = countDistinct #col
 -- in renderExpression expression
 -- :}
--- "count(DISTINCT col)"
+-- "count(DISTINCT \"col\")"
 countDistinct
   :: Expression relations 'Ungrouped params ty
   -- ^ what to count
@@ -986,7 +986,7 @@ countDistinct = unsafeAggregateDistinct "count"
 --   expression = every #col
 -- in renderExpression expression
 -- :}
--- "every(col)"
+-- "every(\"col\")"
 every
   :: Expression relations 'Ungrouped params (nullity 'PGbool)
   -- ^ what to aggregate
@@ -1001,7 +1001,7 @@ every = unsafeAggregate "every"
 --   expression = everyDistinct #col
 -- in renderExpression expression
 -- :}
--- "every(DISTINCT col)"
+-- "every(DISTINCT \"col\")"
 everyDistinct
   :: Expression relations 'Ungrouped params (nullity 'PGbool)
   -- ^ what to aggregate

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
@@ -80,7 +80,7 @@ let
     insertRow_ #tab (Set 2 `As` #col1 :* Default `As` #col2 :* Nil)
 in renderManipulation manipulation
 :}
-"INSERT INTO tab (col1, col2) VALUES (2, DEFAULT);"
+"INSERT INTO \"tab\" (\"col1\", \"col2\") VALUES (2, DEFAULT);"
 
 parameterized insert:
 
@@ -96,7 +96,7 @@ let
       (Set (param @1) `As` #col1 :* Set (param @2) `As` #col2 :* Nil)
 in renderManipulation manipulation
 :}
-"INSERT INTO tab (col1, col2) VALUES (($1 :: int4), ($2 :: int4));"
+"INSERT INTO \"tab\" (\"col1\", \"col2\") VALUES (($1 :: int4), ($2 :: int4));"
 
 returning insert:
 
@@ -112,7 +112,7 @@ let
       OnConflictDoRaise (Returning (#col1 `As` #fromOnly :* Nil))
 in renderManipulation manipulation
 :}
-"INSERT INTO tab (col1, col2) VALUES (2, DEFAULT) RETURNING col1 AS fromOnly;"
+"INSERT INTO \"tab\" (\"col1\", \"col2\") VALUES (2, DEFAULT) RETURNING \"col1\" AS \"fromOnly\";"
 
 upsert:
 
@@ -133,7 +133,7 @@ let
       (Returning $ (#col1 + #col2) `As` #sum :* Nil)
 in renderManipulation manipulation
 :}
-"INSERT INTO tab (col1, col2) VALUES (2, 4), (6, 8) ON CONFLICT DO UPDATE SET col1 = 2 WHERE (col1 = col2) RETURNING (col1 + col2) AS sum;"
+"INSERT INTO \"tab\" (\"col1\", \"col2\") VALUES (2, 4), (6, 8) ON CONFLICT DO UPDATE SET \"col1\" = 2 WHERE (\"col1\" = \"col2\") RETURNING (\"col1\" + \"col2\") AS \"sum\";"
 
 query insert:
 
@@ -154,7 +154,7 @@ let
       (selectStar (from (table (#other_tab `As` #t))))
 in renderManipulation manipulation
 :}
-"INSERT INTO tab SELECT * FROM other_tab AS t;"
+"INSERT INTO \"tab\" SELECT * FROM \"other_tab\" AS \"t\";"
 
 update:
 
@@ -169,7 +169,7 @@ let
       (#col1 ./= #col2)
 in renderManipulation manipulation
 :}
-"UPDATE tab SET col1 = 2 WHERE (col1 <> col2);"
+"UPDATE \"tab\" SET \"col1\" = 2 WHERE (\"col1\" <> \"col2\");"
 
 delete:
 
@@ -184,7 +184,7 @@ let
   manipulation = deleteFrom #tab (#col1 .== #col2) ReturningStar
 in renderManipulation manipulation
 :}
-"DELETE FROM tab WHERE (col1 = col2) RETURNING *;"
+"DELETE FROM \"tab\" WHERE (\"col1\" = \"col2\") RETURNING *;"
 -}
 newtype Manipulation
   (schema :: TablesType)
@@ -488,7 +488,7 @@ WITH statements
 --     (insertQuery_ #products_deleted (selectStar (from (table (#deleted_rows `As` #t)))))
 -- in renderManipulation manipulation
 -- :}
--- "WITH deleted_rows AS (DELETE FROM products WHERE (date < ($1 :: date)) RETURNING *) INSERT INTO products_deleted SELECT * FROM deleted_rows AS t;"
+-- "WITH \"deleted_rows\" AS (DELETE FROM \"products\" WHERE (\"date\" < ($1 :: date)) RETURNING *) INSERT INTO \"products_deleted\" SELECT * FROM \"deleted_rows\" AS \"t\";"
 with
   :: SOP.SListI commons
   => NP (Aliased (Manipulation schema params)) commons

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -106,7 +106,7 @@ let
   query = selectStar (from (table (#tab `As` #t)))
 in renderQuery query
 :}
-"SELECT * FROM tab AS t"
+"SELECT * FROM \"tab\" AS \"t\""
 
 restricted query:
 
@@ -127,7 +127,7 @@ let
         & where_ (#col2 .> 0) )
 in renderQuery query
 :}
-"SELECT (col1 + col2) AS sum, col1 AS col1 FROM tab AS t WHERE ((col1 > col2) AND (col2 > 0))"
+"SELECT (\"col1\" + \"col2\") AS \"sum\", \"col1\" AS \"col1\" FROM \"tab\" AS \"t\" WHERE ((\"col1\" > \"col2\") AND (\"col2\" > 0))"
 
 subquery:
 
@@ -142,7 +142,7 @@ let
       (from (subquery (selectStar (from (table (#tab `As` #t))) `As` #sub)))
 in renderQuery query
 :}
-"SELECT * FROM (SELECT * FROM tab AS t) AS sub"
+"SELECT * FROM (SELECT * FROM \"tab\" AS \"t\") AS \"sub\""
 
 limits and offsets:
 
@@ -156,7 +156,7 @@ let
     (from (table (#tab `As` #t)) & limit 100 & offset 2 & limit 50 & offset 2)
 in renderQuery query
 :}
-"SELECT * FROM tab AS t LIMIT 50 OFFSET 4"
+"SELECT * FROM \"tab\" AS \"t\" LIMIT 50 OFFSET 4"
 
 parameterized query:
 
@@ -170,7 +170,7 @@ let
     (from (table (#tab `As` #t)) & where_ (#col .> param @1))
 in renderQuery query
 :}
-"SELECT * FROM tab AS t WHERE (col > ($1 :: float8))"
+"SELECT * FROM \"tab\" AS \"t\" WHERE (\"col\" > ($1 :: float8))"
 
 aggregation query:
 
@@ -190,7 +190,7 @@ let
       & having (#col1 + sum_ #col2 .> 1) )
 in renderQuery query
 :}
-"SELECT sum(col2) AS sum, col1 AS col1 FROM tab AS table1 GROUP BY col1 HAVING ((col1 + sum(col2)) > 1)"
+"SELECT sum(\"col2\") AS \"sum\", \"col1\" AS \"col1\" FROM \"tab\" AS \"table1\" GROUP BY \"col1\" HAVING ((\"col1\" + sum(\"col2\")) > 1)"
 
 sorted query:
 
@@ -204,7 +204,7 @@ let
     (from (table (#tab `As` #t)) & orderBy [#col & AscNullsFirst])
 in renderQuery query
 :}
-"SELECT * FROM tab AS t ORDER BY col ASC NULLS FIRST"
+"SELECT * FROM \"tab\" AS \"t\" ORDER BY \"col\" ASC NULLS FIRST"
 
 joins:
 
@@ -248,7 +248,7 @@ let
         (#o ! #shipper_id .== #s ! #id)) )
 in renderQuery query
 :}
-"SELECT o.price AS order_price, c.name AS customer_name, s.name AS shipper_name FROM orders AS o INNER JOIN customers AS c ON (o.customer_id = c.id) INNER JOIN shippers AS s ON (o.shipper_id = s.id)"
+"SELECT \"o\".\"price\" AS \"order_price\", \"c\".\"name\" AS \"customer_name\", \"s\".\"name\" AS \"shipper_name\" FROM \"orders\" AS \"o\" INNER JOIN \"customers\" AS \"c\" ON (\"o\".\"customer_id\" = \"c\".\"id\") INNER JOIN \"shippers\" AS \"s\" ON (\"o\".\"shipper_id\" = \"s\".\"id\")"
 
 self-join:
 
@@ -262,7 +262,7 @@ let
     (from (table (#tab `As` #t1) & crossJoin (table (#tab `As` #t2))))
 in renderQuery query
 :}
-"SELECT t1.* FROM tab AS t1 CROSS JOIN tab AS t2"
+"SELECT \"t1\".* FROM \"tab\" AS \"t1\" CROSS JOIN \"tab\" AS \"t2\""
 
 set operations:
 
@@ -278,7 +278,7 @@ let
     selectStar (from (table (#tab `As` #t)))
 in renderQuery query
 :}
-"(SELECT * FROM tab AS t) UNION ALL (SELECT * FROM tab AS t)"
+"(SELECT * FROM \"tab\" AS \"t\") UNION ALL (SELECT * FROM \"tab\" AS \"t\")"
 -}
 newtype Query
   (schema :: TablesType)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
@@ -22,6 +22,7 @@ module Squeal.PostgreSQL.Render
     parenthesized
   , (<+>)
   , commaSeparated
+  , doubleQuoted
   , renderCommaSeparated
   , renderCommaSeparatedMaybe
   , renderNat
@@ -47,6 +48,10 @@ str1 <+> str2 = str1 <> " " <> str2
 -- | Comma separate a list of `ByteString`s.
 commaSeparated :: [ByteString] -> ByteString
 commaSeparated = ByteString.intercalate ", "
+
+-- | Add double quotes around a `ByteString`.
+doubleQuoted :: ByteString -> ByteString
+doubleQuoted str = "\"" <> str <> "\""
 
 -- | Comma separate the renderings of a heterogeneous list.
 renderCommaSeparated

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -384,7 +384,7 @@ deriving instance Ord (expression ty)
 
 -- | >>> let renderMaybe = fromString . maybe "Nothing" (const "Just")
 -- >>> renderAliasedAs renderMaybe (Just (3::Int) `As` #an_int)
--- "Just AS an_int"
+-- "Just AS \"an_int\""
 renderAliasedAs
   :: (forall ty. expression ty -> ByteString)
   -> Aliased expression aliased

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -110,6 +110,8 @@ import GHC.TypeLits
 
 import qualified Generics.SOP.Type.Metadata as Type
 
+import Squeal.PostgreSQL.Render
+
 -- | `PGType` is the promoted datakind of PostgreSQL types.
 --
 -- >>> import Squeal.PostgreSQL.Schema
@@ -358,9 +360,9 @@ instance alias1 ~ alias2 => IsLabel alias1 (Alias alias2) where
   fromLabel = Alias
 
 -- | >>> renderAlias #jimbob
--- "jimbob"
+-- "\"jimbob\""
 renderAlias :: KnownSymbol alias => Alias alias -> ByteString
-renderAlias = fromString . symbolVal
+renderAlias = doubleQuoted . fromString . symbolVal
 
 -- | The `As` operator is used to name an expression. `As` is like a demoted
 -- version of `:::`.


### PR DESCRIPTION
Right now it is possible to create invalid queries by using aliases that has the same name as a table name.
For example, the following query
```
select
  ( #user ! #name `As` #userName :* Nil)
  ( from (table (#users `As` #user)) )
```
will render as
```
SELECT user.name AS userName FROM users AS user
```
which is not a valid query as it collides with the built-in user table.

When quoting aliases the query will render as follows
```
SELECT "user"."name" AS "userName" FROM "users" AS "user"
```
which is a valid query.


This change will also make it possible to have table/column names with camel casing, etc. (Without quotes the names are lowercased in postgres)

All the renderQuery, etc tests breaks with this change, let me know if you want to pull this in and I will update the tests.