### PR TITLE
0.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: haskell:latest
+      - image: haskell:8.2.2
       - image: circleci/postgres:latest
         environment:
           POSTGRES_DB: exampledb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           keys:
             - dependency-cache
       - run: apt-get update && apt-get install -y libpq-dev xz-utils make
-      - run: stack setup && stack upgrade && stack update
+      - run: stack upgrade && stack update
       - run: stack build
       - run: stack test
       - run: stack haddock

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ jobs:
           keys:
             - dependency-cache
       - run: apt-get update && apt-get install -y libpq-dev xz-utils make
-      - run: stack upgrade && stack update
-      - run: stack build
+      - run: stack setup && stack upgrade && stack update
+      - run: stack build --resolver ghc-8.4.3
       - run: stack test
       - run: stack haddock
       - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             - dependency-cache
       - run: apt-get update && apt-get install -y libpq-dev xz-utils make
       - run: stack setup && stack upgrade && stack update
-      - run: stack build --resolver ghc-8.4.3
+      - run: stack build
       - run: stack test
       - run: stack haddock
       - save_cache:

--- a/README.md
+++ b/README.md
@@ -127,12 +127,12 @@ let
   setup = 
    createTable #users
      ( serial `As` #id :*
-       (text & notNull) `As` #name :* Nil )
+       (text & hasNotNull) `As` #name :* Nil )
      ( primaryKey #id `As` #pk_users :* Nil ) >>>
    createTable #emails
      ( serial `As` #id :*
-       (int & notNull) `As` #user_id :*
-       (text & null_) `As` #email :* Nil )
+       (int & hasNotNull) `As` #user_id :*
+       (text & hasNull) `As` #email :* Nil )
      ( primaryKey #id `As` #pk_emails :*
        foreignKey #user_id #users #id
          OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ let
    createTable #emails
      ( serial `As` #id :*
        (int & notNull) `As` #user_id :*
-       (text & null') `As` #email :* Nil )
+       (text & null_) `As` #email :* Nil )
      ( primaryKey #id `As` #pk_emails :*
        foreignKey #user_id #users #id
          OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ We'll use generics to easily convert between Haskell and PostgreSQL values.
 ```
 
 The first step is to define the schema of our database. This is where
-we use @DataKinds@ and @TypeOperators@.
+we use `DataKinds` and `TypeOperators`.
 
 ```Haskell
 >>> :{
@@ -113,12 +113,12 @@ type Schema =
 Notice the use of type operators.
 
 `:::` is used to pair an alias `GHC.TypeLits.Symbol` with a `SchemumType`,
-a `TableConstraint` or a `ColumnType`. It is intended to connote Haskell's @::@
+a `TableConstraint` or a `ColumnType`. It is intended to connote Haskell's `::`
 operator.
 
 `:=>` is used to pair `TableConstraints` with a `ColumnsType`,
 yielding a `TableType`, or to pair a `ColumnConstraint` with a `NullityType`,
-yielding a `ColumnType`. It is intended to connote Haskell's @=>@ operator
+yielding a `ColumnType`. It is intended to connote Haskell's `=>` operator
 
 Next, we'll write `Definition`s to set up and tear down the schema. In
 Squeal, a `Definition` like `createTable`, `alterTable` or `dropTable` 
@@ -154,9 +154,9 @@ CREATE TABLE "users" ("id" serial, "name" text NOT NULL, CONSTRAINT "pk_users" P
 CREATE TABLE "emails" ("id" serial, "user_id" int NOT NULL, "email" text NULL, CONSTRAINT "pk_emails" PRIMARY KEY ("id"), CONSTRAINT "fk_user_id" FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE);
 ```
 
-Notice that @setup@ starts with an empty schema @'[]@ and produces @Schema@.
+Notice that `setup` starts with an empty schema `'[]` and produces `Schema`.
 In our `createTable` commands we included `TableConstraint`s to define
-primary and foreign keys, making them somewhat complex. Our @teardown@
+primary and foreign keys, making them somewhat complex. Our `teardown`
 `Definition` is simpler.
 
 ```Haskell
@@ -175,8 +175,8 @@ Next, we'll write `Manipulation`s to insert data into our two tables.
 A `Manipulation` like `insertRow`, `update` or `deleteFrom`
 has three type parameters, the schema it refers to, a list of parameters
 it can take as input, and a list of columns it produces as output. When
-we insert into the users table, we will need a parameter for the @name@
-field but not for the @id@ field. Since it's serial, we can use a default
+we insert into the users table, we will need a parameter for the `name`
+field but not for the `id` field. Since it's serial, we can use a default
 value. However, since the emails table refers to the users table, we will
 need to retrieve the user id that the insert generates and insert it into
 the emails table. Take a careful look at the type and definition of both
@@ -232,8 +232,8 @@ SELECT "u"."name" AS "userName", "e"."email" AS "userEmail" FROM "users" AS "u" 
 Now that we've defined the SQL side of things, we'll need a Haskell type
 for users. We give the type `Generics.SOP.Generic` and
 `Generics.SOP.HasDatatypeInfo` instances so that we can decode the rows
-we receive when we run @getUsers@. Notice that the record fields of the
-@User@ type match the column names of @getUsers@.
+we receive when we run `getUsers`. Notice that the record fields of the
+`User` type match the column names of `getUsers`.
 
 ```Haskell
 >>> data User = User { userName :: Text, userEmail :: Maybe Text } deriving (Show, GHC.Generic)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ composable and cover a large portion of SQL.
 * linear, invertible migrations
 * connection pools
 * transactions
+* views
+* composite and enumerated types
 
 ## installation
 
@@ -62,118 +64,125 @@ Let's see an example!
 First, we need some language extensions because Squeal uses modern GHC
 features.
 
-```haskell
+```Haskell
 >>> :set -XDataKinds -XDeriveGeneric -XOverloadedLabels
 >>> :set -XOverloadedStrings -XTypeApplications -XTypeOperators
 ```
 
 We'll need some imports.
 
-```haskell
+```Haskell
 >>> import Control.Monad (void)
 >>> import Control.Monad.Base (liftBase)
 >>> import Data.Int (Int32)
 >>> import Data.Text (Text)
 >>> import Squeal.PostgreSQL
+>>> import Squeal.PostgreSQL.Render
 ```
 
 We'll use generics to easily convert between Haskell and PostgreSQL values.
 
-```haskell
+```Haskell
 >>> import qualified Generics.SOP as SOP
 >>> import qualified GHC.Generics as GHC
 ```
 
 The first step is to define the schema of our database. This is where
-we use `DataKinds` and `TypeOperators`.
+we use @DataKinds@ and @TypeOperators@.
 
-```haskell
+```Haskell
 >>> :{
 type Schema =
-  '[ "users" :::
-       '[ "pk_users" ::: 'PrimaryKey '["id"] ] :=>
-       '[ "id"   :::   'Def :=> 'NotNull 'PGint4
-        , "name" ::: 'NoDef :=> 'NotNull 'PGtext
-        ]
-   , "emails" :::
-       '[ "pk_emails"  ::: 'PrimaryKey '["id"]
-        , "fk_user_id" ::: 'ForeignKey '["user_id"] "users" '["id"]
-        ] :=>
-       '[ "id"      :::   'Def :=> 'NotNull 'PGint4
-        , "user_id" ::: 'NoDef :=> 'NotNull 'PGint4
-        , "email"   ::: 'NoDef :=>    'Null 'PGtext
-        ]
-   ]
+  '[ "users" ::: 'Table (
+      '[ "pk_users" ::: 'PrimaryKey '["id"] ] :=>
+      '[ "id"   :::   'Def :=> 'NotNull 'PGint4
+       , "name" ::: 'NoDef :=> 'NotNull 'PGtext
+       ])
+  , "emails" ::: 'Table (
+      '[ "pk_emails"  ::: 'PrimaryKey '["id"]
+       , "fk_user_id" ::: 'ForeignKey '["user_id"] "users" '["id"]
+       ] :=>
+      '[ "id"      :::   'Def :=> 'NotNull 'PGint4
+       , "user_id" ::: 'NoDef :=> 'NotNull 'PGint4
+       , "email"   ::: 'NoDef :=>    'Null 'PGtext
+       ])
+  ]
 :}
 ```
 
-Notice the use of type operators. `:::` is used
-to pair an alias `Symbol` with either a `TableType` or a `ColumnType`.
-`:=>` is used to pair a `TableConstraint`s with a `ColumnsType`,
+Notice the use of type operators.
+
+`:::` is used to pair an alias `GHC.TypeLits.Symbol` with a `SchemumType`,
+a `TableConstraint` or a `ColumnType`. It is intended to connote Haskell's @::@
+operator.
+
+`:=>` is used to pair `TableConstraints` with a `ColumnsType`,
 yielding a `TableType`, or to pair a `ColumnConstraint` with a `NullityType`,
-yielding a `ColumnType`.
+yielding a `ColumnType`. It is intended to connote Haskell's @=>@ operator
 
 Next, we'll write `Definition`s to set up and tear down the schema. In
-Squeal, a `Definition` is a `createTable`, `alterTable` or `dropTable`
-command and has two type parameters, corresponding to the schema
-before being run and the schema after. We can compose definitions using
-`>>>`. Here and in the rest of our commands we make use of overloaded
+Squeal, a `Definition` like `createTable`, `alterTable` or `dropTable` 
+has two type parameters, corresponding to the schema
+before being run and the schema after. We can compose definitions using `>>>`.
+Here and in the rest of our commands we make use of overloaded
 labels to refer to named tables and columns in our schema.
 
-```haskell
+```Haskell
 >>> :{
 let
   setup :: Definition '[] Schema
   setup = 
-   createTable #users
-     ( serial `As` #id :*
-       (text & notNullable) `As` #name :* Nil )
-     ( primaryKey #id `As` #pk_users :* Nil ) >>>
-   createTable #emails
-     ( serial `As` #id :*
-       (int & notNullable) `As` #user_id :*
-       (text & nullable) `As` #email :* Nil )
-     ( primaryKey #id `As` #pk_emails :*
-       foreignKey #user_id #users #id
-         OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )
+    createTable #users
+      ( serial `As` #id :*
+        (text & notNullable) `As` #name :* Nil )
+      ( primaryKey #id `As` #pk_users :* Nil ) >>>
+    createTable #emails
+      ( serial `As` #id :*
+        (int & notNullable) `As` #user_id :*
+        (text & nullable) `As` #email :* Nil )
+      ( primaryKey #id `As` #pk_emails :*
+        foreignKey #user_id #users #id
+          OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )
 :}
 ```
 
-We can easily see the generated SQL is unsuprising looking.
+We can easily see the generated SQL is unsurprising looking.
 
-```haskell
->>> renderDefinition setup
-"CREATE TABLE users (id serial, name text NOT NULL, CONSTRAINT pk_users PRIMARY KEY (id)); CREATE TABLE emails (id serial, user_id int NOT NULL, email text, CONSTRAINT pk_emails PRIMARY KEY (id), CONSTRAINT fk_user_id FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE ON UPDATE CASCADE);"
+```Haskell
+>>> printSQL setup
+CREATE TABLE "users" ("id" serial, "name" text NOT NULL, CONSTRAINT "pk_users" PRIMARY KEY ("id"));
+CREATE TABLE "emails" ("id" serial, "user_id" int NOT NULL, "email" text NULL, CONSTRAINT "pk_emails" PRIMARY KEY ("id"), CONSTRAINT "fk_user_id" FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE);
 ```
 
-Notice that `setup` starts with an empty schema `'[]` and produces `Schema`.
+Notice that @setup@ starts with an empty schema @'[]@ and produces @Schema@.
 In our `createTable` commands we included `TableConstraint`s to define
-primary and foreign keys, making them somewhat complex. Our tear down
+primary and foreign keys, making them somewhat complex. Our @teardown@
 `Definition` is simpler.
 
-```haskell
+```Haskell
 >>> :{
 let
   teardown :: Definition Schema '[]
   teardown = dropTable #emails >>> dropTable #users
 :}
->>> renderDefinition teardown
-"DROP TABLE emails; DROP TABLE users;"
+
+>>> printSQL teardown
+DROP TABLE "emails";
+DROP TABLE "users";
 ```
 
 Next, we'll write `Manipulation`s to insert data into our two tables.
-A `Manipulation` is an `insertRow` (or other inserts), `update`
-or `deleteFrom` command and
+A `Manipulation` like `insertRow`, `update` or `deleteFrom`
 has three type parameters, the schema it refers to, a list of parameters
 it can take as input, and a list of columns it produces as output. When
-we insert into the users table, we will need a parameter for the `name`
-field but not for the `id` field. Since it's optional, we can use a default
+we insert into the users table, we will need a parameter for the @name@
+field but not for the @id@ field. Since it's serial, we can use a default
 value. However, since the emails table refers to the users table, we will
 need to retrieve the user id that the insert generates and insert it into
 the emails table. Take a careful look at the type and definition of both
 of our inserts.
 
-```haskell
+```Haskell
 >>> :{
 let
   insertUser :: Manipulation Schema '[ 'NotNull 'PGtext ] '[ "fromOnly" ::: 'NotNull 'PGint4 ]
@@ -181,6 +190,7 @@ let
     (Default `As` #id :* Set (param @1) `As` #name :* Nil)
     OnConflictDoNothing (Returning (#id `As` #fromOnly :* Nil))
 :}
+
 >>> :{
 let
   insertEmail :: Manipulation Schema '[ 'NotNull 'PGint4, 'Null 'PGtext] '[]
@@ -190,10 +200,11 @@ let
       Set (param @2) `As` #email :* Nil )
     OnConflictDoNothing (Returning Nil)
 :}
->>> renderManipulation insertUser
-"INSERT INTO users (id, name) VALUES (DEFAULT, ($1 :: text)) ON CONFLICT DO NOTHING RETURNING id AS fromOnly;"
->>> renderManipulation insertEmail
-"INSERT INTO emails (id, user_id, email) VALUES (DEFAULT, ($1 :: int4), ($2 :: text)) ON CONFLICT DO NOTHING;"
+
+>>> printSQL insertUser
+INSERT INTO "users" ("id", "name") VALUES (DEFAULT, ($1 :: text)) ON CONFLICT DO NOTHING RETURNING "id" AS "fromOnly"
+>>> printSQL insertEmail
+INSERT INTO "emails" ("id", "user_id", "email") VALUES (DEFAULT, ($1 :: int4), ($2 :: text)) ON CONFLICT DO NOTHING
 ```
 
 Next we write a `Query` to retrieve users from the database. We're not
@@ -201,7 +212,7 @@ interested in the ids here, just the usernames and email addresses. We
 need to use an inner join to get the right result. A `Query` is like a
 `Manipulation` with the same kind of type parameters.
 
-```haskell
+```Haskell
 >>> :{
 let
   getUsers :: Query Schema '[]
@@ -213,17 +224,18 @@ let
       & innerJoin (table (#emails `As` #e))
         (#u ! #id .== #e ! #user_id)) )
 :}
->>> renderQuery getUsers
-"SELECT u.name AS userName, e.email AS userEmail FROM users AS u INNER JOIN emails AS e ON (u.id = e.user_id)"
+
+>>> printSQL getUsers
+SELECT "u"."name" AS "userName", "e"."email" AS "userEmail" FROM "users" AS "u" INNER JOIN "emails" AS "e" ON ("u"."id" = "e"."user_id")
 ```
 
 Now that we've defined the SQL side of things, we'll need a Haskell type
 for users. We give the type `Generics.SOP.Generic` and
 `Generics.SOP.HasDatatypeInfo` instances so that we can decode the rows
-we receive when we run `getUsers`. Notice that the record fields of the
-`User` type match the column names of `getUsers`.
+we receive when we run @getUsers@. Notice that the record fields of the
+@User@ type match the column names of @getUsers@.
 
-```haskell
+```Haskell
 >>> data User = User { userName :: Text, userEmail :: Maybe Text } deriving (Show, GHC.Generic)
 >>> instance SOP.Generic User
 >>> instance SOP.HasDatatypeInfo User
@@ -231,7 +243,7 @@ we receive when we run `getUsers`. Notice that the record fields of the
 
 Let's also create some users to add to the database.
 
-```haskell
+```Haskell
 >>> :{
 let
   users :: [User]
@@ -251,7 +263,7 @@ the changing schema information through by using the indexed `PQ` monad
 transformer and when the schema doesn't change we can use `Monad` and
 `MonadPQ` functionality.
 
-```haskell
+```Haskell
 >>> :{
 let
   session :: PQ Schema Schema IO ()
@@ -262,12 +274,12 @@ let
     usersResult <- runQuery getUsers
     usersRows <- getRows usersResult
     liftBase $ print (usersRows :: [User])
-:}
->>> :{
-void . withConnection "host=localhost port=5432 dbname=exampledb" $
-  define setup
-  & pqThen session
-  & pqThen (define teardown)
+in
+  void . withConnection "host=localhost port=5432 dbname=exampledb" $
+    define setup
+    & pqThen session
+    & pqThen (define teardown)
 :}
 [User {userName = "Alice", userEmail = Just "alice@gmail.com"},User {userName = "Bob", userEmail = Nothing},User {userName = "Carole", userEmail = Just "carole@hotmail.com"}]
+-}
 ```

--- a/README.md
+++ b/README.md
@@ -281,5 +281,4 @@ in
     & pqThen (define teardown)
 :}
 [User {userName = "Alice", userEmail = Just "alice@gmail.com"},User {userName = "Bob", userEmail = Nothing},User {userName = "Carole", userEmail = Just "carole@hotmail.com"}]
--}
 ```

--- a/README.md
+++ b/README.md
@@ -127,12 +127,12 @@ let
   setup = 
    createTable #users
      ( serial `As` #id :*
-       (text & hasNotNull) `As` #name :* Nil )
+       (text & notNullable) `As` #name :* Nil )
      ( primaryKey #id `As` #pk_users :* Nil ) >>>
    createTable #emails
      ( serial `As` #id :*
-       (int & hasNotNull) `As` #user_id :*
-       (text & hasNull) `As` #email :* Nil )
+       (int & notNullable) `As` #user_id :*
+       (text & nullable) `As` #email :* Nil )
      ( primaryKey #id `As` #pk_emails :*
        foreignKey #user_id #users #id
          OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )

--- a/RELEASE NOTES.md
+++ b/RELEASE NOTES.md
@@ -228,7 +228,7 @@ Squeal 0.3 also adds `IsLabel` instances for `Aliased` expressions and tables as
 heterogeneous lists, allowing for some more economy of code.
 
 ```Haskell
--- Squeal 0.2
+-- Squeal 0.2 (or 0.3)
 >>> select (#a `As` #a :* Nil) (from (table (#t `As` #t)))
 
 -- Squeal 0.3

--- a/RELEASE NOTES.md
+++ b/RELEASE NOTES.md
@@ -199,6 +199,44 @@ in printSQL expr
 ```
 
 Both composite and enum types can be automatically encoded from and decoded to their equivalent Haskell types.
+And they can be dropped.
+
+```Haskell
+>>> :{
+let
+  definition :: Definition '["mood" ::: 'Typedef ('PGenum '["sad", "ok", "happy"])] '[]
+  definition = dropType #mood
+:}
+>>> printSQL definition
+DROP TYPE "mood";
+```
+
+**Additional Changes**
+
+Squeal 0.3 also introduces a typeclass `HasAll` similar to `Has` but for a list of aliases.
+This makes it possible to clean up some unfortunately messy Squeal 0.2 definitions.
+
+```Haskell
+-- Squeal 0.2
+>>> unique (Column #a :* Column #b :* Nil)
+
+-- Squeal 0.3
+>>> unique (#a :* #b :* Nil)
+```
+
+Squeal 0.3 also adds `IsLabel` instances for `Aliased` expressions and tables as well as
+heterogeneous lists, allowing for some more economy of code.
+
+```Haskell
+-- Squeal 0.2
+>>> select (#a `As` #a :* Nil) (from (table (#t `As` #t)))
+
+-- Squeal 0.3
+>>> select #a (from (table #t))
+```
+
+The above changes required major and minor changes to Squeal DSL functions.
+Please consult the documentation.
 
 ### Version 0.2.1 - April 7, 2018
 

--- a/RELEASE NOTES.md
+++ b/RELEASE NOTES.md
@@ -1,6 +1,6 @@
 ## RELEASE NOTES
 
-### Version 0.3 - June 23, 2018
+### Version 0.3 - June 27, 2018
 
 Version 0.3 of Squeal adds views as well as composite and enumerated types to Squeal.
 To support these features, a new kind `SchemumType` was added.

--- a/RELEASE NOTES.md
+++ b/RELEASE NOTES.md
@@ -1,6 +1,6 @@
 ## RELEASE NOTES
 
-### Version 0.3 - June 27, 2018
+### Version 0.3 - June 26, 2018
 
 Version 0.3 of Squeal adds views as well as composite and enumerated types to Squeal.
 To support these features, a new kind `SchemumType` was added.

--- a/RELEASE NOTES.md
+++ b/RELEASE NOTES.md
@@ -235,6 +235,8 @@ heterogeneous lists, allowing for some more economy of code.
 >>> select #a (from (table #t))
 ```
 
+Squeal 0.3 also fixes a bug that prevented joined queries on self-referencing tables.
+
 The above changes required major and minor changes to Squeal DSL functions.
 Please consult the documentation.
 

--- a/RELEASE NOTES.md
+++ b/RELEASE NOTES.md
@@ -1,5 +1,12 @@
 ## RELEASE NOTES
 
+### Version 0.3.0.0 - June 23, 2018
+
+**Changes**
+- **Views** - Create, drop and query views
+- **Enums, Composites** - Create, drop and marshal enumerated and composite types
+- **Bugfixes**
+
 ### Version 0.2.1 - April 7, 2018
 
 This minor update fixes an issue where alias identifiers could conflict with

--- a/RELEASE NOTES.md
+++ b/RELEASE NOTES.md
@@ -151,7 +151,7 @@ CREATE TYPE "complex" AS ("real" float8, "imaginary" float8);
 ```
 
 Composite types are almost equivalent to Haskell record types.
-However, because of the potential presence of @NULL@
+However, because of the potential presence of `NULL`
 all the record fields must be `Maybe`s of basic types.
 Composite types can be generated from a Haskell record type, for example:
 

--- a/squeal-postgresql/exe/Example.hs
+++ b/squeal-postgresql/exe/Example.hs
@@ -45,14 +45,14 @@ setup :: Definition '[] Schema
 setup = 
   createTable #users
     ( serial `As` #id :*
-      (text & notNull) `As` #name :*
-      (vararray int2 & notNull) `As` #vec :* Nil )
+      (text & hasNotNull) `As` #name :*
+      (vararray int2 & hasNotNull) `As` #vec :* Nil )
     ( primaryKey #id `As` #pk_users :* Nil )
   >>>
   createTable #emails
     ( serial `As` #id :*
-      (int & notNull) `As` #user_id :*
-      (text & null_) `As` #email :* Nil )
+      (int & hasNotNull) `As` #user_id :*
+      (text & hasNull) `As` #email :* Nil )
     ( primaryKey #id `As` #pk_emails :*
       foreignKey #user_id #users #id
         OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )

--- a/squeal-postgresql/exe/Example.hs
+++ b/squeal-postgresql/exe/Example.hs
@@ -52,7 +52,7 @@ setup =
   createTable #emails
     ( serial `As` #id :*
       (int & notNull) `As` #user_id :*
-      (text & null') `As` #email :* Nil )
+      (text & null_) `As` #email :* Nil )
     ( primaryKey #id `As` #pk_emails :*
       foreignKey #user_id #users #id
         OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )

--- a/squeal-postgresql/exe/Example.hs
+++ b/squeal-postgresql/exe/Example.hs
@@ -45,14 +45,14 @@ setup :: Definition '[] Schema
 setup = 
   createTable #users
     ( serial `As` #id :*
-      (text & hasNotNull) `As` #name :*
-      (vararray int2 & hasNotNull) `As` #vec :* Nil )
+      (text & notNullable) `As` #name :*
+      (vararray int2 & notNullable) `As` #vec :* Nil )
     ( primaryKey #id `As` #pk_users :* Nil )
   >>>
   createTable #emails
     ( serial `As` #id :*
-      (int & hasNotNull) `As` #user_id :*
-      (text & hasNull) `As` #email :* Nil )
+      (int & notNullable) `As` #user_id :*
+      (text & nullable) `As` #email :* Nil )
     ( primaryKey #id `As` #pk_emails :*
       foreignKey #user_id #users #id
         OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )

--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -34,7 +34,7 @@ library
     Squeal.PostgreSQL.Schema
     Squeal.PostgreSQL.Transaction
   default-language: Haskell2010
-  ghc-options: -Wall -fprint-explicit-kinds
+  ghc-options: -Wall -Werror -fprint-explicit-kinds
   build-depends:
       aeson >= 1.2.4.0
     , base >= 4.10.1.0 && < 5.0
@@ -63,7 +63,7 @@ test-suite squeal-postgresql-doctest
   default-language: Haskell2010
   type: exitcode-stdio-1.0
   hs-source-dirs: test
-  ghc-options: -Wall
+  ghc-options: -Wall -Werror
   main-is: DocTest.hs
   build-depends:
       base >= 4.10.0.0
@@ -72,7 +72,7 @@ test-suite squeal-postgresql-doctest
 executable squeal-postgresql-example
   default-language: Haskell2010
   hs-source-dirs: exe
-  ghc-options: -Wall
+  ghc-options: -Wall -Werror
   main-is: Example.hs
   build-depends:
       base >= 4.10.0.0 && < 5.0

--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -1,5 +1,5 @@
 name: squeal-postgresql
-version: 0.2.1.0
+version: 0.3.0.0
 synopsis: Squeal PostgreSQL Library
 description: Squeal is a type-safe embedding of PostgreSQL in Haskell
 homepage: https://github.com/morphismtech/squeal
@@ -38,8 +38,8 @@ library
   build-depends:
       aeson >= 1.2.4.0
     , base >= 4.10.1.0 && < 5.0
-    , binary-parser
-    , bytestring-strict-builder
+    , binary-parser >= 0.5.5
+    , bytestring-strict-builder >= 0.4.5
     , bytestring >= 0.10.8.2
     , deepseq >= 1.4.3.0
     , generics-sop >= 0.3.2.0

--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -39,6 +39,7 @@ library
       aeson >= 1.2.4.0
     , base >= 4.10.1.0 && < 5.0
     , binary-parser
+    , bytestring-strict-builder
     , bytestring >= 0.10.8.2
     , deepseq >= 1.4.3.0
     , generics-sop >= 0.3.2.0

--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -39,8 +39,8 @@ library
       aeson >= 1.2.4.0
     , base >= 4.10.1.0 && < 5.0
     , binary-parser >= 0.5.5
-    , bytestring-strict-builder >= 0.4.5
     , bytestring >= 0.10.8.2
+    , bytestring-strict-builder >= 0.4.5
     , deepseq >= 1.4.3.0
     , generics-sop >= 0.3.2.0
     , lifted-base >= 0.2.3.12

--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -34,7 +34,7 @@ library
     Squeal.PostgreSQL.Schema
     Squeal.PostgreSQL.Transaction
   default-language: Haskell2010
-  ghc-options: -Wall -Werror -fprint-explicit-kinds
+  ghc-options: -Wall -Werror
   build-depends:
       aeson >= 1.2.4.0
     , base >= 4.10.1.0 && < 5.0

--- a/squeal-postgresql/src/Squeal/PostgreSQL.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL.hs
@@ -66,12 +66,12 @@
 --   setup = 
 --    createTable #users
 --      ( serial `As` #id :*
---        (text & notNull) `As` #name :* Nil )
+--        (text & hasNotNull) `As` #name :* Nil )
 --      ( primaryKey #id `As` #pk_users :* Nil ) >>>
 --    createTable #emails
 --      ( serial `As` #id :*
---        (int & notNull) `As` #user_id :*
---        (text & null_) `As` #email :* Nil )
+--        (int & hasNotNull) `As` #user_id :*
+--        (text & hasNull) `As` #email :* Nil )
 --      ( primaryKey #id `As` #pk_emails :*
 --        foreignKey #user_id #users #id
 --          OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )

--- a/squeal-postgresql/src/Squeal/PostgreSQL.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL.hs
@@ -66,12 +66,12 @@
 --   setup = 
 --    createTable #users
 --      ( serial `As` #id :*
---        (text & hasNotNull) `As` #name :* Nil )
+--        (text & notNullable) `As` #name :* Nil )
 --      ( primaryKey #id `As` #pk_users :* Nil ) >>>
 --    createTable #emails
 --      ( serial `As` #id :*
---        (int & hasNotNull) `As` #user_id :*
---        (text & hasNull) `As` #email :* Nil )
+--        (int & notNullable) `As` #user_id :*
+--        (text & nullable) `As` #email :* Nil )
 --      ( primaryKey #id `As` #pk_emails :*
 --        foreignKey #user_id #users #id
 --          OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )

--- a/squeal-postgresql/src/Squeal/PostgreSQL.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL.hs
@@ -71,7 +71,7 @@
 --    createTable #emails
 --      ( serial `As` #id :*
 --        (int & notNull) `As` #user_id :*
---        (text & null') `As` #email :* Nil )
+--        (text & null_) `As` #email :* Nil )
 --      ( primaryKey #id `As` #pk_emails :*
 --        foreignKey #user_id #users #id
 --          OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )

--- a/squeal-postgresql/src/Squeal/PostgreSQL.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL.hs
@@ -83,7 +83,7 @@ let
           OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )
 :}
 
-We can easily see the generated SQL is unsuprising looking.
+We can easily see the generated SQL is unsurprising looking.
 
 >>> printSQL setup
 CREATE TABLE "users" ("id" serial, "name" text NOT NULL, CONSTRAINT "pk_users" PRIMARY KEY ("id"));

--- a/squeal-postgresql/src/Squeal/PostgreSQL.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL.hs
@@ -1,206 +1,210 @@
--- | Module: Squeal.PostgreSQL
--- Description: Squeel export module
--- Copyright: (c) Eitan Chatav, 2017
--- Maintainer: eitan@morphism.tech
--- Stability: experimental
---
--- Squeal is a deep embedding of [PostgreSQL](https://www.postgresql.org) in Haskell.
--- Let's see an example!
---
--- First, we need some language extensions because Squeal uses modern GHC
--- features.
---
--- >>> :set -XDataKinds -XDeriveGeneric -XOverloadedLabels
--- >>> :set -XOverloadedStrings -XTypeApplications -XTypeOperators
--- 
--- We'll need some imports.
---
--- >>> import Control.Monad (void)
--- >>> import Control.Monad.Base (liftBase)
--- >>> import Data.Int (Int32)
--- >>> import Data.Text (Text)
--- >>> import Squeal.PostgreSQL
---
--- We'll use generics to easily convert between Haskell and PostgreSQL values.
---
--- >>> import qualified Generics.SOP as SOP
--- >>> import qualified GHC.Generics as GHC
---
--- The first step is to define the schema of our database. This is where
--- we use @DataKinds@ and @TypeOperators@.
---
--- >>> :{
--- type Schema =
---   '[ "users" ::: 'Table (
---        '[ "pk_users" ::: 'PrimaryKey '["id"] ] :=>
---        '[ "id"   :::   'Def :=> 'NotNull 'PGint4
---         , "name" ::: 'NoDef :=> 'NotNull 'PGtext
---         ])
---    , "emails" ::: 'Table (
---        '[ "pk_emails"  ::: 'PrimaryKey '["id"]
---         , "fk_user_id" ::: 'ForeignKey '["user_id"] "users" '["id"]
---         ] :=>
---        '[ "id"      :::   'Def :=> 'NotNull 'PGint4
---         , "user_id" ::: 'NoDef :=> 'NotNull 'PGint4
---         , "email"   ::: 'NoDef :=>    'Null 'PGtext
---         ])
---    ]
--- :}
---
--- Notice the use of type operators. `:::` is used
--- to pair an alias `Symbol` with either a `TableType` or a `ColumnType`.
--- `:=>` is used to pair a `TableConstraint`s with a `ColumnsType`,
--- yielding a `TableType`, or to pair a `ColumnConstraint` with a `NullityType`,
--- yielding a `ColumnType`.
---
--- Next, we'll write `Definition`s to set up and tear down the schema. In
--- Squeal, a `Definition` is a `createTable`, `alterTable` or `dropTable`
--- command and has two type parameters, corresponding to the schema
--- before being run and the schema after. We can compose definitions using
--- `>>>`. Here and in the rest of our commands we make use of overloaded
--- labels to refer to named tables and columns in our schema.
---
--- >>> :{
--- let
---   setup :: Definition '[] Schema
---   setup = 
---    createTable #users
---      ( serial `As` #id :*
---        (text & notNullable) `As` #name :* Nil )
---      ( primaryKey #id `As` #pk_users :* Nil ) >>>
---    createTable #emails
---      ( serial `As` #id :*
---        (int & notNullable) `As` #user_id :*
---        (text & nullable) `As` #email :* Nil )
---      ( primaryKey #id `As` #pk_emails :*
---        foreignKey #user_id #users #id
---          OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )
--- :}
---
--- We can easily see the generated SQL is unsuprising looking.
---
--- >>> renderDefinition setup
--- "CREATE TABLE \"users\" (\"id\" serial, \"name\" text NOT NULL, CONSTRAINT \"pk_users\" PRIMARY KEY (\"id\")); CREATE TABLE \"emails\" (\"id\" serial, \"user_id\" int NOT NULL, \"email\" text NULL, CONSTRAINT \"pk_emails\" PRIMARY KEY (\"id\"), CONSTRAINT \"fk_user_id\" FOREIGN KEY (\"user_id\") REFERENCES \"users\" (\"id\") ON DELETE CASCADE ON UPDATE CASCADE);"
---
--- Notice that @setup@ starts with an empty schema @'[]@ and produces @Schema@.
--- In our `createTable` commands we included `TableConstraint`s to define
--- primary and foreign keys, making them somewhat complex. Our tear down
--- `Definition` is simpler.
---
--- >>> :{
--- let
---   teardown :: Definition Schema '[]
---   teardown = dropTable #emails >>> dropTable #users
--- :}
---
--- >>> renderDefinition teardown
--- "DROP TABLE \"emails\"; DROP TABLE \"users\";"
---
--- Next, we'll write `Manipulation`s to insert data into our two tables.
--- A `Manipulation` is an `insertRow` (or other inserts), `update`
--- or `deleteFrom` command and
--- has three type parameters, the schema it refers to, a list of parameters
--- it can take as input, and a list of columns it produces as output. When
--- we insert into the users table, we will need a parameter for the @name@
--- field but not for the @id@ field. Since it's optional, we can use a default
--- value. However, since the emails table refers to the users table, we will
--- need to retrieve the user id that the insert generates and insert it into
--- the emails table. Take a careful look at the type and definition of both
--- of our inserts.
---
--- >>> :{
--- let
---   insertUser :: Manipulation Schema '[ 'NotNull 'PGtext ] '[ "fromOnly" ::: 'NotNull 'PGint4 ]
---   insertUser = insertRow #users
---     (Default `As` #id :* Set (param @1) `As` #name :* Nil)
---     OnConflictDoNothing (Returning (#id `As` #fromOnly :* Nil))
--- :}
---
--- >>> :{
--- let
---   insertEmail :: Manipulation Schema '[ 'NotNull 'PGint4, 'Null 'PGtext] '[]
---   insertEmail = insertRow #emails
---     ( Default `As` #id :*
---       Set (param @1) `As` #user_id :*
---       Set (param @2) `As` #email :* Nil )
---     OnConflictDoNothing (Returning Nil)
--- :}
---
--- >>> renderManipulation insertUser
--- "INSERT INTO \"users\" (\"id\", \"name\") VALUES (DEFAULT, ($1 :: text)) ON CONFLICT DO NOTHING RETURNING \"id\" AS \"fromOnly\""
--- >>> renderManipulation insertEmail
--- "INSERT INTO \"emails\" (\"id\", \"user_id\", \"email\") VALUES (DEFAULT, ($1 :: int4), ($2 :: text)) ON CONFLICT DO NOTHING"
---
--- Next we write a `Query` to retrieve users from the database. We're not
--- interested in the ids here, just the usernames and email addresses. We
--- need to use an inner join to get the right result. A `Query` is like a
--- `Manipulation` with the same kind of type parameters.
---
--- >>> :{
--- let
---   getUsers :: Query Schema '[]
---     '[ "userName"  ::: 'NotNull 'PGtext
---      , "userEmail" :::    'Null 'PGtext ]
---   getUsers = select
---     (#u ! #name `As` #userName :* #e ! #email `As` #userEmail :* Nil)
---     ( from (table (#users `As` #u)
---       & innerJoin (table (#emails `As` #e))
---         (#u ! #id .== #e ! #user_id)) )
--- :}
---
--- >>> renderQuery getUsers
--- "SELECT \"u\".\"name\" AS \"userName\", \"e\".\"email\" AS \"userEmail\" FROM \"users\" AS \"u\" INNER JOIN \"emails\" AS \"e\" ON (\"u\".\"id\" = \"e\".\"user_id\")"
---
--- Now that we've defined the SQL side of things, we'll need a Haskell type
--- for users. We give the type `Generics.SOP.Generic` and
--- `Generics.SOP.HasDatatypeInfo` instances so that we can decode the rows
--- we receive when we run @getUsers@. Notice that the record fields of the
--- @User@ type match the column names of @getUsers@.
--- 
--- >>> data User = User { userName :: Text, userEmail :: Maybe Text } deriving (Show, GHC.Generic)
--- >>> instance SOP.Generic User
--- >>> instance SOP.HasDatatypeInfo User
---
--- Let's also create some users to add to the database.
---
--- >>> :{
--- let
---   users :: [User]
---   users = 
---     [ User "Alice" (Just "alice@gmail.com")
---     , User "Bob" Nothing
---     , User "Carole" (Just "carole@hotmail.com")
---     ]
--- :}
---
--- Now we can put together all the pieces into a program. The program
--- connects to the database, sets up the schema, inserts the user data
--- (using prepared statements as an optimization), queries the user
--- data and prints it out and finally closes the connection. We can thread
--- the changing schema information through by using the indexed `PQ` monad
--- transformer and when the schema doesn't change we can use `Monad` and
--- `MonadPQ` functionality.
---
--- >>> :{
--- let
---   session :: PQ Schema Schema IO ()
---   session = do
---     idResults <- traversePrepared insertUser (Only . userName <$> users)
---     ids <- traverse (fmap fromOnly . getRow 0) idResults
---     traversePrepared_ insertEmail (zip (ids :: [Int32]) (userEmail <$> users))
---     usersResult <- runQuery getUsers
---     usersRows <- getRows usersResult
---     liftBase $ print (usersRows :: [User])
--- :}
---
--- >>> :{
--- void . withConnection "host=localhost port=5432 dbname=exampledb" $
---   define setup
---   & pqThen session
---   & pqThen (define teardown)
--- :}
--- [User {userName = "Alice", userEmail = Just "alice@gmail.com"},User {userName = "Bob", userEmail = Nothing},User {userName = "Carole", userEmail = Just "carole@hotmail.com"}]
+{-|
+Module: Squeal.PostgreSQL
+Description: Squeel export module
+Copyright: (c) Eitan Chatav, 2017
+Maintainer: eitan@morphism.tech
+Stability: experimental
 
+Squeal is a deep embedding of [PostgreSQL](https://www.postgresql.org) in Haskell.
+Let's see an example!
+
+First, we need some language extensions because Squeal uses modern GHC
+features.
+
+>>> :set -XDataKinds -XDeriveGeneric -XOverloadedLabels
+>>> :set -XOverloadedStrings -XTypeApplications -XTypeOperators
+ 
+We'll need some imports.
+
+>>> import Control.Monad (void)
+>>> import Control.Monad.Base (liftBase)
+>>> import Data.Int (Int32)
+>>> import Data.Text (Text)
+>>> import Squeal.PostgreSQL
+>>> import qualified Data.ByteString.Char8 as Char8 (putStrLn)
+
+We'll use generics to easily convert between Haskell and PostgreSQL values.
+
+>>> import qualified Generics.SOP as SOP
+>>> import qualified GHC.Generics as GHC
+
+The first step is to define the schema of our database. This is where
+we use @DataKinds@ and @TypeOperators@.
+
+>>> :{
+type Schema =
+  '[ "users" ::: 'Table (
+      '[ "pk_users" ::: 'PrimaryKey '["id"] ] :=>
+      '[ "id"   :::   'Def :=> 'NotNull 'PGint4
+        , "name" ::: 'NoDef :=> 'NotNull 'PGtext
+        ])
+  , "emails" ::: 'Table (
+      '[ "pk_emails"  ::: 'PrimaryKey '["id"]
+        , "fk_user_id" ::: 'ForeignKey '["user_id"] "users" '["id"]
+        ] :=>
+      '[ "id"      :::   'Def :=> 'NotNull 'PGint4
+        , "user_id" ::: 'NoDef :=> 'NotNull 'PGint4
+        , "email"   ::: 'NoDef :=>    'Null 'PGtext
+        ])
+  ]
+:}
+
+Notice the use of type operators. `:::` is used
+to pair an alias `Symbol` with either a `TableType` or a `ColumnType`.
+`:=>` is used to pair a `TableConstraint`s with a `ColumnsType`,
+yielding a `TableType`, or to pair a `ColumnConstraint` with a `NullityType`,
+yielding a `ColumnType`.
+
+Next, we'll write `Definition`s to set up and tear down the schema. In
+Squeal, a `Definition` is a `createTable`, `alterTable` or `dropTable`
+command and has two type parameters, corresponding to the schema
+before being run and the schema after. We can compose definitions using `>>>`.
+Here and in the rest of our commands we make use of overloaded
+labels to refer to named tables and columns in our schema.
+
+>>> :{
+let
+  setup :: Definition '[] Schema
+  setup = 
+    createTable #users
+      ( serial `As` #id :*
+        (text & notNullable) `As` #name :* Nil )
+      ( primaryKey #id `As` #pk_users :* Nil ) >>>
+    createTable #emails
+      ( serial `As` #id :*
+        (int & notNullable) `As` #user_id :*
+        (text & nullable) `As` #email :* Nil )
+      ( primaryKey #id `As` #pk_emails :*
+        foreignKey #user_id #users #id
+          OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )
+:}
+
+We can easily see the generated SQL is unsuprising looking.
+
+>>> Char8.putStrLn $ renderDefinition setup
+CREATE TABLE "users" ("id" serial, "name" text NOT NULL, CONSTRAINT "pk_users" PRIMARY KEY ("id"));
+CREATE TABLE "emails" ("id" serial, "user_id" int NOT NULL, "email" text NULL, CONSTRAINT "pk_emails" PRIMARY KEY ("id"), CONSTRAINT "fk_user_id" FOREIGN KEY ("user_id") REFERENCES "users" ("id") ON DELETE CASCADE ON UPDATE CASCADE);
+
+Notice that @setup@ starts with an empty schema @'[]@ and produces @Schema@.
+In our `createTable` commands we included `TableConstraint`s to define
+primary and foreign keys, making them somewhat complex. Our tear down
+`Definition` is simpler.
+
+>>> :{
+let
+  teardown :: Definition Schema '[]
+  teardown = dropTable #emails >>> dropTable #users
+:}
+
+>>> Char8.putStrLn $ renderDefinition teardown
+DROP TABLE "emails";
+DROP TABLE "users";
+
+Next, we'll write `Manipulation`s to insert data into our two tables.
+A `Manipulation` is an `insertRow` (or other inserts), `update`
+or `deleteFrom` command and
+has three type parameters, the schema it refers to, a list of parameters
+it can take as input, and a list of columns it produces as output. When
+we insert into the users table, we will need a parameter for the @name@
+field but not for the @id@ field. Since it's optional, we can use a default
+value. However, since the emails table refers to the users table, we will
+need to retrieve the user id that the insert generates and insert it into
+the emails table. Take a careful look at the type and definition of both
+of our inserts.
+
+>>> :{
+let
+  insertUser :: Manipulation Schema '[ 'NotNull 'PGtext ] '[ "fromOnly" ::: 'NotNull 'PGint4 ]
+  insertUser = insertRow #users
+    (Default `As` #id :* Set (param @1) `As` #name :* Nil)
+    OnConflictDoNothing (Returning (#id `As` #fromOnly :* Nil))
+:}
+
+>>> :{
+let
+  insertEmail :: Manipulation Schema '[ 'NotNull 'PGint4, 'Null 'PGtext] '[]
+  insertEmail = insertRow #emails
+    ( Default `As` #id :*
+      Set (param @1) `As` #user_id :*
+      Set (param @2) `As` #email :* Nil )
+    OnConflictDoNothing (Returning Nil)
+:}
+
+>>> Char8.putStrLn $ renderManipulation insertUser
+INSERT INTO "users" ("id", "name") VALUES (DEFAULT, ($1 :: text)) ON CONFLICT DO NOTHING RETURNING "id" AS "fromOnly"
+>>> Char8.putStrLn $ renderManipulation insertEmail
+INSERT INTO "emails" ("id", "user_id", "email") VALUES (DEFAULT, ($1 :: int4), ($2 :: text)) ON CONFLICT DO NOTHING
+
+Next we write a `Query` to retrieve users from the database. We're not
+interested in the ids here, just the usernames and email addresses. We
+need to use an inner join to get the right result. A `Query` is like a
+`Manipulation` with the same kind of type parameters.
+
+>>> :{
+let
+  getUsers :: Query Schema '[]
+    '[ "userName"  ::: 'NotNull 'PGtext
+    , "userEmail" :::    'Null 'PGtext ]
+  getUsers = select
+    (#u ! #name `As` #userName :* #e ! #email `As` #userEmail :* Nil)
+    ( from (table (#users `As` #u)
+      & innerJoin (table (#emails `As` #e))
+        (#u ! #id .== #e ! #user_id)) )
+:}
+
+>>> Char8.putStrLn $ renderQuery getUsers
+SELECT "u"."name" AS "userName", "e"."email" AS "userEmail" FROM "users" AS "u" INNER JOIN "emails" AS "e" ON ("u"."id" = "e"."user_id")
+
+Now that we've defined the SQL side of things, we'll need a Haskell type
+for users. We give the type `Generics.SOP.Generic` and
+`Generics.SOP.HasDatatypeInfo` instances so that we can decode the rows
+we receive when we run @getUsers@. Notice that the record fields of the
+@User@ type match the column names of @getUsers@.
+ 
+>>> data User = User { userName :: Text, userEmail :: Maybe Text } deriving (Show, GHC.Generic)
+>>> instance SOP.Generic User
+>>> instance SOP.HasDatatypeInfo User
+
+Let's also create some users to add to the database.
+
+>>> :{
+let
+  users :: [User]
+  users = 
+    [ User "Alice" (Just "alice@gmail.com")
+    , User "Bob" Nothing
+    , User "Carole" (Just "carole@hotmail.com")
+    ]
+:}
+
+Now we can put together all the pieces into a program. The program
+connects to the database, sets up the schema, inserts the user data
+(using prepared statements as an optimization), queries the user
+data and prints it out and finally closes the connection. We can thread
+the changing schema information through by using the indexed `PQ` monad
+transformer and when the schema doesn't change we can use `Monad` and
+`MonadPQ` functionality.
+
+>>> :{
+let
+  session :: PQ Schema Schema IO ()
+  session = do
+    idResults <- traversePrepared insertUser (Only . userName <$> users)
+    ids <- traverse (fmap fromOnly . getRow 0) idResults
+    traversePrepared_ insertEmail (zip (ids :: [Int32]) (userEmail <$> users))
+    usersResult <- runQuery getUsers
+    usersRows <- getRows usersResult
+    liftBase $ print (usersRows :: [User])
+:}
+
+>>> :{
+void . withConnection "host=localhost port=5432 dbname=exampledb" $
+  define setup
+  & pqThen session
+  & pqThen (define teardown)
+:}
+[User {userName = "Alice", userEmail = Just "alice@gmail.com"},User {userName = "Bob", userEmail = Nothing},User {userName = "Carole", userEmail = Just "carole@hotmail.com"}]
+-}
 module Squeal.PostgreSQL
   ( module Squeal.PostgreSQL.Binary
   , module Squeal.PostgreSQL.Definition

--- a/squeal-postgresql/src/Squeal/PostgreSQL.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL.hs
@@ -127,9 +127,9 @@
 -- :}
 --
 -- >>> renderManipulation insertUser
--- "INSERT INTO \"users\" (\"id\", \"name\") VALUES (DEFAULT, ($1 :: text)) ON CONFLICT DO NOTHING RETURNING \"id\" AS \"fromOnly\";"
+-- "INSERT INTO \"users\" (\"id\", \"name\") VALUES (DEFAULT, ($1 :: text)) ON CONFLICT DO NOTHING RETURNING \"id\" AS \"fromOnly\""
 -- >>> renderManipulation insertEmail
--- "INSERT INTO \"emails\" (\"id\", \"user_id\", \"email\") VALUES (DEFAULT, ($1 :: int4), ($2 :: text)) ON CONFLICT DO NOTHING;"
+-- "INSERT INTO \"emails\" (\"id\", \"user_id\", \"email\") VALUES (DEFAULT, ($1 :: int4), ($2 :: text)) ON CONFLICT DO NOTHING"
 --
 -- Next we write a `Query` to retrieve users from the database. We're not
 -- interested in the ids here, just the usernames and email addresses. We

--- a/squeal-postgresql/src/Squeal/PostgreSQL.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL.hs
@@ -21,6 +21,7 @@ We'll need some imports.
 >>> import Data.Int (Int32)
 >>> import Data.Text (Text)
 >>> import Squeal.PostgreSQL
+>>> import Squeal.PostgreSQL.Render
 
 We'll use generics to easily convert between Haskell and PostgreSQL values.
 

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -121,7 +121,7 @@ instance (HasOid pg, ToParam x pg)
 instance
   ( IsEnumType x
   , HasDatatypeInfo x
-  , SameLabels (DatatypeInfoOf x) labels
+  , LabelsWith x ~ labels
   ) => ToParam x ('PGenum labels) where
     toParam =
       let
@@ -141,7 +141,7 @@ instance
   , MapMaybes xs
   , IsProductType x (Maybes xs)
   , AllZip ToAliasedParam xs fields
-  , SameFields (DatatypeInfoOf x) fields
+  , FieldNamesWith x ~ AliasesOf fields
   , All HasAliasedOid fields
   ) => ToParam x ('PGcomposite fields) where
     toParam =
@@ -277,7 +277,7 @@ instance FromValue pg y => FromValue ('PGfixarray n pg) (Vector (Maybe y)) where
 instance
   ( IsEnumType y
   , HasDatatypeInfo y
-  , SameLabels (DatatypeInfoOf y) labels
+  , LabelsWith y ~ labels
   ) => FromValue ('PGenum labels) y where
     fromValue _ = 
       let
@@ -302,7 +302,7 @@ instance
   , MapMaybes ys
   , IsProductType y (Maybes ys)
   , AllZip FromAliasedValue fields ys
-  , SameFields (DatatypeInfoOf y) fields
+  , FieldNamesWith y ~ AliasesOf fields
   ) => FromValue ('PGcomposite fields) y where
     fromValue =
       let
@@ -395,7 +395,7 @@ instance
   ( SListI results
   , IsProductType y ys
   , AllZip FromColumnValue results ys
-  , SameFields (DatatypeInfoOf y) results
+  , FieldNamesWith y ~ AliasesOf results
   ) => FromRow results y where
     fromRow
       = to . SOP . Z . htrans (Proxy @FromColumnValue) (I . fromColumnValue)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -314,7 +314,7 @@ instance ToParam x ty => ToAliasedParam x (alias ::: ty) where
     Just x -> K . Just . unK $ toParam @x @ty x
 
 -- | A `ToColumnParam` constraint lifts the `ToParam` encoding
--- of a `Type` to a `ColumnType`, encoding `Maybe`s to `Null`s. You should
+-- of a `Type` to a `NullityType`, encoding `Maybe`s to `Null`s. You should
 -- not define instances of `ToColumnParam`, just use the provided instances.
 class ToColumnParam (x :: Type) (ty :: NullityType) where
   -- | >>> toColumnParam @Int16 @('NotNull 'PGint2) 0

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -5,12 +5,11 @@ Copyright: (c) Eitan Chatav, 2017
 Maintainer: eitan@morphism.tech
 Stability: experimental
 
-Binary encoding and decoding between Haskell and PostgreSQL types.
+This module provides binary encoding and decoding between Haskell and PostgreSQL types.
 
 Instances are governed by the `Generic` and `HasDatatypeInfo` typeclasses, so you absolutely
 do not need to define your own instances to decode retrieved rows into Haskell values or
-to encode Haskell values into statement parameters. You only need to derive those type
-classes.
+to encode Haskell values into statement parameters.
 
 >>> import Data.Int (Int16)
 >>> import Data.Text (Text)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -40,7 +40,6 @@ module Squeal.PostgreSQL.Binary
 
 import BinaryParser
 import Data.Aeson hiding (Null)
-import Data.Char (toUpper)
 import Data.Int
 import Data.Kind
 import Data.Scientific

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -85,18 +85,18 @@ Then we can perform roundtrip queries;
 
 >>> :{
 let
-  qry1 :: Query Schema
+  querySchwarma :: Query Schema
     '[ 'NotNull (EnumFrom Schwarma)]
     '["fromOnly" ::: 'NotNull (EnumFrom Schwarma)]
-  qry1 = values_ (parameter @1 #schwarma `As` #fromOnly :* Nil)
+  querySchwarma = values_ (parameter @1 #schwarma `As` #fromOnly :* Nil)
 :}
 
 >>> :{
 let
-  qry2 :: Query Schema
+  queryPerson :: Query Schema
     '[ 'NotNull (CompositeFrom Person)]
     '["fromOnly" ::: 'NotNull (CompositeFrom Person)]
-  qry2 = values_ (parameter @1 #person `As` #fromOnly :* Nil)
+  queryPerson = values_ (parameter @1 #person `As` #fromOnly :* Nil)
 :}
 
 And finally drop the types.
@@ -112,10 +112,10 @@ Now let's run it.
 >>> :{
 let
   session = do
-    result1 <- runQueryParams qry1 (Only Chicken)
+    result1 <- runQueryParams querySchwarma (Only Chicken)
     Just (Only schwarma) <- firstRow result1
     liftBase $ print (schwarma :: Schwarma)
-    result2 <- runQueryParams qry2 (Only (Person (Just "Faisal") (Just 24)))
+    result2 <- runQueryParams queryPerson (Only (Person (Just "Faisal") (Just 24)))
     Just (Only person) <- firstRow result2
     liftBase $ print (person :: Person)
 in

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -313,7 +313,7 @@ instance FromValue pg y => FromAliasedValue (alias ::: pg) y where
   fromAliasedValue _ = fromValue (Proxy @pg)
 
 -- | A `FromColumnValue` constraint lifts the `FromValue` parser
--- to a decoding of a @(Symbol, ColumnType)@ to a `Type`,
+-- to a decoding of a @(Symbol, NullityType)@ to a `Type`,
 -- decoding `Null`s to `Maybe`s. You should not define instances for
 -- `FromColumnValue`, just use the provided instances.
 class FromColumnValue (colty :: (Symbol,NullityType)) (y :: Type) where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -193,7 +193,7 @@ instance ToParam x ty => ToAliasedParam x (alias ::: ty) where
     Nothing -> K Nothing
     Just x -> K . Just . unK $ toParam @x @ty x
 
--- | A `ToColumnParam` constraint lifts the `ToParam` encoding 
+-- | A `ToColumnParam` constraint lifts the `ToParam` encoding
 -- of a `Type` to a `ColumnType`, encoding `Maybe`s to `Null`s. You should
 -- not define instances of `ToColumnParam`, just use the provided instances.
 class ToColumnParam (x :: Type) (ty :: NullityType) where
@@ -279,7 +279,7 @@ instance
   , HasDatatypeInfo y
   , LabelsWith y ~ labels
   ) => FromValue ('PGenum labels) y where
-    fromValue _ = 
+    fromValue _ =
       let
         greadConstructor
           :: All ((~) '[]) xss

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -13,6 +13,7 @@ Instances are governed by the `Generic` and `HasDatatype` typeclasses.
 >>> import Control.Monad.Base
 
 >>> import Squeal.PostgreSQL
+>>> import qualified Squeal.PostgreSQL as SQL
 
 >>> data Schwarma = Beef | Lamb | Chicken deriving (Show, GHC.Generic)
 >>> instance Generic Schwarma
@@ -28,6 +29,7 @@ void . withConnection "host=localhost port=5432 dbname=exampledb" $ do
 :}
 Beef
 
+>>> :set -XTypeFamilies -XTypeInType -XUndecidableInstances
 >>> :{
 type family Schema :: SchemaType where
   Schema =
@@ -50,7 +52,7 @@ let
     insertRow_ #tab (Set (param @1) `As` #col :* Nil)
     :: Manipulation Schema '[ 'NotNull (EnumWith Schwarma)] '[]
   qry =
-    select (#col `As` #fromOnly :* Nil) (from (table #tab))
+    select (#col `As` #fromOnly :* Nil) (SQL.from (table #tab))
     :: Query Schema '[] '["fromOnly" ::: 'NotNull (EnumWith Schwarma)]
   session = do
     manipulateParams manip (Only Chicken)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -211,18 +211,9 @@ instance FromValue pg y => FromValue ('PGfixarray n pg) (Vector (Maybe y)) where
 instance
   ( IsEnumType y
   , Read y
-  -- , SameLabels (DatatypeInfoOf y) labels
-  --
-  -- uncomment above constraint when GHC issue #11671 is fixed
-  -- Allow labels starting with uppercase with OverloadedLabels
-  -- https://ghc.haskell.org/trac/ghc/ticket/11671?cversion=0&cnum_hist=8
+  , SameLabels (DatatypeInfoOf y) labels
   ) => FromValue ('PGenum labels) y where
-    fromValue _ =
-      let
-        upper "" = ""
-        upper (ch:chs) = toUpper ch : chs
-      in
-        Decoding.enum (readMaybe . upper . Strict.unpack)
+    fromValue _ = Decoding.enum (readMaybe . Strict.unpack)
 instance
   ( SListI fields
   , MapMaybes ys

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -66,6 +66,7 @@ module Squeal.PostgreSQL.Definition
     -- * Types
   , createType
   , createTypeEnum
+  , createTypeEnumFromHaskell
   , dropType
   , ColumnTypeExpression (..)
   , notNull
@@ -788,6 +789,18 @@ createTypeEnum
 createTypeEnum enum labels = UnsafeDefinition $
   "CREATE" <+> "TYPE" <+> renderAlias enum <+> "AS" <+>
   parenthesized (commaSeparated (renderLabels labels)) <> ";"
+
+createTypeEnumFromHaskell
+  :: forall enum labels hask proxy schema
+   . ( KnownSymbol enum
+     , SOP.All KnownSymbol labels
+     , SOP.IsEnumType hask
+     , labels ~ DatatypeLabels (SOP.DatatypeInfoOf hask) )
+  => Alias enum
+  -> proxy hask
+  -> Definition schema (Create enum ('Typedef ('PGenum labels)) schema)
+createTypeEnumFromHaskell enum _ = createTypeEnum enum
+  (SOP.hpure label :: NP PGlabel labels)
 
 createType
   :: (KnownSymbol comp, SOP.SListI fields)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -9,7 +9,8 @@ Squeal data definition language.
 -}
 
 {-# LANGUAGE
-    ConstraintKinds
+    AllowAmbiguousTypes
+  , ConstraintKinds
   , DeriveGeneric
   , FlexibleContexts
   , FlexibleInstances
@@ -793,25 +794,14 @@ createTypeEnum enum labels = UnsafeDefinition $
 
 class
   ( SOP.IsEnumType hask
-  , PGenumWith hask ~ 'PGenum labels
+  , SOP.All KnownSymbol (PGenumWith hask)
   ) => HasPGenum hask where
   createTypeEnumWith
     :: KnownSymbol enum
     => Alias enum
-    -> Definition schema (Create enum ('Typedef (PGenumWith hask)) schema)
+    -> Definition schema (Create enum ('Typedef ('PGenum (PGenumWith hask))) schema)
   createTypeEnumWith enum = createTypeEnum enum
-    (SOP.hpure label :: NP PGlabel labels)
--- createTypeEnumWith
---   :: forall enum labels hask proxy schema
---    . ( KnownSymbol enum
---      , SOP.All KnownSymbol labels
---      , SOP.IsEnumType hask
---      , labels ~ DatatypeLabels (SOP.DatatypeInfoOf hask) )
---   => Alias enum
---   -> proxy hask
---   -> Definition schema (Create enum ('Typedef ('PGenum labels)) schema)
--- createTypeEnumWith enum _ = createTypeEnum enum
---   (SOP.hpure label :: NP PGlabel labels)
+    (SOP.hpure label :: NP PGlabel (PGenumWith hask))
 
 createType
   :: (KnownSymbol comp, SOP.SListI fields)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -28,10 +28,11 @@ Squeal data definition language.
 #-}
 
 module Squeal.PostgreSQL.Definition
-  (  -- * Definition
+  ( -- * Definition
     Definition (UnsafeDefinition, renderDefinition)
   , (>>>)
-    -- * Create
+    -- * Tables
+    -- ** Create
   , createTable
   , createTableIfNotExists
   , TableConstraintExpression (..)
@@ -44,9 +45,9 @@ module Squeal.PostgreSQL.Definition
   , renderOnDeleteClause
   , OnUpdateClause (OnUpdateNoAction, OnUpdateRestrict, OnUpdateCascade)
   , renderOnUpdateClause
-    -- * Drop
+    -- ** Drop
   , dropTable
-    -- * Alter
+    -- ** Alter
   , alterTable
   , alterTableRename
   , AlterTable (UnsafeAlterTable, renderAlterTable)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -806,7 +806,9 @@ dropView v = UnsafeDefinition $ "DROP VIEW" <+> renderAlias v <> ";"
 createTypeEnum
   :: (KnownSymbol enum, SOP.All KnownSymbol labels)
   => Alias enum
+  -- ^ name of the user defined enumerated type
   -> NP PGlabel labels
+  -- ^ labels of the enumerated type
   -> Definition schema (Create enum ('Typedef ('PGenum labels)) schema)
 createTypeEnum enum labels = UnsafeDefinition $
   "CREATE" <+> "TYPE" <+> renderAlias enum <+> "AS" <+>
@@ -826,6 +828,7 @@ createTypeEnumWith
   , KnownSymbol enum
   )
   => Alias enum
+  -- ^ name of the user defined enumerated type
   -> Definition schema (Create enum ('Typedef (EnumWith hask)) schema)
 createTypeEnumWith enum = createTypeEnum enum
   (SOP.hpure label :: NP PGlabel (LabelsWith hask))
@@ -838,7 +841,9 @@ createTypeEnumWith enum = createTypeEnum enum
 createTypeComposite
   :: (KnownSymbol ty, SOP.SListI fields)
   => Alias ty
+  -- ^ name of the user defined composite type
   -> NP (Aliased TypeExpression) fields
+  -- ^ list of attribute names and data types
   -> Definition schema (Create ty ('Typedef ('PGcomposite fields)) schema)
 createTypeComposite ty fields = UnsafeDefinition $
   "CREATE" <+> "TYPE" <+> renderAlias ty <+> "AS" <+> parenthesized
@@ -858,6 +863,7 @@ createTypeCompositeWith
   , KnownSymbol ty
   )
   => Alias ty
+  -- ^ name of the user defined composite type
   -> Definition schema (Create ty ( 'Typedef (CompositeWith hask)) schema)
 createTypeCompositeWith ty = createTypeComposite ty $ zipAs
   (SOP.hpure Alias :: NP Alias (FieldNamesWith hask))
@@ -874,6 +880,7 @@ createTypeCompositeWith ty = createTypeComposite ty $ zipAs
 dropType
   :: Has tydef schema ('Typedef ty)
   => Alias tydef
+  -- ^ name of the user defined type
   -> Definition schema (Drop tydef schema)
 dropType tydef = UnsafeDefinition $ "DROP" <+> "TYPE" <+> renderAlias tydef <> ";"
 

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -783,11 +783,11 @@ dropView v = UnsafeDefinition $ "DROP VIEW" <+> renderAlias v <> ";"
 createTypeEnum
   :: (KnownSymbol enum, SOP.All KnownSymbol labels)
   => Alias enum
-  -> NP Alias labels
+  -> NP PGlabel labels
   -> Definition schema (Create enum ('Typedef ('PGenum labels)) schema)
 createTypeEnum enum labels = UnsafeDefinition $
   "CREATE" <+> "TYPE" <+> renderAlias enum <+> "AS" <+>
-  parenthesized (commaSeparated (renderAliases labels)) <> ";"
+  parenthesized (commaSeparated (renderLabels labels)) <> ";"
 
 createType
   :: (KnownSymbol comp, SOP.SListI fields)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -896,7 +896,7 @@ newtype ColumnTypeExpression (schema :: SchemaType) (ty :: ColumnType)
 
 instance (Has alias schema ('Typedef ty))
   => IsLabel alias (ColumnTypeExpression schema ('NoDef :=> 'NotNull ty)) where
-    fromLabel = UnsafeColumnTypeExpression (renderAlias (fromLabel @alias))
+    fromLabel = UnsafeColumnTypeExpression (renderAlias (fromLabel @alias) <+> "NOT NULL")
 
 -- | used in `createTable` commands as a column constraint to note that
 -- @NULL@ may be present in a column

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -246,7 +246,9 @@ check
   :: ( Has alias schema ('Table table)
      , HasAll aliases (TableToRelation table) subcolumns )
   => NP Alias aliases
+  -- ^ specify the subcolumns which are getting checked
   -> (forall tab. Condition '[tab ::: subcolumns] 'Ungrouped '[])
+  -- ^ a closed `Condition` on those subcolumns
   -> TableConstraintExpression schema alias ('Check aliases)
 check _cols condition = UnsafeTableConstraintExpression $
   "CHECK" <+> parenthesized (renderExpression condition)
@@ -277,6 +279,7 @@ unique
   :: ( Has alias schema ('Table table)
      , HasAll aliases (TableToRelation table) subcolumns )
   => NP Alias aliases
+  -- ^ specify subcolumns which together are unique for each row
   -> TableConstraintExpression schema alias ('Unique aliases)
 unique columns = UnsafeTableConstraintExpression $
   "UNIQUE" <+> parenthesized (commaSeparated (renderAliases columns))
@@ -309,6 +312,7 @@ primaryKey
      , HasAll aliases (TableToColumns table) subcolumns
      , AllNotNull subcolumns )
   => NP Alias aliases
+  -- ^ specify the subcolumns which together form a primary key.
   -> TableConstraintExpression schema alias ('PrimaryKey aliases)
 primaryKey columns = UnsafeTableConstraintExpression $
   "PRIMARY KEY" <+> parenthesized (commaSeparated (renderAliases columns))

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -151,7 +151,8 @@ createTable tab columns constraints = UnsafeDefinition $
 
 {-| `createTableIfNotExists` creates a table if it doesn't exist, but does not add it to the schema.
 Instead, the schema already has the table so if the table did not yet exist, the schema was wrong.
-`createTableIfNotExists` fixes this. Interestingly, this property makes it an idempotent in the `Category` `Definition`.
+`createTableIfNotExists` fixes this. Interestingly, this property makes it an idempotent in
+the `Category` of `Definition`s.
 
 >>> :set -XOverloadedLabels -XTypeApplications
 >>> type Table = '[] :=> '["a" ::: 'NoDef :=> 'Null 'PGint4, "b" ::: 'NoDef :=> 'Null 'PGfloat4]
@@ -789,7 +790,7 @@ alterType ty = UnsafeAlterColumn $ "TYPE" <+> renderColumnTypeExpression ty
 -- CREATE VIEW "bc" AS SELECT "b" AS "b", "c" AS "c" FROM "abc" AS "abc";
 createView
   :: KnownSymbol view
-  => Alias view -- ^ the name of the table to add
+  => Alias view -- ^ the name of the view to add
   -> Query schema '[] relation
     -- ^ query
   -> Definition schema (Create view ('View relation) schema)
@@ -932,19 +933,19 @@ default_ x ty = UnsafeColumnTypeExpression $
   renderColumnTypeExpression ty <+> "DEFAULT" <+> renderExpression x
 
 -- | not a true type, but merely a notational convenience for creating
--- unique identifier columns with type `'PGint2`
+-- unique identifier columns with type `PGint2`
 serial2, smallserial
   :: ColumnTypeExpression schema ('Def :=> 'NotNull 'PGint2)
 serial2 = UnsafeColumnTypeExpression "serial2"
 smallserial = UnsafeColumnTypeExpression "smallserial"
 -- | not a true type, but merely a notational convenience for creating
--- unique identifier columns with type `'PGint4`
+-- unique identifier columns with type `PGint4`
 serial4, serial
   :: ColumnTypeExpression schema ('Def :=> 'NotNull 'PGint4)
 serial4 = UnsafeColumnTypeExpression "serial4"
 serial = UnsafeColumnTypeExpression "serial"
 -- | not a true type, but merely a notational convenience for creating
--- unique identifier columns with type `'PGint8`
+-- unique identifier columns with type `PGint8`
 serial8, bigserial
   :: ColumnTypeExpression schema ('Def :=> 'NotNull 'PGint8)
 serial8 = UnsafeColumnTypeExpression "serial8"

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -10,20 +10,16 @@ Squeal data definition language.
 
 {-# LANGUAGE
     ConstraintKinds
-  , DataKinds
-  , DeriveDataTypeable
   , DeriveGeneric
   , FlexibleContexts
   , FlexibleInstances
   , GADTs
   , GeneralizedNewtypeDeriving
-  , KindSignatures
   , LambdaCase
   , MultiParamTypeClasses
   , OverloadedStrings
   , RankNTypes
   , ScopedTypeVariables
-  , StandaloneDeriving
   , TypeApplications
   , TypeInType
   , TypeOperators

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -338,7 +338,7 @@ primaryKey columns = UnsafeTableConstraintExpression $
 -- >>> :{
 -- let
 --   setup :: Definition '[] Schema
---   setup = 
+--   setup =
 --    createTable #users
 --      ( serial `As` #id :*
 --        (text & hasNotNull) `As` #name :* Nil )
@@ -372,7 +372,7 @@ primaryKey columns = UnsafeTableConstraintExpression $
 -- >>> :{
 -- let
 --   setup :: Definition '[] Schema
---   setup = 
+--   setup =
 --    createTable #employees
 --      ( serial `As` #id :*
 --        (text & hasNotNull) `As` #name :*

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -27,7 +27,7 @@ Squeal expressions are the atoms used to build statements.
   , UndecidableInstances
 #-}
 
-module Squeal.PostgreSQL.Expression 
+module Squeal.PostgreSQL.Expression
   ( -- * Expression
     Expression (UnsafeExpression, renderExpression)
   , HasParameter (param)
@@ -223,7 +223,7 @@ instance (Has relation relations columns, Has column columns ty)
   => IsQualified relation column
     (NP (Aliased (Expression relations 'Ungrouped params)) '[column ::: ty]) where
     relation ! column = relation ! column :* Nil
-  
+
 instance
   ( HasUnique relation relations columns
   , Has column columns ty

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -1045,7 +1045,7 @@ newtype Table
     deriving (GHC.Generic,Show,Eq,Ord,NFData)
 instance
   ( Has alias schema ('Table table)
-  , relation ~ ColumnsToRelation (TableToColumns table)
+  , relation ~ TableToRelation table
   ) => IsLabel alias (Table schema relation) where
     fromLabel = UnsafeTable $ renderAlias (Alias @alias)
 

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -320,8 +320,7 @@ array xs = UnsafeExpression $
 
 instance (KnownSymbol label, label `In` labels) => IsPGlabel label
   (Expression relations grouping params (nullity ('PGenum labels))) where
-  label = UnsafeExpression $
-    "\'" <> fromString (symbolVal (Proxy @label)) <> "\'"
+  label = UnsafeExpression $ renderLabel (PGlabel @label)
 
 row
   :: (SListI (Nulls fields))

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -42,7 +42,6 @@ module Squeal.PostgreSQL.Expression
   , nullIf
     -- ** Arrays, Enums, Composites
   , array
-  , label
   , row
     -- ** Functions
   , unsafeBinaryOp
@@ -319,12 +318,10 @@ array
 array xs = UnsafeExpression $
   "ARRAY[" <> commaSeparated (renderExpression <$> xs) <> "]"
 
-label
-  :: (KnownSymbol label, label `In` labels)
-  => Alias label
-  -> Expression relations grouping params (nullity ('PGenum labels))
-label (_ :: Alias label) = UnsafeExpression $
-  fromString $ symbolVal (Proxy @label)
+instance (KnownSymbol label, label `In` labels) => IsPGlabel label
+  (Expression relations grouping params (nullity ('PGenum labels))) where
+  label = UnsafeExpression $
+    "\'" <> fromString (symbolVal (Proxy @label)) <> "\'"
 
 row
   :: (SListI (Nulls fields))

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -92,9 +92,6 @@ module Squeal.PostgreSQL.Expression
   , count, countDistinct
   , every, everyDistinct
   , max_, maxDistinct, min_, minDistinct
-    -- * Tables
-  , Table (UnsafeTable, renderTable)
-  , View (UnsafeView, renderView)
     -- * Types
   , TypeExpression (UnsafeTypeExpression, renderTypeExpression)
   , PGTyped (pgtype)
@@ -1079,35 +1076,6 @@ max_ = unsafeAggregate "max"
 min_ = unsafeAggregate "min"
 maxDistinct = unsafeAggregateDistinct "max"
 minDistinct = unsafeAggregateDistinct "min"
-
-{-----------------------------------------
-tables
------------------------------------------}
-
--- | A `Table` from a table expression is a way
--- to call a table reference by its alias.
-newtype Table
-  (schema :: SchemaType)
-  (columns :: RelationType)
-    = UnsafeTable { renderTable :: ByteString }
-    deriving (GHC.Generic,Show,Eq,Ord,NFData)
-instance
-  ( Has alias schema ('Table table)
-  , relation ~ TableToRelation table
-  ) => IsLabel alias (Table schema relation) where
-    fromLabel = UnsafeTable $ renderAlias (Alias @alias)
-
--- | A `View` from a table expression is a way
--- to call a table reference by its alias.
-newtype View
-  (schema :: SchemaType)
-  (columns :: RelationType)
-    = UnsafeView { renderView :: ByteString }
-    deriving (GHC.Generic,Show,Eq,Ord,NFData)
-instance
-  ( Has alias schema ('View columns)
-  ) => IsLabel alias (View schema columns) where
-    fromLabel = UnsafeView $ renderAlias (Alias @alias)
 
 {-----------------------------------------
 type expressions

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -32,12 +32,12 @@ module Squeal.PostgreSQL.Expression
     Expression (UnsafeExpression, renderExpression)
   , HasParameter (param)
     -- ** Null
-  , HasNull (null_)
-  , HasNotNull (notNull)
+  , null_
+  , notNull
   , coalesce
   , fromNull
   , isNull
-  , isn'tNull
+  , isNotNull
   , matchNull
   , nullIf
     -- ** Arrays, Enums, Composites
@@ -221,24 +221,21 @@ instance
       relation ! column = UnsafeExpression $
         renderAlias relation <> "." <> renderAlias column
 
-class HasNull expr where null_ :: expr
-instance HasNull (Expression rels grouping params ('Null ty)) where
-  -- | analagous to `Nothing`
-  --
-  -- >>> renderExpression $ null_
-  -- "NULL"
-  null_ = UnsafeExpression "NULL"
+-- | analagous to `Nothing`
+--
+-- >>> renderExpression $ null_
+-- "NULL"
+null_ :: Expression rels grouping params ('Null ty)
+null_ = UnsafeExpression "NULL"
 
-class HasNotNull expr where notNull :: expr
-instance HasNotNull
-  ( Expression rels grouping params ('NotNull ty)
-    ->
-    Expression rels grouping params ('Null ty) ) where
-  -- | analagous to `Just`
-  --
-  -- >>> renderExpression $ notNull true
-  -- "TRUE"
-  notNull = UnsafeExpression . renderExpression
+-- | analagous to `Just`
+--
+-- >>> renderExpression $ notNull true
+-- "TRUE"
+notNull
+  :: Expression rels grouping params ('NotNull ty)
+  -> Expression rels grouping params ('Null ty)
+notNull = UnsafeExpression . renderExpression
 
 -- | return the leftmost value which is not NULL
 --
@@ -273,13 +270,13 @@ isNull
   -> Condition relations grouping params
 isNull x = UnsafeExpression $ renderExpression x <+> "IS NULL"
 
--- | >>> renderExpression $ null_ & isn'tNull
+-- | >>> renderExpression $ null_ & isNotNull
 -- "NULL IS NOT NULL"
-isn'tNull
+isNotNull
   :: Expression relations grouping params ('Null ty)
   -- ^ possibly @NULL@
   -> Condition relations grouping params
-isn'tNull x = UnsafeExpression $ renderExpression x <+> "IS NOT NULL"
+isNotNull x = UnsafeExpression $ renderExpression x <+> "IS NOT NULL"
 
 -- | analagous to `maybe` using @IS NULL@
 --

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -189,6 +189,11 @@ class KnownNat n => HasParameter
   (params :: [NullityType])
   (ty :: NullityType)
   | n params -> ty where
+    -- | `parameter` takes a `Nat` using type application and a `TypeExpression`.
+    --
+    -- >>> let expr = parameter @1 int4 :: Expression sch rels grp '[ 'Null 'PGint4] ('Null 'PGint4)
+    -- >>> printSQL expr
+    -- ($1 :: int4)
     parameter
       :: TypeExpression schema (PGTypeOf ty)
       -> Expression schema relations grouping params ty
@@ -199,10 +204,16 @@ instance {-# OVERLAPPING #-} HasParameter 1 schema (ty1:tys) ty1
 instance {-# OVERLAPPABLE #-} (KnownNat n, HasParameter (n-1) schema params ty)
   => HasParameter n schema (ty' : params) ty
 
+-- | `param` takes a `Nat` using type application and for basic types,
+-- infers a `TypeExpression`.
+--
+-- >>> let expr = param @1 :: Expression sch rels grp '[ 'Null 'PGint4] ('Null 'PGint4)
+-- >>> printSQL expr
+-- ($1 :: int4)
 param
   :: forall n schema params relations grouping ty
    . (PGTyped schema (PGTypeOf ty), HasParameter n schema params ty)
-  => Expression schema relations grouping params ty
+  => Expression schema relations grouping params ty -- ^ param
 param = parameter @n pgtype
 
 instance (HasUnique relation relations columns, Has column columns ty)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -138,7 +138,7 @@ import Control.Category
 import Control.DeepSeq
 import Data.ByteString (ByteString)
 import Data.Function ((&))
-import Data.Monoid hiding (All)
+import Data.Semigroup
 import Data.Ratio
 import Data.String
 import Generics.SOP hiding (from)
@@ -338,10 +338,14 @@ instance Has field fields ty => IsLabel field
       parenthesized (renderExpression expr) <> "." <>
         fromString (symbolVal (Proxy @field))
 
+instance Semigroup
+  (Expression relations grouping params (nullity ('PGvararray ty))) where
+    (<>) = unsafeBinaryOp "||"
+
 instance Monoid
   (Expression relations grouping params (nullity ('PGvararray ty))) where
     mempty = array []
-    mappend = unsafeBinaryOp "||"
+    mappend = (<>)
 
 -- | >>> renderExpression @_ @_ @'[_] $ greatest currentTimestamp [param @1]
 -- "GREATEST(CURRENT_TIMESTAMP, ($1 :: timestamp with time zone))"
@@ -734,10 +738,14 @@ instance IsString
           '\\' -> "\\\\"
           c -> [c]
 
+instance Semigroup
+  (Expression relations grouping params (nullity 'PGtext)) where
+    (<>) = unsafeBinaryOp "||"
+
 instance Monoid
   (Expression relations grouping params (nullity 'PGtext)) where
     mempty = fromString ""
-    mappend = unsafeBinaryOp "||"
+    mappend = (<>)
 
 -- | >>> renderExpression $ lower "ARRRGGG"
 -- "lower(E'ARRRGGG')"

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -30,7 +30,8 @@ Squeal expressions are the atoms used to build statements.
 module Squeal.PostgreSQL.Expression
   ( -- * Expression
     Expression (UnsafeExpression, renderExpression)
-  , HasParameter (param)
+  , HasParameter (parameter)
+  , param
     -- ** Null
   , null_
   , notNull
@@ -163,6 +164,7 @@ values from primitive expression using arithmetic, logical,
 and other operations.
 -}
 newtype Expression
+  (schema :: SchemaType)
   (relations :: RelationsType)
   (grouping :: Grouping)
   (params :: [NullityType])
@@ -178,43 +180,51 @@ supplied externally to a SQL statement.
 separately from the SQL command string, in which case `param`s are used to
 refer to the out-of-line data values.
 -}
-class (PGTyped (PGTypeOf ty), KnownNat n) => HasParameter
+class KnownNat n => HasParameter
   (n :: Nat)
+  (schema :: SchemaType)
   (params :: [NullityType])
   (ty :: NullityType)
   | n params -> ty where
-    param :: Expression relations grouping params ty
-    param = UnsafeExpression $ parenthesized $
+    parameter
+      :: TypeExpression schema (PGTypeOf ty)
+      -> Expression schema relations grouping params ty
+    parameter ty = UnsafeExpression $ parenthesized $
       "$" <> renderNat (Proxy @n) <+> "::"
-        <+> renderTypeExpression (pgtype @(PGTypeOf ty))
-instance {-# OVERLAPPING #-} PGTyped (PGTypeOf ty1)
-  => HasParameter 1 (ty1:tys) ty1
-instance {-# OVERLAPPABLE #-} (KnownNat n, HasParameter (n-1) params ty)
-  => HasParameter n (ty' : params) ty
+        <+> renderTypeExpression ty
+instance {-# OVERLAPPING #-} HasParameter 1 schema (ty1:tys) ty1
+instance {-# OVERLAPPABLE #-} (KnownNat n, HasParameter (n-1) schema params ty)
+  => HasParameter n schema (ty' : params) ty
+
+param
+  :: forall n schema params relations grouping ty
+   . (PGTyped schema (PGTypeOf ty), HasParameter n schema params ty)
+  => Expression schema relations grouping params ty
+param = parameter @n pgtype
 
 instance (HasUnique relation relations columns, Has column columns ty)
-  => IsLabel column (Expression relations 'Ungrouped params ty) where
+  => IsLabel column (Expression schema relations 'Ungrouped params ty) where
     fromLabel = UnsafeExpression $ renderAlias (Alias @column)
 instance (HasUnique relation relations columns, Has column columns ty)
   => IsLabel column
-    (Aliased (Expression relations 'Ungrouped params) (column ::: ty)) where
+    (Aliased (Expression schema relations 'Ungrouped params) (column ::: ty)) where
     fromLabel = fromLabel @column `As` Alias @column
 instance (HasUnique relation relations columns, Has column columns ty)
   => IsLabel column
-    (NP (Aliased (Expression relations 'Ungrouped params)) '[column ::: ty]) where
+    (NP (Aliased (Expression schema relations 'Ungrouped params)) '[column ::: ty]) where
     fromLabel = fromLabel @column :* Nil
 
 instance (Has relation relations columns, Has column columns ty)
-  => IsQualified relation column (Expression relations 'Ungrouped params ty) where
+  => IsQualified relation column (Expression schema relations 'Ungrouped params ty) where
     relation ! column = UnsafeExpression $
       renderAlias relation <> "." <> renderAlias column
 instance (Has relation relations columns, Has column columns ty)
   => IsQualified relation column
-    (Aliased (Expression relations 'Ungrouped params) (column ::: ty)) where
+    (Aliased (Expression schema relations 'Ungrouped params) (column ::: ty)) where
     relation ! column = relation ! column `As` column
 instance (Has relation relations columns, Has column columns ty)
   => IsQualified relation column
-    (NP (Aliased (Expression relations 'Ungrouped params)) '[column ::: ty]) where
+    (NP (Aliased (Expression schema relations 'Ungrouped params)) '[column ::: ty]) where
     relation ! column = relation ! column :* Nil
 
 instance
@@ -222,14 +232,14 @@ instance
   , Has column columns ty
   , GroupedBy relation column bys
   ) => IsLabel column
-    (Expression relations ('Grouped bys) params ty) where
+    (Expression schema relations ('Grouped bys) params ty) where
       fromLabel = UnsafeExpression $ renderAlias (Alias @column)
 instance
   ( HasUnique relation relations columns
   , Has column columns ty
   , GroupedBy relation column bys
   ) => IsLabel column
-    ( Aliased (Expression relations ('Grouped bys) params)
+    ( Aliased (Expression schema relations ('Grouped bys) params)
       (column ::: ty) ) where
       fromLabel = fromLabel @column `As` Alias @column
 instance
@@ -237,7 +247,7 @@ instance
   , Has column columns ty
   , GroupedBy relation column bys
   ) => IsLabel column
-    ( NP (Aliased (Expression relations ('Grouped bys) params))
+    ( NP (Aliased (Expression schema relations ('Grouped bys) params))
       '[column ::: ty] ) where
       fromLabel = fromLabel @column :* Nil
 
@@ -246,7 +256,7 @@ instance
   , Has column columns ty
   , GroupedBy relation column bys
   ) => IsQualified relation column
-    (Expression relations ('Grouped bys) params ty) where
+    (Expression schema relations ('Grouped bys) params ty) where
       relation ! column = UnsafeExpression $
         renderAlias relation <> "." <> renderAlias column
 instance
@@ -254,7 +264,7 @@ instance
   , Has column columns ty
   , GroupedBy relation column bys
   ) => IsQualified relation column
-    (Aliased (Expression relations ('Grouped bys) params)
+    (Aliased (Expression schema relations ('Grouped bys) params)
       (column ::: ty)) where
         relation ! column = relation ! column `As` column
 instance
@@ -262,7 +272,7 @@ instance
   , Has column columns ty
   , GroupedBy relation column bys
   ) => IsQualified relation column
-    ( NP (Aliased (Expression relations ('Grouped bys) params))
+    ( NP (Aliased (Expression schema relations ('Grouped bys) params))
       '[column ::: ty]) where
         relation ! column = relation ! column :* Nil
 
@@ -270,7 +280,7 @@ instance
 --
 -- >>> renderExpression $ null_
 -- "NULL"
-null_ :: Expression rels grouping params ('Null ty)
+null_ :: Expression schema rels grouping params ('Null ty)
 null_ = UnsafeExpression "NULL"
 
 -- | analagous to `Just`
@@ -278,8 +288,8 @@ null_ = UnsafeExpression "NULL"
 -- >>> renderExpression $ notNull true
 -- "TRUE"
 notNull
-  :: Expression rels grouping params ('NotNull ty)
-  -> Expression rels grouping params ('Null ty)
+  :: Expression schema rels grouping params ('NotNull ty)
+  -> Expression schema rels grouping params ('Null ty)
 notNull = UnsafeExpression . renderExpression
 
 -- | return the leftmost value which is not NULL
@@ -287,11 +297,11 @@ notNull = UnsafeExpression . renderExpression
 -- >>> renderExpression $ coalesce [null_, notNull true] false
 -- "COALESCE(NULL, TRUE, FALSE)"
 coalesce
-  :: [Expression relations grouping params ('Null ty)]
+  :: [Expression schema relations grouping params ('Null ty)]
   -- ^ @NULL@s may be present
-  -> Expression relations grouping params ('NotNull ty)
+  -> Expression schema relations grouping params ('NotNull ty)
   -- ^ @NULL@ is absent
-  -> Expression relations grouping params ('NotNull ty)
+  -> Expression schema relations grouping params ('NotNull ty)
 coalesce nullxs notNullx = UnsafeExpression $
   "COALESCE" <> parenthesized (commaSeparated
     ((renderExpression <$> nullxs) <> [renderExpression notNullx]))
@@ -301,26 +311,26 @@ coalesce nullxs notNullx = UnsafeExpression $
 -- >>> renderExpression $ fromNull true null_
 -- "COALESCE(NULL, TRUE)"
 fromNull
-  :: Expression relations grouping params ('NotNull ty)
+  :: Expression schema relations grouping params ('NotNull ty)
   -- ^ what to convert @NULL@ to
-  -> Expression relations grouping params ('Null ty)
-  -> Expression relations grouping params ('NotNull ty)
+  -> Expression schema relations grouping params ('Null ty)
+  -> Expression schema relations grouping params ('NotNull ty)
 fromNull notNullx nullx = coalesce [nullx] notNullx
 
 -- | >>> renderExpression $ null_ & isNull
 -- "NULL IS NULL"
 isNull
-  :: Expression relations grouping params ('Null ty)
+  :: Expression schema relations grouping params ('Null ty)
   -- ^ possibly @NULL@
-  -> Condition relations grouping params
+  -> Condition schema relations grouping params
 isNull x = UnsafeExpression $ renderExpression x <+> "IS NULL"
 
 -- | >>> renderExpression $ null_ & isNotNull
 -- "NULL IS NOT NULL"
 isNotNull
-  :: Expression relations grouping params ('Null ty)
+  :: Expression schema relations grouping params ('Null ty)
   -- ^ possibly @NULL@
-  -> Condition relations grouping params
+  -> Condition schema relations grouping params
 isNotNull x = UnsafeExpression $ renderExpression x <+> "IS NOT NULL"
 
 -- | analagous to `maybe` using @IS NULL@
@@ -328,13 +338,13 @@ isNotNull x = UnsafeExpression $ renderExpression x <+> "IS NOT NULL"
 -- >>> renderExpression $ matchNull true not_ null_
 -- "CASE WHEN NULL IS NULL THEN TRUE ELSE (NOT NULL) END"
 matchNull
-  :: Expression relations grouping params (nullty)
+  :: Expression schema relations grouping params (nullty)
   -- ^ what to convert @NULL@ to
-  -> ( Expression relations grouping params ('NotNull ty)
-       -> Expression relations grouping params (nullty) )
+  -> ( Expression schema relations grouping params ('NotNull ty)
+       -> Expression schema relations grouping params (nullty) )
   -- ^ function to perform when @NULL@ is absent
-  -> Expression relations grouping params ('Null ty)
-  -> Expression relations grouping params (nullty)
+  -> Expression schema relations grouping params ('Null ty)
+  -> Expression schema relations grouping params (nullty)
 matchNull y f x = ifThenElse (isNull x) y
   (f (UnsafeExpression (renderExpression x)))
 
@@ -345,25 +355,25 @@ matchNull y f x = ifThenElse (isNull x) y
 -- >>> renderExpression @_ @_ @'[_] $ fromNull false (nullIf false (param @1))
 -- "COALESCE(NULL IF (FALSE, ($1 :: bool)), FALSE)"
 nullIf
-  :: Expression relations grouping params ('NotNull ty)
+  :: Expression schema relations grouping params ('NotNull ty)
   -- ^ @NULL@ is absent
-  -> Expression relations grouping params ('NotNull ty)
+  -> Expression schema relations grouping params ('NotNull ty)
   -- ^ @NULL@ is absent
-  -> Expression relations grouping params ('Null ty)
+  -> Expression schema relations grouping params ('Null ty)
 nullIf x y = UnsafeExpression $ "NULL IF" <+> parenthesized
   (renderExpression x <> ", " <> renderExpression y)
 
 -- | >>> renderExpression $ array [null_, notNull false, notNull true]
 -- "ARRAY[NULL, FALSE, TRUE]"
 array
-  :: [Expression relations grouping params ('Null ty)]
+  :: [Expression schema relations grouping params ('Null ty)]
   -- ^ array elements
-  -> Expression relations grouping params (nullity ('PGvararray ty))
+  -> Expression schema relations grouping params (nullity ('PGvararray ty))
 array xs = UnsafeExpression $
   "ARRAY[" <> commaSeparated (renderExpression <$> xs) <> "]"
 
 instance (KnownSymbol label, label `In` labels) => IsPGlabel label
-  (Expression relations grouping params (nullity ('PGenum labels))) where
+  (Expression schema relations grouping params (nullity ('PGenum labels))) where
   label = UnsafeExpression $ renderLabel (PGlabel @label)
 
 -- | A row constructor is an expression that builds a row value
@@ -375,47 +385,47 @@ instance (KnownSymbol label, label `In` labels) => IsPGlabel label
 -- "ROW(0, 1)"
 row
   :: SListI (Nulls fields)
-  => NP (Aliased (Expression relation grouping params)) (Nulls fields)
+  => NP (Aliased (Expression schema relations grouping params)) (Nulls fields)
   -- ^ zero or more expressions for the row field values
-  -> Expression relation grouping params (nullity ('PGcomposite fields))
+  -> Expression schema relations grouping params (nullity ('PGcomposite fields))
 row exprs = UnsafeExpression $ "ROW" <> parenthesized
   (renderCommaSeparated (\ (expr `As` _) -> renderExpression expr) exprs)
 
 instance Has field fields ty => IsLabel field
-  (   Expression relation grouping params (nullity ('PGcomposite fields))
-   -> Expression relation grouping params ('Null ty) ) where
+  (   Expression schema relation grouping params (nullity ('PGcomposite fields))
+   -> Expression schema relation grouping params ('Null ty) ) where
     fromLabel expr = UnsafeExpression $
       parenthesized (renderExpression expr) <> "." <>
         fromString (symbolVal (Proxy @field))
 
 instance Semigroup
-  (Expression relations grouping params (nullity ('PGvararray ty))) where
+  (Expression schema relations grouping params (nullity ('PGvararray ty))) where
     (<>) = unsafeBinaryOp "||"
 
 instance Monoid
-  (Expression relations grouping params (nullity ('PGvararray ty))) where
+  (Expression schema relations grouping params (nullity ('PGvararray ty))) where
     mempty = array []
     mappend = (<>)
 
 -- | >>> renderExpression @_ @_ @'[_] $ greatest currentTimestamp [param @1]
 -- "GREATEST(CURRENT_TIMESTAMP, ($1 :: timestamp with time zone))"
 greatest
-  :: Expression relations grouping params (nullty)
+  :: Expression schema relations grouping params (nullty)
   -- ^ needs at least 1 argument
-  -> [Expression relations grouping params (nullty)]
+  -> [Expression schema relations grouping params (nullty)]
   -- ^ or more
-  -> Expression relations grouping params (nullty)
+  -> Expression schema relations grouping params (nullty)
 greatest x xs = UnsafeExpression $ "GREATEST("
   <> commaSeparated (renderExpression <$> (x:xs)) <> ")"
 
 -- | >>> renderExpression $ least currentTimestamp [null_]
 -- "LEAST(CURRENT_TIMESTAMP, NULL)"
 least
-  :: Expression relations grouping params (nullty)
+  :: Expression schema relations grouping params (nullty)
   -- ^ needs at least 1 argument
-  -> [Expression relations grouping params (nullty)]
+  -> [Expression schema relations grouping params (nullty)]
   -- ^ or more
-  -> Expression relations grouping params (nullty)
+  -> Expression schema relations grouping params (nullty)
 least x xs = UnsafeExpression $ "LEAST("
   <> commaSeparated (renderExpression <$> (x:xs)) <> ")"
 
@@ -424,9 +434,9 @@ least x xs = UnsafeExpression $ "LEAST("
 unsafeBinaryOp
   :: ByteString
   -- ^ operator
-  -> Expression relations grouping params (ty0)
-  -> Expression relations grouping params (ty1)
-  -> Expression relations grouping params (ty2)
+  -> Expression schema relations grouping params (ty0)
+  -> Expression schema relations grouping params (ty1)
+  -> Expression schema relations grouping params (ty2)
 unsafeBinaryOp op x y = UnsafeExpression $ parenthesized $
   renderExpression x <+> op <+> renderExpression y
 
@@ -435,8 +445,8 @@ unsafeBinaryOp op x y = UnsafeExpression $ parenthesized $
 unsafeUnaryOp
   :: ByteString
   -- ^ operator
-  -> Expression relations grouping params (ty0)
-  -> Expression relations grouping params (ty1)
+  -> Expression schema relations grouping params (ty0)
+  -> Expression schema relations grouping params (ty1)
 unsafeUnaryOp op x = UnsafeExpression $ parenthesized $
   op <+> renderExpression x
 
@@ -445,13 +455,13 @@ unsafeUnaryOp op x = UnsafeExpression $ parenthesized $
 unsafeFunction
   :: ByteString
   -- ^ function
-  -> Expression relations grouping params (xty)
-  -> Expression relations grouping params (yty)
+  -> Expression schema relations grouping params (xty)
+  -> Expression schema relations grouping params (yty)
 unsafeFunction fun x = UnsafeExpression $
   fun <> parenthesized (renderExpression x)
 
 instance PGNum ty
-  => Num (Expression relations grouping params (nullity ty)) where
+  => Num (Expression schema relations grouping params (nullity ty)) where
     (+) = unsafeBinaryOp "+"
     (-) = unsafeBinaryOp "-"
     (*) = unsafeBinaryOp "*"
@@ -463,12 +473,12 @@ instance PGNum ty
       . show
 
 instance (PGNum ty, PGFloating ty) => Fractional
-  (Expression relations grouping params (nullity ty)) where
+  (Expression schema relations grouping params (nullity ty)) where
     (/) = unsafeBinaryOp "/"
     fromRational x = fromInteger (numerator x) / fromInteger (denominator x)
 
 instance (PGNum ty, PGFloating ty) => Floating
-  (Expression relations grouping params (nullity ty)) where
+  (Expression schema relations grouping params (nullity ty)) where
     pi = UnsafeExpression "pi()"
     exp = unsafeFunction "exp"
     log = unsafeFunction "ln"
@@ -491,18 +501,18 @@ instance (PGNum ty, PGFloating ty) => Floating
 
 -- | >>> :{
 -- let
---   expression :: Expression relations grouping params (nullity 'PGfloat4)
+--   expression :: Expression schema relations grouping params (nullity 'PGfloat4)
 --   expression = atan2_ pi 2
 -- in renderExpression expression
 -- :}
 -- "atan2(pi(), 2)"
 atan2_
   :: PGFloating float
-  => Expression relations grouping params (nullity float)
+  => Expression schema relations grouping params (nullity float)
   -- ^ numerator
-  -> Expression relations grouping params (nullity float)
+  -> Expression schema relations grouping params (nullity float)
   -- ^ denominator
-  -> Expression relations grouping params (nullity float)
+  -> Expression schema relations grouping params (nullity float)
 atan2_ y x = UnsafeExpression $
   "atan2(" <> renderExpression y <> ", " <> renderExpression x <> ")"
 
@@ -513,11 +523,11 @@ atan2_ y x = UnsafeExpression $
 -- | >>> renderExpression $ true & cast int4
 -- "(TRUE :: int4)"
 cast
-  :: TypeExpression ty1
+  :: TypeExpression schema ty1
   -- ^ type to cast as
-  -> Expression relations grouping params (nullity ty0)
+  -> Expression schema relations grouping params (nullity ty0)
   -- ^ value to convert
-  -> Expression relations grouping params (nullity ty1)
+  -> Expression schema relations grouping params (nullity ty1)
 cast ty x = UnsafeExpression $ parenthesized $
   renderExpression x <+> "::" <+> renderTypeExpression ty
 
@@ -525,135 +535,135 @@ cast ty x = UnsafeExpression $ parenthesized $
 --
 -- >>> :{
 -- let
---   expression :: Expression relations grouping params (nullity 'PGint2)
+--   expression :: Expression schema relations grouping params (nullity 'PGint2)
 --   expression = 5 `quot_` 2
 -- in renderExpression expression
 -- :}
 -- "(5 / 2)"
 quot_
   :: PGIntegral int
-  => Expression relations grouping params (nullity int)
+  => Expression schema relations grouping params (nullity int)
   -- ^ numerator
-  -> Expression relations grouping params (nullity int)
+  -> Expression schema relations grouping params (nullity int)
   -- ^ denominator
-  -> Expression relations grouping params (nullity int)
+  -> Expression schema relations grouping params (nullity int)
 quot_ = unsafeBinaryOp "/"
 
 -- | remainder upon integer division
 --
 -- >>> :{
 -- let
---   expression :: Expression relations grouping params (nullity 'PGint2)
+--   expression :: Expression schema relations grouping params (nullity 'PGint2)
 --   expression = 5 `rem_` 2
 -- in renderExpression expression
 -- :}
 -- "(5 % 2)"
 rem_
   :: PGIntegral int
-  => Expression relations grouping params (nullity int)
+  => Expression schema relations grouping params (nullity int)
   -- ^ numerator
-  -> Expression relations grouping params (nullity int)
+  -> Expression schema relations grouping params (nullity int)
   -- ^ denominator
-  -> Expression relations grouping params (nullity int)
+  -> Expression schema relations grouping params (nullity int)
 rem_ = unsafeBinaryOp "%"
 
 -- | >>> :{
 -- let
---   expression :: Expression relations grouping params (nullity 'PGfloat4)
+--   expression :: Expression schema relations grouping params (nullity 'PGfloat4)
 --   expression = trunc pi
 -- in renderExpression expression
 -- :}
 -- "trunc(pi())"
 trunc
   :: PGFloating frac
-  => Expression relations grouping params (nullity frac)
+  => Expression schema relations grouping params (nullity frac)
   -- ^ fractional number
-  -> Expression relations grouping params (nullity frac)
+  -> Expression schema relations grouping params (nullity frac)
 trunc = unsafeFunction "trunc"
 
 -- | >>> :{
 -- let
---   expression :: Expression relations grouping params (nullity 'PGfloat4)
+--   expression :: Expression schema relations grouping params (nullity 'PGfloat4)
 --   expression = round_ pi
 -- in renderExpression expression
 -- :}
 -- "round(pi())"
 round_
   :: PGFloating frac
-  => Expression relations grouping params (nullity frac)
+  => Expression schema relations grouping params (nullity frac)
   -- ^ fractional number
-  -> Expression relations grouping params (nullity frac)
+  -> Expression schema relations grouping params (nullity frac)
 round_ = unsafeFunction "round"
 
 -- | >>> :{
 -- let
---   expression :: Expression relations grouping params (nullity 'PGfloat4)
+--   expression :: Expression schema relations grouping params (nullity 'PGfloat4)
 --   expression = ceiling_ pi
 -- in renderExpression expression
 -- :}
 -- "ceiling(pi())"
 ceiling_
   :: PGFloating frac
-  => Expression relations grouping params (nullity frac)
+  => Expression schema relations grouping params (nullity frac)
   -- ^ fractional number
-  -> Expression relations grouping params (nullity frac)
+  -> Expression schema relations grouping params (nullity frac)
 ceiling_ = unsafeFunction "ceiling"
 
 -- | A `Condition` is a boolean valued `Expression`. While SQL allows
 -- conditions to have @NULL@, Squeal instead chooses to disallow @NULL@,
 -- forcing one to handle the case of @NULL@ explicitly to produce
 -- a `Condition`.
-type Condition relations grouping params =
-  Expression relations grouping params ('NotNull 'PGbool)
+type Condition schema relations grouping params =
+  Expression schema relations grouping params ('NotNull 'PGbool)
 
 -- | >>> renderExpression true
 -- "TRUE"
-true :: Condition relations grouping params
+true :: Condition schema relations grouping params
 true = UnsafeExpression "TRUE"
 
 -- | >>> renderExpression false
 -- "FALSE"
-false :: Condition relations grouping params
+false :: Condition schema relations grouping params
 false = UnsafeExpression "FALSE"
 
 -- | >>> renderExpression $ not_ true
 -- "(NOT TRUE)"
 not_
-  :: Condition relations grouping params
-  -> Condition relations grouping params
+  :: Condition schema relations grouping params
+  -> Condition schema relations grouping params
 not_ = unsafeUnaryOp "NOT"
 
 -- | >>> renderExpression $ true .&& false
 -- "(TRUE AND FALSE)"
 (.&&)
-  :: Condition relations grouping params
-  -> Condition relations grouping params
-  -> Condition relations grouping params
+  :: Condition schema relations grouping params
+  -> Condition schema relations grouping params
+  -> Condition schema relations grouping params
 (.&&) = unsafeBinaryOp "AND"
 
 -- | >>> renderExpression $ true .|| false
 -- "(TRUE OR FALSE)"
 (.||)
-  :: Condition relations grouping params
-  -> Condition relations grouping params
-  -> Condition relations grouping params
+  :: Condition schema relations grouping params
+  -> Condition schema relations grouping params
+  -> Condition schema relations grouping params
 (.||) = unsafeBinaryOp "OR"
 
 -- | >>> :{
 -- let
---   expression :: Expression relations grouping params (nullity 'PGint2)
+--   expression :: Expression schema relations grouping params (nullity 'PGint2)
 --   expression = caseWhenThenElse [(true, 1), (false, 2)] 3
 -- in renderExpression expression
 -- :}
 -- "CASE WHEN TRUE THEN 1 WHEN FALSE THEN 2 ELSE 3 END"
 caseWhenThenElse
-  :: [ ( Condition relations grouping params
-       , Expression relations grouping params (ty)
+  :: [ ( Condition schema relations grouping params
+       , Expression schema relations grouping params (ty)
      ) ]
   -- ^ whens and thens
-  -> Expression relations grouping params (ty)
+  -> Expression schema relations grouping params (ty)
   -- ^ else
-  -> Expression relations grouping params (ty)
+  -> Expression schema relations grouping params (ty)
 caseWhenThenElse whenThens else_ = UnsafeExpression $ mconcat
   [ "CASE"
   , mconcat
@@ -669,16 +679,16 @@ caseWhenThenElse whenThens else_ = UnsafeExpression $ mconcat
 
 -- | >>> :{
 -- let
---   expression :: Expression relations grouping params (nullity 'PGint2)
+--   expression :: Expression schema relations grouping params (nullity 'PGint2)
 --   expression = ifThenElse true 1 0
 -- in renderExpression expression
 -- :}
 -- "CASE WHEN TRUE THEN 1 ELSE 0 END"
 ifThenElse
-  :: Condition relations grouping params
-  -> Expression relations grouping params (ty) -- ^ then
-  -> Expression relations grouping params (ty) -- ^ else
-  -> Expression relations grouping params (ty)
+  :: Condition schema relations grouping params
+  -> Expression schema relations grouping params (ty) -- ^ then
+  -> Expression schema relations grouping params (ty) -- ^ else
+  -> Expression schema relations grouping params (ty)
 ifThenElse if_ then_ else_ = caseWhenThenElse [(if_,then_)] else_
 
 -- | Comparison operations like `.==`, `./=`, `.>`, `.>=`, `.<` and `.<=`
@@ -687,85 +697,85 @@ ifThenElse if_ then_ else_ = caseWhenThenElse [(if_,then_)] else_
 -- >>> renderExpression $ notNull true .== null_
 -- "(TRUE = NULL)"
 (.==)
-  :: Expression relations grouping params (nullity ty) -- ^ lhs
-  -> Expression relations grouping params (nullity ty) -- ^ rhs
-  -> Expression relations grouping params (nullity 'PGbool)
+  :: Expression schema relations grouping params (nullity ty) -- ^ lhs
+  -> Expression schema relations grouping params (nullity ty) -- ^ rhs
+  -> Expression schema relations grouping params (nullity 'PGbool)
 (.==) = unsafeBinaryOp "="
 infix 4 .==
 
 -- | >>> renderExpression $ notNull true ./= null_
 -- "(TRUE <> NULL)"
 (./=)
-  :: Expression relations grouping params (nullity ty) -- ^ lhs
-  -> Expression relations grouping params (nullity ty) -- ^ rhs
-  -> Expression relations grouping params (nullity 'PGbool)
+  :: Expression schema relations grouping params (nullity ty) -- ^ lhs
+  -> Expression schema relations grouping params (nullity ty) -- ^ rhs
+  -> Expression schema relations grouping params (nullity 'PGbool)
 (./=) = unsafeBinaryOp "<>"
 infix 4 ./=
 
 -- | >>> renderExpression $ notNull true .>= null_
 -- "(TRUE >= NULL)"
 (.>=)
-  :: Expression relations grouping params (nullity ty) -- ^ lhs
-  -> Expression relations grouping params (nullity ty) -- ^ rhs
-  -> Expression relations grouping params (nullity 'PGbool)
+  :: Expression schema relations grouping params (nullity ty) -- ^ lhs
+  -> Expression schema relations grouping params (nullity ty) -- ^ rhs
+  -> Expression schema relations grouping params (nullity 'PGbool)
 (.>=) = unsafeBinaryOp ">="
 infix 4 .>=
 
 -- | >>> renderExpression $ notNull true .< null_
 -- "(TRUE < NULL)"
 (.<)
-  :: Expression relations grouping params (nullity ty) -- ^ lhs
-  -> Expression relations grouping params (nullity ty) -- ^ rhs
-  -> Expression relations grouping params (nullity 'PGbool)
+  :: Expression schema relations grouping params (nullity ty) -- ^ lhs
+  -> Expression schema relations grouping params (nullity ty) -- ^ rhs
+  -> Expression schema relations grouping params (nullity 'PGbool)
 (.<) = unsafeBinaryOp "<"
 infix 4 .<
 
 -- | >>> renderExpression $ notNull true .<= null_
 -- "(TRUE <= NULL)"
 (.<=)
-  :: Expression relations grouping params (nullity ty) -- ^ lhs
-  -> Expression relations grouping params (nullity ty) -- ^ rhs
-  -> Expression relations grouping params (nullity 'PGbool)
+  :: Expression schema relations grouping params (nullity ty) -- ^ lhs
+  -> Expression schema relations grouping params (nullity ty) -- ^ rhs
+  -> Expression schema relations grouping params (nullity 'PGbool)
 (.<=) = unsafeBinaryOp "<="
 infix 4 .<=
 
 -- | >>> renderExpression $ notNull true .> null_
 -- "(TRUE > NULL)"
 (.>)
-  :: Expression relations grouping params (nullity ty) -- ^ lhs
-  -> Expression relations grouping params (nullity ty) -- ^ rhs
-  -> Expression relations grouping params (nullity 'PGbool)
+  :: Expression schema relations grouping params (nullity ty) -- ^ lhs
+  -> Expression schema relations grouping params (nullity ty) -- ^ rhs
+  -> Expression schema relations grouping params (nullity 'PGbool)
 (.>) = unsafeBinaryOp ">"
 infix 4 .>
 
 -- | >>> renderExpression currentDate
 -- "CURRENT_DATE"
 currentDate
-  :: Expression relations grouping params (nullity 'PGdate)
+  :: Expression schema relations grouping params (nullity 'PGdate)
 currentDate = UnsafeExpression "CURRENT_DATE"
 
 -- | >>> renderExpression currentTime
 -- "CURRENT_TIME"
 currentTime
-  :: Expression relations grouping params (nullity 'PGtimetz)
+  :: Expression schema relations grouping params (nullity 'PGtimetz)
 currentTime = UnsafeExpression "CURRENT_TIME"
 
 -- | >>> renderExpression currentTimestamp
 -- "CURRENT_TIMESTAMP"
 currentTimestamp
-  :: Expression relations grouping params (nullity 'PGtimestamptz)
+  :: Expression schema relations grouping params (nullity 'PGtimestamptz)
 currentTimestamp = UnsafeExpression "CURRENT_TIMESTAMP"
 
 -- | >>> renderExpression localTime
 -- "LOCALTIME"
 localTime
-  :: Expression relations grouping params (nullity 'PGtime)
+  :: Expression schema relations grouping params (nullity 'PGtime)
 localTime = UnsafeExpression "LOCALTIME"
 
 -- | >>> renderExpression localTimestamp
 -- "LOCALTIMESTAMP"
 localTimestamp
-  :: Expression relations grouping params (nullity 'PGtimestamp)
+  :: Expression schema relations grouping params (nullity 'PGtimestamp)
 localTimestamp = UnsafeExpression "LOCALTIMESTAMP"
 
 {-----------------------------------------
@@ -773,7 +783,7 @@ text
 -----------------------------------------}
 
 instance IsString
-  (Expression relations grouping params (nullity 'PGtext)) where
+  (Expression schema relations grouping params (nullity 'PGtext)) where
     fromString str = UnsafeExpression $
       "E\'" <> fromString (escape =<< str) <> "\'"
       where
@@ -789,36 +799,36 @@ instance IsString
           c -> [c]
 
 instance Semigroup
-  (Expression relations grouping params (nullity 'PGtext)) where
+  (Expression schema relations grouping params (nullity 'PGtext)) where
     (<>) = unsafeBinaryOp "||"
 
 instance Monoid
-  (Expression relations grouping params (nullity 'PGtext)) where
+  (Expression schema relations grouping params (nullity 'PGtext)) where
     mempty = fromString ""
     mappend = (<>)
 
 -- | >>> renderExpression $ lower "ARRRGGG"
 -- "lower(E'ARRRGGG')"
 lower
-  :: Expression relations grouping params (nullity 'PGtext)
+  :: Expression schema relations grouping params (nullity 'PGtext)
   -- ^ string to lower case
-  -> Expression relations grouping params (nullity 'PGtext)
+  -> Expression schema relations grouping params (nullity 'PGtext)
 lower = unsafeFunction "lower"
 
 -- | >>> renderExpression $ upper "eeee"
 -- "upper(E'eeee')"
 upper
-  :: Expression relations grouping params (nullity 'PGtext)
+  :: Expression schema relations grouping params (nullity 'PGtext)
   -- ^ string to upper case
-  -> Expression relations grouping params (nullity 'PGtext)
+  -> Expression schema relations grouping params (nullity 'PGtext)
 upper = unsafeFunction "upper"
 
 -- | >>> renderExpression $ charLength "four"
 -- "char_length(E'four')"
 charLength
-  :: Expression relations grouping params (nullity 'PGtext)
+  :: Expression schema relations grouping params (nullity 'PGtext)
   -- ^ string to measure
-  -> Expression relations grouping params (nullity 'PGint4)
+  -> Expression schema relations grouping params (nullity 'PGint4)
 charLength = unsafeFunction "char_length"
 
 -- | The `like` expression returns true if the @string@ matches
@@ -831,11 +841,11 @@ charLength = unsafeFunction "char_length"
 -- >>> renderExpression $ "abc" `like` "a%"
 -- "(E'abc' LIKE E'a%')"
 like
-  :: Expression relations grouping params (nullity 'PGtext)
+  :: Expression schema relations grouping params (nullity 'PGtext)
   -- ^ string
-  -> Expression relations grouping params (nullity 'PGtext)
+  -> Expression schema relations grouping params (nullity 'PGtext)
   -- ^ pattern
-  -> Expression relations grouping params (nullity 'PGbool)
+  -> Expression schema relations grouping params (nullity 'PGbool)
 like = unsafeBinaryOp "LIKE"
 
 {-----------------------------------------
@@ -845,16 +855,16 @@ aggregation
 -- | escape hatch to define aggregate functions
 unsafeAggregate
   :: ByteString -- ^ aggregate function
-  -> Expression relations 'Ungrouped params (xty)
-  -> Expression relations ('Grouped bys) params (yty)
+  -> Expression schema relations 'Ungrouped params (xty)
+  -> Expression schema relations ('Grouped bys) params (yty)
 unsafeAggregate fun x = UnsafeExpression $ mconcat
   [fun, "(", renderExpression x, ")"]
 
 -- | escape hatch to define aggregate functions over distinct values
 unsafeAggregateDistinct
   :: ByteString -- ^ aggregate function
-  -> Expression relations 'Ungrouped params (xty)
-  -> Expression relations ('Grouped bys) params (yty)
+  -> Expression schema relations 'Ungrouped params (xty)
+  -> Expression schema relations ('Grouped bys) params (yty)
 unsafeAggregateDistinct fun x = UnsafeExpression $ mconcat
   [fun, "(DISTINCT ", renderExpression x, ")"]
 
@@ -867,9 +877,9 @@ unsafeAggregateDistinct fun x = UnsafeExpression $ mconcat
 -- "sum(\"col\")"
 sum_
   :: PGNum ty
-  => Expression relations 'Ungrouped params (nullity ty)
+  => Expression schema relations 'Ungrouped params (nullity ty)
   -- ^ what to sum
-  -> Expression relations ('Grouped bys) params (nullity ty)
+  -> Expression schema relations ('Grouped bys) params (nullity ty)
 sum_ = unsafeAggregate "sum"
 
 -- | >>> :{
@@ -881,18 +891,18 @@ sum_ = unsafeAggregate "sum"
 -- "sum(DISTINCT \"col\")"
 sumDistinct
   :: PGNum ty
-  => Expression relations 'Ungrouped params (nullity ty)
+  => Expression schema relations 'Ungrouped params (nullity ty)
   -- ^ what to sum
-  -> Expression relations ('Grouped bys) params (nullity ty)
+  -> Expression schema relations ('Grouped bys) params (nullity ty)
 sumDistinct = unsafeAggregateDistinct "sum"
 
 -- | A constraint for `PGType`s that you can take averages of and the resulting
 -- `PGType`.
 class PGAvg ty avg | ty -> avg where
   avg, avgDistinct
-    :: Expression relations 'Ungrouped params (nullity ty)
+    :: Expression schema relations 'Ungrouped params (nullity ty)
     -- ^ what to average
-    -> Expression relations ('Grouped bys) params (nullity avg)
+    -> Expression schema relations ('Grouped bys) params (nullity avg)
   avg = unsafeAggregate "avg"
   avgDistinct = unsafeAggregateDistinct "avg"
 instance PGAvg 'PGint2 'PGnumeric
@@ -912,9 +922,9 @@ instance PGAvg 'PGinterval 'PGinterval
 -- "bit_and(\"col\")"
 bitAnd
   :: PGIntegral int
-  => Expression relations 'Ungrouped params (nullity int)
+  => Expression schema relations 'Ungrouped params (nullity int)
   -- ^ what to aggregate
-  -> Expression relations ('Grouped bys) params (nullity int)
+  -> Expression schema relations ('Grouped bys) params (nullity int)
 bitAnd = unsafeAggregate "bit_and"
 
 -- | >>> :{
@@ -926,9 +936,9 @@ bitAnd = unsafeAggregate "bit_and"
 -- "bit_or(\"col\")"
 bitOr
   :: PGIntegral int
-  => Expression relations 'Ungrouped params (nullity int)
+  => Expression schema relations 'Ungrouped params (nullity int)
   -- ^ what to aggregate
-  -> Expression relations ('Grouped bys) params (nullity int)
+  -> Expression schema relations ('Grouped bys) params (nullity int)
 bitOr = unsafeAggregate "bit_or"
 
 -- | >>> :{
@@ -940,9 +950,9 @@ bitOr = unsafeAggregate "bit_or"
 -- "bit_and(DISTINCT \"col\")"
 bitAndDistinct
   :: PGIntegral int
-  => Expression relations 'Ungrouped params (nullity int)
+  => Expression schema relations 'Ungrouped params (nullity int)
   -- ^ what to aggregate
-  -> Expression relations ('Grouped bys) params (nullity int)
+  -> Expression schema relations ('Grouped bys) params (nullity int)
 bitAndDistinct = unsafeAggregateDistinct "bit_and"
 
 -- | >>> :{
@@ -954,9 +964,9 @@ bitAndDistinct = unsafeAggregateDistinct "bit_and"
 -- "bit_or(DISTINCT \"col\")"
 bitOrDistinct
   :: PGIntegral int
-  => Expression relations 'Ungrouped params (nullity int)
+  => Expression schema relations 'Ungrouped params (nullity int)
   -- ^ what to aggregate
-  -> Expression relations ('Grouped bys) params (nullity int)
+  -> Expression schema relations ('Grouped bys) params (nullity int)
 bitOrDistinct = unsafeAggregateDistinct "bit_or"
 
 -- | >>> :{
@@ -967,9 +977,9 @@ bitOrDistinct = unsafeAggregateDistinct "bit_or"
 -- :}
 -- "bool_and(\"col\")"
 boolAnd
-  :: Expression relations 'Ungrouped params (nullity 'PGbool)
+  :: Expression schema relations 'Ungrouped params (nullity 'PGbool)
   -- ^ what to aggregate
-  -> Expression relations ('Grouped bys) params (nullity 'PGbool)
+  -> Expression schema relations ('Grouped bys) params (nullity 'PGbool)
 boolAnd = unsafeAggregate "bool_and"
 
 -- | >>> :{
@@ -980,9 +990,9 @@ boolAnd = unsafeAggregate "bool_and"
 -- :}
 -- "bool_or(\"col\")"
 boolOr
-  :: Expression relations 'Ungrouped params (nullity 'PGbool)
+  :: Expression schema relations 'Ungrouped params (nullity 'PGbool)
   -- ^ what to aggregate
-  -> Expression relations ('Grouped bys) params (nullity 'PGbool)
+  -> Expression schema relations ('Grouped bys) params (nullity 'PGbool)
 boolOr = unsafeAggregate "bool_or"
 
 -- | >>> :{
@@ -993,9 +1003,9 @@ boolOr = unsafeAggregate "bool_or"
 -- :}
 -- "bool_and(DISTINCT \"col\")"
 boolAndDistinct
-  :: Expression relations 'Ungrouped params (nullity 'PGbool)
+  :: Expression schema relations 'Ungrouped params (nullity 'PGbool)
   -- ^ what to aggregate
-  -> Expression relations ('Grouped bys) params (nullity 'PGbool)
+  -> Expression schema relations ('Grouped bys) params (nullity 'PGbool)
 boolAndDistinct = unsafeAggregateDistinct "bool_and"
 
 -- | >>> :{
@@ -1006,9 +1016,9 @@ boolAndDistinct = unsafeAggregateDistinct "bool_and"
 -- :}
 -- "bool_or(DISTINCT \"col\")"
 boolOrDistinct
-  :: Expression relations 'Ungrouped params (nullity 'PGbool)
+  :: Expression schema relations 'Ungrouped params (nullity 'PGbool)
   -- ^ what to aggregate
-  -> Expression relations ('Grouped bys) params (nullity 'PGbool)
+  -> Expression schema relations ('Grouped bys) params (nullity 'PGbool)
 boolOrDistinct = unsafeAggregateDistinct "bool_or"
 
 -- | A special aggregation that does not require an input
@@ -1016,7 +1026,7 @@ boolOrDistinct = unsafeAggregateDistinct "bool_or"
 -- >>> renderExpression countStar
 -- "count(*)"
 countStar
-  :: Expression relations ('Grouped bys) params ('NotNull 'PGint8)
+  :: Expression schema relations ('Grouped bys) params ('NotNull 'PGint8)
 countStar = UnsafeExpression $ "count(*)"
 
 -- | >>> :{
@@ -1027,9 +1037,9 @@ countStar = UnsafeExpression $ "count(*)"
 -- :}
 -- "count(\"col\")"
 count
-  :: Expression relations 'Ungrouped params ty
+  :: Expression schema relations 'Ungrouped params ty
   -- ^ what to count
-  -> Expression relations ('Grouped bys) params ('NotNull 'PGint8)
+  -> Expression schema relations ('Grouped bys) params ('NotNull 'PGint8)
 count = unsafeAggregate "count"
 
 -- | >>> :{
@@ -1040,9 +1050,9 @@ count = unsafeAggregate "count"
 -- :}
 -- "count(DISTINCT \"col\")"
 countDistinct
-  :: Expression relations 'Ungrouped params ty
+  :: Expression schema relations 'Ungrouped params ty
   -- ^ what to count
-  -> Expression relations ('Grouped bys) params ('NotNull 'PGint8)
+  -> Expression schema relations ('Grouped bys) params ('NotNull 'PGint8)
 countDistinct = unsafeAggregateDistinct "count"
 
 -- | synonym for `boolAnd`
@@ -1055,9 +1065,9 @@ countDistinct = unsafeAggregateDistinct "count"
 -- :}
 -- "every(\"col\")"
 every
-  :: Expression relations 'Ungrouped params (nullity 'PGbool)
+  :: Expression schema relations 'Ungrouped params (nullity 'PGbool)
   -- ^ what to aggregate
-  -> Expression relations ('Grouped bys) params (nullity 'PGbool)
+  -> Expression schema relations ('Grouped bys) params (nullity 'PGbool)
 every = unsafeAggregate "every"
 
 -- | synonym for `boolAndDistinct`
@@ -1070,16 +1080,16 @@ every = unsafeAggregate "every"
 -- :}
 -- "every(DISTINCT \"col\")"
 everyDistinct
-  :: Expression relations 'Ungrouped params (nullity 'PGbool)
+  :: Expression schema relations 'Ungrouped params (nullity 'PGbool)
   -- ^ what to aggregate
-  -> Expression relations ('Grouped bys) params (nullity 'PGbool)
+  -> Expression schema relations ('Grouped bys) params (nullity 'PGbool)
 everyDistinct = unsafeAggregateDistinct "every"
 
 -- | minimum and maximum aggregation
 max_, min_, maxDistinct, minDistinct
-  :: Expression relations 'Ungrouped params (nullity ty)
+  :: Expression schema relations 'Ungrouped params (nullity ty)
   -- ^ what to aggregate
-  -> Expression relations ('Grouped bys) params (nullity ty)
+  -> Expression schema relations ('Grouped bys) params (nullity ty)
 max_ = unsafeAggregate "max"
 min_ = unsafeAggregate "min"
 maxDistinct = unsafeAggregateDistinct "max"
@@ -1090,92 +1100,96 @@ type expressions
 -----------------------------------------}
 
 -- | `TypeExpression`s are used in `cast`s and `createTable` commands.
-newtype TypeExpression (ty :: PGType)
+newtype TypeExpression (schema :: SchemaType) (ty :: PGType)
   = UnsafeTypeExpression { renderTypeExpression :: ByteString }
   deriving (GHC.Generic,Show,Eq,Ord,NFData)
 
+instance (Has alias schema ('Typedef ty))
+  => IsLabel alias (TypeExpression schema ty) where
+    fromLabel = UnsafeTypeExpression (renderAlias (fromLabel @alias))
+
 -- | logical Boolean (true/false)
-bool :: TypeExpression 'PGbool
+bool :: TypeExpression schema 'PGbool
 bool = UnsafeTypeExpression "bool"
 -- | signed two-byte integer
-int2, smallint :: TypeExpression 'PGint2
+int2, smallint :: TypeExpression schema 'PGint2
 int2 = UnsafeTypeExpression "int2"
 smallint = UnsafeTypeExpression "smallint"
 -- | signed four-byte integer
-int4, int, integer :: TypeExpression 'PGint4
+int4, int, integer :: TypeExpression schema 'PGint4
 int4 = UnsafeTypeExpression "int4"
 int = UnsafeTypeExpression "int"
 integer = UnsafeTypeExpression "integer"
 -- | signed eight-byte integer
-int8, bigint :: TypeExpression 'PGint8
+int8, bigint :: TypeExpression schema 'PGint8
 int8 = UnsafeTypeExpression "int8"
 bigint = UnsafeTypeExpression "bigint"
 -- | arbitrary precision numeric type
-numeric :: TypeExpression 'PGnumeric
+numeric :: TypeExpression schema 'PGnumeric
 numeric = UnsafeTypeExpression "numeric"
 -- | single precision floating-point number (4 bytes)
-float4, real :: TypeExpression 'PGfloat4
+float4, real :: TypeExpression schema 'PGfloat4
 float4 = UnsafeTypeExpression "float4"
 real = UnsafeTypeExpression "real"
 -- | double precision floating-point number (8 bytes)
-float8, doublePrecision :: TypeExpression 'PGfloat8
+float8, doublePrecision :: TypeExpression schema 'PGfloat8
 float8 = UnsafeTypeExpression "float8"
 doublePrecision = UnsafeTypeExpression "double precision"
 -- | variable-length character string
-text :: TypeExpression 'PGtext
+text :: TypeExpression schema 'PGtext
 text = UnsafeTypeExpression "text"
 -- | fixed-length character string
 char, character
   :: (KnownNat n, 1 <= n)
   => proxy n
-  -> TypeExpression ('PGchar n)
+  -> TypeExpression schema ('PGchar n)
 char p = UnsafeTypeExpression $ "char(" <> renderNat p <> ")"
 character p = UnsafeTypeExpression $  "character(" <> renderNat p <> ")"
 -- | variable-length character string
 varchar, characterVarying
   :: (KnownNat n, 1 <= n)
   => proxy n
-  -> TypeExpression ('PGvarchar n)
+  -> TypeExpression schema ('PGvarchar n)
 varchar p = UnsafeTypeExpression $ "varchar(" <> renderNat p <> ")"
 characterVarying p = UnsafeTypeExpression $
   "character varying(" <> renderNat p <> ")"
 -- | binary data ("byte array")
-bytea :: TypeExpression 'PGbytea
+bytea :: TypeExpression schema 'PGbytea
 bytea = UnsafeTypeExpression "bytea"
 -- | date and time (no time zone)
-timestamp :: TypeExpression 'PGtimestamp
+timestamp :: TypeExpression schema 'PGtimestamp
 timestamp = UnsafeTypeExpression "timestamp"
 -- | date and time, including time zone
-timestampWithTimeZone :: TypeExpression 'PGtimestamptz
+timestampWithTimeZone :: TypeExpression schema 'PGtimestamptz
 timestampWithTimeZone = UnsafeTypeExpression "timestamp with time zone"
 -- | calendar date (year, month, day)
-date :: TypeExpression 'PGdate
+date :: TypeExpression schema 'PGdate
 date = UnsafeTypeExpression "date"
 -- | time of day (no time zone)
-time :: TypeExpression 'PGtime
+time :: TypeExpression schema 'PGtime
 time = UnsafeTypeExpression "time"
 -- | time of day, including time zone
-timeWithTimeZone :: TypeExpression 'PGtimetz
+timeWithTimeZone :: TypeExpression schema 'PGtimetz
 timeWithTimeZone = UnsafeTypeExpression "time with time zone"
 -- | time span
-interval :: TypeExpression 'PGinterval
+interval :: TypeExpression schema 'PGinterval
 interval = UnsafeTypeExpression "interval"
 -- | universally unique identifier
-uuid :: TypeExpression 'PGuuid
+uuid :: TypeExpression schema 'PGuuid
 uuid = UnsafeTypeExpression "uuid"
 -- | IPv4 or IPv6 host address
-inet :: TypeExpression 'PGinet
+inet :: TypeExpression schema 'PGinet
 inet = UnsafeTypeExpression "inet"
 -- | textual JSON data
-json :: TypeExpression 'PGjson
+json :: TypeExpression schema 'PGjson
 json = UnsafeTypeExpression "json"
 -- | binary JSON data, decomposed
-jsonb :: TypeExpression 'PGjsonb
+jsonb :: TypeExpression schema 'PGjsonb
 jsonb = UnsafeTypeExpression "jsonb"
 -- | variable length array
 vararray
-  :: TypeExpression pg
-  -> TypeExpression ('PGvararray pg)
+  :: TypeExpression schema pg
+  -> TypeExpression schema ('PGvararray pg)
 vararray ty = UnsafeTypeExpression $ renderTypeExpression ty <> "[]"
 -- | fixed length array
 --
@@ -1184,36 +1198,36 @@ vararray ty = UnsafeTypeExpression $ renderTypeExpression ty <> "[]"
 fixarray
   :: KnownNat n
   => proxy n
-  -> TypeExpression pg
-  -> TypeExpression ('PGfixarray n pg)
+  -> TypeExpression schema pg
+  -> TypeExpression schema ('PGfixarray n pg)
 fixarray p ty = UnsafeTypeExpression $
   renderTypeExpression ty <> "[" <> renderNat p <> "]"
 
 -- | `pgtype` is a demoted version of a `PGType`
-class PGTyped (ty :: PGType) where pgtype :: TypeExpression ty
-instance PGTyped 'PGbool where pgtype = bool
-instance PGTyped 'PGint2 where pgtype = int2
-instance PGTyped 'PGint4 where pgtype = int4
-instance PGTyped 'PGint8 where pgtype = int8
-instance PGTyped 'PGnumeric where pgtype = numeric
-instance PGTyped 'PGfloat4 where pgtype = float4
-instance PGTyped 'PGfloat8 where pgtype = float8
-instance PGTyped 'PGtext where pgtype = text
+class PGTyped schema (ty :: PGType) where pgtype :: TypeExpression schema ty 
+instance PGTyped schema 'PGbool where pgtype = bool
+instance PGTyped schema 'PGint2 where pgtype = int2
+instance PGTyped schema 'PGint4 where pgtype = int4
+instance PGTyped schema 'PGint8 where pgtype = int8
+instance PGTyped schema 'PGnumeric where pgtype = numeric
+instance PGTyped schema 'PGfloat4 where pgtype = float4
+instance PGTyped schema 'PGfloat8 where pgtype = float8
+instance PGTyped schema 'PGtext where pgtype = text
 instance (KnownNat n, 1 <= n)
-  => PGTyped ('PGchar n) where pgtype = char (Proxy @n)
+  => PGTyped schema ('PGchar n) where pgtype = char (Proxy @n)
 instance (KnownNat n, 1 <= n)
-  => PGTyped ('PGvarchar n) where pgtype = varchar (Proxy @n)
-instance PGTyped 'PGbytea where pgtype = bytea
-instance PGTyped 'PGtimestamp where pgtype = timestamp
-instance PGTyped 'PGtimestamptz where pgtype = timestampWithTimeZone
-instance PGTyped 'PGdate where pgtype = date
-instance PGTyped 'PGtime where pgtype = time
-instance PGTyped 'PGtimetz where pgtype = timeWithTimeZone
-instance PGTyped 'PGinterval where pgtype = interval
-instance PGTyped 'PGuuid where pgtype = uuid
-instance PGTyped 'PGjson where pgtype = json
-instance PGTyped 'PGjsonb where pgtype = jsonb
-instance PGTyped ty => PGTyped ('PGvararray ty) where
-  pgtype = vararray (pgtype @ty)
-instance (KnownNat n, PGTyped ty) => PGTyped ('PGfixarray n ty) where
-  pgtype = fixarray (Proxy @n) (pgtype @ty)
+  => PGTyped schema ('PGvarchar n) where pgtype = varchar (Proxy @n)
+instance PGTyped schema 'PGbytea where pgtype = bytea
+instance PGTyped schema 'PGtimestamp where pgtype = timestamp
+instance PGTyped schema 'PGtimestamptz where pgtype = timestampWithTimeZone
+instance PGTyped schema 'PGdate where pgtype = date
+instance PGTyped schema 'PGtime where pgtype = time
+instance PGTyped schema 'PGtimetz where pgtype = timeWithTimeZone
+instance PGTyped schema 'PGinterval where pgtype = interval
+instance PGTyped schema 'PGuuid where pgtype = uuid
+instance PGTyped schema 'PGjson where pgtype = json
+instance PGTyped schema 'PGjsonb where pgtype = jsonb
+instance PGTyped schema ty => PGTyped schema ('PGvararray ty) where
+  pgtype = vararray (pgtype @schema @ty)
+instance (KnownNat n, PGTyped schema ty) => PGTyped schema ('PGfixarray n ty) where
+  pgtype = fixarray (Proxy @n) (pgtype @schema @ty)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -199,10 +199,30 @@ instance (HasUnique relation relations columns, Has column columns ty)
   => IsLabel column (Expression relations 'Ungrouped params ty) where
     fromLabel = UnsafeExpression $ renderAlias (Alias @column)
 
+instance (HasUnique relation relations columns, Has column columns ty)
+  => IsLabel column
+    (Aliased (Expression relations 'Ungrouped params) (column ::: ty)) where
+    fromLabel = fromLabel @column `As` Alias @column
+
+instance (HasUnique relation relations columns, Has column columns ty)
+  => IsLabel column
+    (NP (Aliased (Expression relations 'Ungrouped params)) '[column ::: ty]) where
+    fromLabel = fromLabel @column :* Nil
+
 instance (Has relation relations columns, Has column columns ty)
   => IsQualified relation column (Expression relations 'Ungrouped params ty) where
     relation ! column = UnsafeExpression $
       renderAlias relation <> "." <> renderAlias column
+
+instance (Has relation relations columns, Has column columns ty)
+  => IsQualified relation column
+    (Aliased (Expression relations 'Ungrouped params) (column ::: ty)) where
+    relation ! column = relation ! column `As` column
+
+instance (Has relation relations columns, Has column columns ty)
+  => IsQualified relation column
+    (NP (Aliased (Expression relations 'Ungrouped params)) '[column ::: ty]) where
+    relation ! column = relation ! column :* Nil
   
 instance
   ( HasUnique relation relations columns
@@ -211,7 +231,7 @@ instance
   ) => IsLabel column
     (Expression relations ('Grouped bys) params ty) where
       fromLabel = UnsafeExpression $ renderAlias (Alias @column)
-  
+
 instance
   ( Has relation relations columns
   , Has column columns ty
@@ -220,6 +240,24 @@ instance
     (Expression relations ('Grouped bys) params ty) where
       relation ! column = UnsafeExpression $
         renderAlias relation <> "." <> renderAlias column
+
+instance
+  ( Has relation relations columns
+  , Has column columns ty
+  , GroupedBy relation column bys
+  ) => IsQualified relation column
+    (Aliased (Expression relations ('Grouped bys) params)
+      (column ::: ty)) where
+        relation ! column = relation ! column `As` column
+
+instance
+  ( Has relation relations columns
+  , Has column columns ty
+  , GroupedBy relation column bys
+  ) => IsQualified relation column
+    ( NP (Aliased (Expression relations ('Grouped bys) params))
+      '[column ::: ty]) where
+        relation ! column = relation ! column :* Nil
 
 -- | analagous to `Nothing`
 --

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -198,12 +198,10 @@ instance {-# OVERLAPPABLE #-} (KnownNat n, HasParameter (n-1) params ty)
 instance (HasUnique relation relations columns, Has column columns ty)
   => IsLabel column (Expression relations 'Ungrouped params ty) where
     fromLabel = UnsafeExpression $ renderAlias (Alias @column)
-
 instance (HasUnique relation relations columns, Has column columns ty)
   => IsLabel column
     (Aliased (Expression relations 'Ungrouped params) (column ::: ty)) where
     fromLabel = fromLabel @column `As` Alias @column
-
 instance (HasUnique relation relations columns, Has column columns ty)
   => IsLabel column
     (NP (Aliased (Expression relations 'Ungrouped params)) '[column ::: ty]) where
@@ -213,12 +211,10 @@ instance (Has relation relations columns, Has column columns ty)
   => IsQualified relation column (Expression relations 'Ungrouped params ty) where
     relation ! column = UnsafeExpression $
       renderAlias relation <> "." <> renderAlias column
-
 instance (Has relation relations columns, Has column columns ty)
   => IsQualified relation column
     (Aliased (Expression relations 'Ungrouped params) (column ::: ty)) where
     relation ! column = relation ! column `As` column
-
 instance (Has relation relations columns, Has column columns ty)
   => IsQualified relation column
     (NP (Aliased (Expression relations 'Ungrouped params)) '[column ::: ty]) where
@@ -231,6 +227,22 @@ instance
   ) => IsLabel column
     (Expression relations ('Grouped bys) params ty) where
       fromLabel = UnsafeExpression $ renderAlias (Alias @column)
+instance
+  ( HasUnique relation relations columns
+  , Has column columns ty
+  , GroupedBy relation column bys
+  ) => IsLabel column
+    ( Aliased (Expression relations ('Grouped bys) params)
+      (column ::: ty) ) where
+      fromLabel = fromLabel @column `As` Alias @column
+instance
+  ( HasUnique relation relations columns
+  , Has column columns ty
+  , GroupedBy relation column bys
+  ) => IsLabel column
+    ( NP (Aliased (Expression relations ('Grouped bys) params))
+      '[column ::: ty] ) where
+      fromLabel = fromLabel @column :* Nil
 
 instance
   ( Has relation relations columns
@@ -240,7 +252,6 @@ instance
     (Expression relations ('Grouped bys) params ty) where
       relation ! column = UnsafeExpression $
         renderAlias relation <> "." <> renderAlias column
-
 instance
   ( Has relation relations columns
   , Has column columns ty
@@ -249,7 +260,6 @@ instance
     (Aliased (Expression relations ('Grouped bys) params)
       (column ::: ty)) where
         relation ! column = relation ! column `As` column
-
 instance
   ( Has relation relations columns
   , Has column columns ty

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -352,7 +352,7 @@ matchNull y f x = ifThenElse (isNull x) y
 -- `nullIf` gives @NULL@.
 --
 -- >>> :set -XTypeApplications -XDataKinds
--- >>> renderExpression @_ @_ @'[_] $ fromNull false (nullIf false (param @1))
+-- >>> renderExpression @'[] @_ @_ @'[_] $ fromNull false (nullIf false (param @1))
 -- "COALESCE(NULL IF (FALSE, ($1 :: bool)), FALSE)"
 nullIf
   :: Expression schema relations grouping params ('NotNull ty)
@@ -380,7 +380,7 @@ instance (KnownSymbol label, label `In` labels) => IsPGlabel label
 -- (also called a composite value) using values for its member fields.
 --
 -- >>> type Complex = PGcomposite '["real" ::: 'PGfloat8, "imaginary" ::: 'PGfloat8]
--- >>> let i = row (0 `As` #real :* 1 `As` #imaginary :* Nil) :: Expression '[] 'Ungrouped '[] ('NotNull Complex)
+-- >>> let i = row (0 `As` #real :* 1 `As` #imaginary :* Nil) :: Expression '[] '[] 'Ungrouped '[] ('NotNull Complex)
 -- >>> renderExpression i
 -- "ROW(0, 1)"
 row
@@ -407,7 +407,7 @@ instance Monoid
     mempty = array []
     mappend = (<>)
 
--- | >>> renderExpression @_ @_ @'[_] $ greatest currentTimestamp [param @1]
+-- | >>> renderExpression @'[] @_ @_ @'[_] $ greatest currentTimestamp [param @1]
 -- "GREATEST(CURRENT_TIMESTAMP, ($1 :: timestamp with time zone))"
 greatest
   :: Expression schema relations grouping params (nullty)
@@ -870,7 +870,7 @@ unsafeAggregateDistinct fun x = UnsafeExpression $ mconcat
 
 -- | >>> :{
 -- let
---   expression :: Expression '[tab ::: '["col" ::: 'Null 'PGnumeric]] ('Grouped bys) params ('Null 'PGnumeric)
+--   expression :: Expression schema '[tab ::: '["col" ::: 'Null 'PGnumeric]] ('Grouped bys) params ('Null 'PGnumeric)
 --   expression = sum_ #col
 -- in renderExpression expression
 -- :}
@@ -884,7 +884,7 @@ sum_ = unsafeAggregate "sum"
 
 -- | >>> :{
 -- let
---   expression :: Expression '[tab ::: '["col" ::: nullity 'PGnumeric]] ('Grouped bys) params (nullity 'PGnumeric)
+--   expression :: Expression schema '[tab ::: '["col" ::: nullity 'PGnumeric]] ('Grouped bys) params (nullity 'PGnumeric)
 --   expression = sumDistinct #col
 -- in renderExpression expression
 -- :}
@@ -915,7 +915,7 @@ instance PGAvg 'PGinterval 'PGinterval
 
 -- | >>> :{
 -- let
---   expression :: Expression '[tab ::: '["col" ::: nullity 'PGint4]] (Grouped bys) params (nullity 'PGint4)
+--   expression :: Expression schema '[tab ::: '["col" ::: nullity 'PGint4]] (Grouped bys) params (nullity 'PGint4)
 --   expression = bitAnd #col
 -- in renderExpression expression
 -- :}
@@ -929,7 +929,7 @@ bitAnd = unsafeAggregate "bit_and"
 
 -- | >>> :{
 -- let
---   expression :: Expression '[tab ::: '["col" ::: nullity 'PGint4]] (Grouped bys) params (nullity 'PGint4)
+--   expression :: Expression schema '[tab ::: '["col" ::: nullity 'PGint4]] (Grouped bys) params (nullity 'PGint4)
 --   expression = bitOr #col
 -- in renderExpression expression
 -- :}
@@ -943,7 +943,7 @@ bitOr = unsafeAggregate "bit_or"
 
 -- | >>> :{
 -- let
---   expression :: Expression '[tab ::: '["col" ::: nullity 'PGint4]] (Grouped bys) params (nullity 'PGint4)
+--   expression :: Expression schema '[tab ::: '["col" ::: nullity 'PGint4]] (Grouped bys) params (nullity 'PGint4)
 --   expression = bitAndDistinct #col
 -- in renderExpression expression
 -- :}
@@ -957,7 +957,7 @@ bitAndDistinct = unsafeAggregateDistinct "bit_and"
 
 -- | >>> :{
 -- let
---   expression :: Expression '[tab ::: '["col" ::: nullity 'PGint4]] (Grouped bys) params (nullity 'PGint4)
+--   expression :: Expression schema '[tab ::: '["col" ::: nullity 'PGint4]] (Grouped bys) params (nullity 'PGint4)
 --   expression = bitOrDistinct #col
 -- in renderExpression expression
 -- :}
@@ -971,7 +971,7 @@ bitOrDistinct = unsafeAggregateDistinct "bit_or"
 
 -- | >>> :{
 -- let
---   expression :: Expression '[tab ::: '["col" ::: nullity 'PGbool]] (Grouped bys) params (nullity 'PGbool)
+--   expression :: Expression schema '[tab ::: '["col" ::: nullity 'PGbool]] (Grouped bys) params (nullity 'PGbool)
 --   expression = boolAnd #col
 -- in renderExpression expression
 -- :}
@@ -984,7 +984,7 @@ boolAnd = unsafeAggregate "bool_and"
 
 -- | >>> :{
 -- let
---   expression :: Expression '[tab ::: '["col" ::: nullity 'PGbool]] (Grouped bys) params (nullity 'PGbool)
+--   expression :: Expression schema '[tab ::: '["col" ::: nullity 'PGbool]] (Grouped bys) params (nullity 'PGbool)
 --   expression = boolOr #col
 -- in renderExpression expression
 -- :}
@@ -997,7 +997,7 @@ boolOr = unsafeAggregate "bool_or"
 
 -- | >>> :{
 -- let
---   expression :: Expression '[tab ::: '["col" ::: nullity 'PGbool]] (Grouped bys) params (nullity 'PGbool)
+--   expression :: Expression schema '[tab ::: '["col" ::: nullity 'PGbool]] (Grouped bys) params (nullity 'PGbool)
 --   expression = boolAndDistinct #col
 -- in renderExpression expression
 -- :}
@@ -1010,7 +1010,7 @@ boolAndDistinct = unsafeAggregateDistinct "bool_and"
 
 -- | >>> :{
 -- let
---   expression :: Expression '[tab ::: '["col" ::: nullity 'PGbool]] (Grouped bys) params (nullity 'PGbool)
+--   expression :: Expression schema '[tab ::: '["col" ::: nullity 'PGbool]] (Grouped bys) params (nullity 'PGbool)
 --   expression = boolOrDistinct #col
 -- in renderExpression expression
 -- :}
@@ -1031,7 +1031,7 @@ countStar = UnsafeExpression $ "count(*)"
 
 -- | >>> :{
 -- let
---   expression :: Expression '[tab ::: '["col" ::: nullity ty]] (Grouped bys) params ('NotNull 'PGint8)
+--   expression :: Expression schema '[tab ::: '["col" ::: nullity ty]] (Grouped bys) params ('NotNull 'PGint8)
 --   expression = count #col
 -- in renderExpression expression
 -- :}
@@ -1044,7 +1044,7 @@ count = unsafeAggregate "count"
 
 -- | >>> :{
 -- let
---   expression :: Expression '[tab ::: '["col" ::: nullity ty]] (Grouped bys) params ('NotNull 'PGint8)
+--   expression :: Expression schema '[tab ::: '["col" ::: nullity ty]] (Grouped bys) params ('NotNull 'PGint8)
 --   expression = countDistinct #col
 -- in renderExpression expression
 -- :}
@@ -1059,7 +1059,7 @@ countDistinct = unsafeAggregateDistinct "count"
 --
 -- >>> :{
 -- let
---   expression :: Expression '[tab ::: '["col" ::: nullity 'PGbool]] (Grouped bys) params (nullity 'PGbool)
+--   expression :: Expression schema '[tab ::: '["col" ::: nullity 'PGbool]] (Grouped bys) params (nullity 'PGbool)
 --   expression = every #col
 -- in renderExpression expression
 -- :}
@@ -1074,7 +1074,7 @@ every = unsafeAggregate "every"
 --
 -- >>> :{
 -- let
---   expression :: Expression '[tab ::: '["col" ::: nullity 'PGbool]] (Grouped bys) params (nullity 'PGbool)
+--   expression :: Expression schema '[tab ::: '["col" ::: nullity 'PGbool]] (Grouped bys) params (nullity 'PGbool)
 --   expression = everyDistinct #col
 -- in renderExpression expression
 -- :}
@@ -1204,7 +1204,7 @@ fixarray p ty = UnsafeTypeExpression $
   renderTypeExpression ty <> "[" <> renderNat p <> "]"
 
 -- | `pgtype` is a demoted version of a `PGType`
-class PGTyped schema (ty :: PGType) where pgtype :: TypeExpression schema ty 
+class PGTyped schema (ty :: PGType) where pgtype :: TypeExpression schema ty
 instance PGTyped schema 'PGbool where pgtype = bool
 instance PGTyped schema 'PGint2 where pgtype = int2
 instance PGTyped schema 'PGint4 where pgtype = int4

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -11,21 +11,15 @@ Squeal expressions are the atoms used to build statements.
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 {-# LANGUAGE
     AllowAmbiguousTypes
-  , DataKinds
   , DeriveGeneric
-  , DeriveDataTypeable
   , FlexibleContexts
   , FlexibleInstances
   , FunctionalDependencies
-  , GADTs
   , GeneralizedNewtypeDeriving
   , LambdaCase
   , MagicHash
   , OverloadedStrings
-  , PolyKinds
-  , RankNTypes
   , ScopedTypeVariables
-  , StandaloneDeriving
   , TypeApplications
   , TypeFamilies
   , TypeInType
@@ -46,8 +40,10 @@ module Squeal.PostgreSQL.Expression
   , isn'tNull
   , matchNull
   , nullIf
-    -- ** Arrays
+    -- ** Arrays, Enums, Composites
   , array
+  , label
+  , row
     -- ** Functions
   , unsafeBinaryOp
   , unsafeUnaryOp
@@ -329,10 +325,6 @@ label
   -> Expression relations grouping params (nullity ('PGenum labels))
 label (_ :: Alias label) = UnsafeExpression $
   fromString $ symbolVal (Proxy @label)
-
-type family Nulls tys where
-  Nulls '[] = '[]
-  Nulls (field ::: ty ': tys) = field ::: 'Null ty ': Nulls tys
 
 row
   :: (SListI (Nulls fields))

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
@@ -302,11 +302,11 @@ insertQuery_
 insertQuery_ tab query =
   insertQuery tab query OnConflictDoRaise (Returning Nil)
 
--- | `ColumnValue`s are values to insert or update in a row
+-- | `ColumnValue`s are values to insert or update in a row.
 -- `Same` updates with the same value.
--- `Default` inserts or updates with the @DEFAULT@ value
--- `Set` a value to be an `Expression`, relative to the given
--- row for an update, and closed for an insert.
+-- `Default` inserts or updates with the @DEFAULT@ value.
+-- `Set` sets a value to be an `Expression`, which can refer to
+-- existing value in the row for an update.
 data ColumnValue
   (schema :: SchemaType)
   (columns :: RelationType)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
@@ -144,7 +144,7 @@ let
        , "col2" ::: 'NoDef :=> 'NotNull 'PGint4
        ])
      ] '[] '[]
-  manipulation = 
+  manipulation =
     insertQuery_ #tab
       (selectStar (from (table (#other_tab `As` #t))))
 in renderManipulation manipulation

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
@@ -485,7 +485,7 @@ WITH statements
 --   manipulation :: Manipulation '["products" ::: 'Table ProductsTable, "products_deleted" ::: 'Table ProductsTable] '[ 'NotNull 'PGdate] '[]
 --   manipulation = with
 --     (deleteFrom #products (#date .< param @1) ReturningStar `As` #deleted_rows :* Nil)
---     (insertQuery_ #products_deleted (selectStar (from (table (#deleted_rows `As` #t)))))
+--     (insertQuery_ #products_deleted (selectStar (from (view (#deleted_rows `As` #t)))))
 -- in renderManipulation manipulation
 -- :}
 -- "WITH \"deleted_rows\" AS (DELETE FROM \"products\" WHERE (\"date\" < ($1 :: date)) RETURNING *) INSERT INTO \"products_deleted\" SELECT * FROM \"deleted_rows\" AS \"t\";"

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -37,7 +37,7 @@ let
     , up = void . define $
         createTable #users
         ( serial `As` #id :*
-          (text & notNull) `As` #name :* Nil )
+          (text & hasNotNull) `As` #name :* Nil )
         ( primaryKey #id `As` #pk_users :* Nil )
     , down = void . define $ dropTable #users
     }
@@ -52,8 +52,8 @@ let
     , up = void . define $
         createTable #emails
           ( serial `As` #id :*
-            (int & notNull) `As` #user_id :*
-            (text & null_) `As` #email :* Nil )
+            (int & hasNotNull) `As` #user_id :*
+            (text & hasNull) `As` #email :* Nil )
           ( primaryKey #id `As` #pk_emails :*
             foreignKey #user_id #users #id
               OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )
@@ -285,8 +285,8 @@ createMigrations
   => Definition schema schema
 createMigrations =
   createTableIfNotExists #schema_migrations
-    ( (text & notNull) `As` #name :*
-      (timestampWithTimeZone & notNull & default_ currentTimestamp)
+    ( (text & hasNotNull) `As` #name :*
+      (timestampWithTimeZone & hasNotNull & default_ currentTimestamp)
         `As` #executed_at :* Nil )
     ( unique (#name :* Nil) `As` #migrations_unique_name :* Nil )
 

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -37,7 +37,7 @@ let
     , up = void . define $
         createTable #users
         ( serial `As` #id :*
-          (text & hasNotNull) `As` #name :* Nil )
+          (text & notNullable) `As` #name :* Nil )
         ( primaryKey #id `As` #pk_users :* Nil )
     , down = void . define $ dropTable #users
     }
@@ -52,8 +52,8 @@ let
     , up = void . define $
         createTable #emails
           ( serial `As` #id :*
-            (int & hasNotNull) `As` #user_id :*
-            (text & hasNull) `As` #email :* Nil )
+            (int & notNullable) `As` #user_id :*
+            (text & nullable) `As` #email :* Nil )
           ( primaryKey #id `As` #pk_emails :*
             foreignKey #user_id #users #id
               OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )
@@ -285,8 +285,8 @@ createMigrations
   => Definition schema schema
 createMigrations =
   createTableIfNotExists #schema_migrations
-    ( (text & hasNotNull) `As` #name :*
-      (timestampWithTimeZone & hasNotNull & default_ currentTimestamp)
+    ( (text & notNullable) `As` #name :*
+      (timestampWithTimeZone & notNullable & default_ currentTimestamp)
         `As` #executed_at :* Nil )
     ( unique (#name :* Nil) `As` #migrations_unique_name :* Nil )
 

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -53,7 +53,7 @@ let
         createTable #emails
           ( serial `As` #id :*
             (int & notNull) `As` #user_id :*
-            (text & null') `As` #email :* Nil )
+            (text & null_) `As` #email :* Nil )
           ( primaryKey #id `As` #pk_emails :*
             foreignKey #user_id #users #id
               OnDeleteCascade OnUpdateCascade `As` #fk_user_id :* Nil )

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -90,9 +90,7 @@ Row 0
 -}
 
 {-# LANGUAGE
-    ScopedTypeVariables
-  , OverloadedStrings
-  , DataKinds
+    DataKinds
   , GADTs
   , LambdaCase
   , PolyKinds

--- a/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
@@ -395,7 +395,8 @@ instance (MonadBase IO io, schema0 ~ schema, schema1 ~ schema)
         let
           toParam' bytes = (LibPQ.invalidOid,bytes,LibPQ.Binary)
           params' = fmap (fmap toParam') (hcollapse (toParams @x @ps params))
-        resultMaybe <- liftBase $ LibPQ.execParams conn q params' LibPQ.Binary
+          q' = q <> ";"
+        resultMaybe <- liftBase $ LibPQ.execParams conn q' params' LibPQ.Binary
         case resultMaybe of
           Nothing -> error
             "manipulateParams: LibPQ.execParams returned no results"

--- a/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
@@ -20,15 +20,10 @@ of executing Squeal commands.
 
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 {-# LANGUAGE
-    DataKinds
-  , DefaultSignatures
+    DefaultSignatures
   , FunctionalDependencies
-  , PolyKinds
-  , DeriveFunctor
   , FlexibleContexts
   , FlexibleInstances
-  , MagicHash
-  , MultiParamTypeClasses
   , OverloadedStrings
   , RankNTypes
   , ScopedTypeVariables

--- a/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
@@ -166,7 +166,7 @@ instance Monad m => Functor (PQ schema0 schema1 m) where
     K x <- pq conn
     return $ K (f x)
 
--- | Run a `PQ` and keep the result and the `Connection`. 
+-- | Run a `PQ` and keep the result and the `Connection`.
 runPQ
   :: Functor m
   => PQ schema0 schema1 m x
@@ -176,7 +176,7 @@ runPQ (PQ pq) conn = (\ x -> (unK x, K (unK conn))) <$> pq conn
   -- K x <- pq conn
   -- return (x, K (unK conn))
 
--- | Execute a `PQ` and discard the result but keep the `Connection`. 
+-- | Execute a `PQ` and discard the result but keep the `Connection`.
 execPQ
   :: Functor m
   => PQ schema0 schema1 m x

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Pool.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Pool.hs
@@ -9,8 +9,7 @@ A `MonadPQ` for pooled connections.
 -}
 
 {-# LANGUAGE
-    DataKinds
-  , DeriveFunctor
+    DeriveFunctor
   , FlexibleContexts
   , FlexibleInstances
   , MultiParamTypeClasses

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Pool.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Pool.hs
@@ -109,7 +109,7 @@ instance MonadBaseControl IO io => MonadPQ schema (PoolPQ schema io) where
       (_ :: K () schema) <- flip unPQ conn $
         traversePrepared_ manipulation params
       return ()
-  liftPQ m = PoolPQ $ \ pool -> 
+  liftPQ m = PoolPQ $ \ pool ->
     withResource pool $ \ conn -> do
       (K result :: K result schema) <- flip unPQ conn $
         liftPQ m

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -112,7 +112,7 @@ let
     '[]
     '[ "sum" ::: 'NotNull 'PGint4
      , "col1" ::: 'NotNull 'PGint4 ]
-  query = 
+  query =
     select
       ((#col1 + #col2) `As` #sum :* #col1 :* Nil)
       ( from (table (#tab `As` #t))
@@ -179,7 +179,7 @@ let
   query =
     select (sum_ #col2 `As` #sum :* #col1 `As` #col1 :* Nil)
     ( from (table (#tab `As` #table1))
-      & group (By #col1 :* Nil) 
+      & group (By #col1 :* Nil)
       & having (#col1 + sum_ #col2 .> 1) )
 in renderQuery query
 :}
@@ -281,7 +281,7 @@ newtype Query
     deriving (GHC.Generic,Show,Eq,Ord,NFData)
 
 -- | The results of two queries can be combined using the set operation
--- `union`. Duplicate rows are eliminated. 
+-- `union`. Duplicate rows are eliminated.
 union
   :: Query schema params columns
   -> Query schema params columns
@@ -412,7 +412,7 @@ selectDotStar
 selectDotStar rel relations = UnsafeQuery $
   "SELECT" <+> renderAlias rel <> ".*" <+> renderTableExpression relations
 
--- | A `selectDistinctDotStar` asks for all the columns of a particular table, 
+-- | A `selectDistinctDotStar` asks for all the columns of a particular table,
 -- and eliminates duplicate rows.
 selectDistinctDotStar
   :: Has relation relations columns
@@ -555,7 +555,7 @@ where_ wh rels = rels {whereClause = wh : whereClause rels}
 group
   :: SListI bys
   => NP (By relations) bys -- ^ grouped columns
-  -> TableExpression schema params relations 'Ungrouped 
+  -> TableExpression schema params relations 'Ungrouped
   -> TableExpression schema params relations ('Grouped bys)
 group bys rels = TableExpression
   { fromClause = fromClause rels

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -9,23 +9,14 @@ Squeal queries.
 -}
 
 {-# LANGUAGE
-    DataKinds
-  , DeriveDataTypeable
-  , DeriveGeneric
-  , FlexibleContexts
-  , FlexibleInstances
+    DeriveGeneric
   , GADTs
   , GeneralizedNewtypeDeriving
-  , KindSignatures
   , LambdaCase
-  , MultiParamTypeClasses
   , OverloadedStrings
-  , ScopedTypeVariables
   , StandaloneDeriving
-  , TypeApplications
   , TypeInType
   , TypeOperators
-  , UndecidableInstances
 #-}
 
 module Squeal.PostgreSQL.Query

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -37,6 +37,7 @@ module Squeal.PostgreSQL.Query
   , selectDotStar
   , selectDistinctDotStar
   , values
+  , values_
     -- * Table Expressions
   , TableExpression (..)
   , renderTableExpression
@@ -440,6 +441,7 @@ values
   => NP (Aliased (Expression '[] 'Ungrouped params)) cols
   -> [NP (Aliased (Expression '[] 'Ungrouped params)) cols]
   -- ^ When more than one row is specified, all the rows must
+  -- must have the same number of elements
   -> Query schema params cols
 values rw rws = UnsafeQuery $ "SELECT * FROM"
   <+> parenthesized (
@@ -454,6 +456,15 @@ values rw rws = UnsafeQuery $ "SELECT * FROM"
       :: Aliased (Expression '[] 'Ungrouped params) ty -> ByteString
     renderAliasPart (_ `As` name) = renderAlias name
     renderValuePart (value `As` _) = renderExpression value
+
+-- | `values_` computes a row value or set of row values
+-- specified by value expressions.
+values_
+  :: SListI cols
+  => NP (Aliased (Expression '[] 'Ungrouped params)) cols
+  -- ^ one row of values
+  -> Query schema params cols
+values_ rw = values rw []
 
 {-----------------------------------------
 Table Expressions

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -426,10 +426,20 @@ selectDistinctDotStar rel relations = UnsafeQuery $
   "SELECT DISTINCT" <+> renderAlias rel <> ".*"
   <+> renderTableExpression relations
 
+-- | `values` computes a row value or set of row values
+-- specified by value expressions. It is most commonly used
+-- to generate a “constant table” within a larger command,
+-- but it can be used on its own.
+--
+-- >>> type Row = '["a" ::: 'NotNull 'PGint4, "b" ::: 'NotNull 'PGtext]
+-- >>> let query = values (1 `As` #a :* "one" `As` #b :* Nil) [] :: Query '[] '[] Row
+-- >>> renderQuery query
+-- "SELECT * FROM (VALUES (1, E'one')) AS t (\"a\", \"b\")"
 values
   :: SListI cols
   => NP (Aliased (Expression '[] 'Ungrouped params)) cols
   -> [NP (Aliased (Expression '[] 'Ungrouped params)) cols]
+  -- ^ When more than one row is specified, all the rows must
   -> Query schema params cols
 values rw rws = UnsafeQuery $ "SELECT * FROM"
   <+> parenthesized (

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -114,7 +114,7 @@ let
      , "col1" ::: 'NotNull 'PGint4 ]
   query = 
     select
-      ((#col1 + #col2) `As` #sum :* #col1 `As` #col1 :* Nil)
+      ((#col1 + #col2) `As` #sum :* #col1 :* Nil)
       ( from (table (#tab `As` #t))
         & where_ (#col1 .> #col2)
         & where_ (#col2 .> 0) )

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -177,7 +177,7 @@ let
     '[ "sum" ::: 'NotNull 'PGint4
      , "col1" ::: 'NotNull 'PGint4 ]
   query =
-    select (sum_ #col2 `As` #sum :* #col1 `As` #col1 :* Nil)
+    select (sum_ #col2 `As` #sum :* #col1 :* Nil)
     ( from (table (#tab `As` #table1))
       & group (By #col1 :* Nil)
       & having (#col1 + sum_ #col2 .> 1) )

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
@@ -9,7 +9,8 @@ Rendering helper functions.
 -}
 
 {-# LANGUAGE
-    MagicHash
+    FlexibleContexts
+  , MagicHash
   , OverloadedStrings
   , PolyKinds
   , RankNTypes
@@ -25,8 +26,11 @@ module Squeal.PostgreSQL.Render
   , renderCommaSeparated
   , renderCommaSeparatedMaybe
   , renderNat
+  , RenderSQL (..)
+  , printSQL
   ) where
 
+import Control.Monad.Base
 import Data.ByteString (ByteString)
 import Data.Maybe
 import Data.Monoid ((<>))
@@ -35,6 +39,7 @@ import GHC.Exts
 import GHC.TypeLits
 
 import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Char8 as Char8
 
 -- | Parenthesize a `ByteString`.
 parenthesized :: ByteString -> ByteString
@@ -77,3 +82,9 @@ renderCommaSeparatedMaybe render
 -- | Render a promoted `Nat`.
 renderNat :: KnownNat n => proxy n -> ByteString
 renderNat (_ :: proxy n) = fromString (show (natVal' (proxy# :: Proxy# n)))
+
+class RenderSQL sql where
+  renderSQL :: sql -> ByteString
+
+printSQL :: (RenderSQL sql, MonadBase IO io) => sql -> io ()
+printSQL = liftBase . Char8.putStrLn . renderSQL

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
@@ -14,7 +14,6 @@ Rendering helper functions.
   , PolyKinds
   , RankNTypes
   , ScopedTypeVariables
-  , TypeApplications
 #-}
 
 module Squeal.PostgreSQL.Render

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
@@ -83,8 +83,10 @@ renderCommaSeparatedMaybe render
 renderNat :: KnownNat n => proxy n -> ByteString
 renderNat (_ :: proxy n) = fromString (show (natVal' (proxy# :: Proxy# n)))
 
+-- | A class for rendering SQL
 class RenderSQL sql where
   renderSQL :: sql -> ByteString
 
+-- | Print SQL.
 printSQL :: (RenderSQL sql, MonadBase IO io) => sql -> io ()
 printSQL = liftBase . Char8.putStrLn . renderSQL

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -582,12 +582,15 @@ type family SameLabels
 class MapMaybes xs where
   type family Maybes (xs :: [Type]) = (mxs :: [Type]) | mxs -> xs
   maybes :: SOP.NP Maybe xs -> SOP.NP SOP.I (Maybes xs)
+  unMaybes :: SOP.NP SOP.I (Maybes xs) -> SOP.NP Maybe xs
 instance MapMaybes '[] where
   type Maybes '[] = '[]
   maybes SOP.Nil = SOP.Nil
+  unMaybes SOP.Nil = SOP.Nil
 instance MapMaybes xs => MapMaybes (x ': xs) where
   type Maybes (x ': xs) = Maybe x ': Maybes xs
   maybes (x SOP.:* xs) = SOP.I x SOP.:* maybes xs
+  unMaybes (SOP.I mx SOP.:* xs) = mx SOP.:* unMaybes xs
 
 type family Nulls tys where
   Nulls '[] = '[]

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -695,9 +695,9 @@ type family PG (hask :: Type) = (pg :: PGType) | pg -> hask where
   PG (NetAddr IP) = 'PGinet
   PG Value = 'PGjson
 
-type family PGenumWith (hask :: Type) :: PGType where
+type family PGenumWith (hask :: Type) :: [Type.ConstructorName] where
   PGenumWith hask =
-    'PGenum (ConstructorNamesOf (ConstructorsOf (SOP.DatatypeInfoOf hask)))
+    ConstructorNamesOf (ConstructorsOf (SOP.DatatypeInfoOf hask))
 
 type family PGcompositeWith (hask :: Type) :: PGType where
   PGcompositeWith hask =

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -365,6 +365,7 @@ instance alias1 ~ alias2 => IsLabel alias1 (Alias alias2) where
   fromLabel = Alias
 instance aliases ~ '[alias] => IsLabel alias (NP Alias aliases) where
   fromLabel = fromLabel :* Nil
+instance KnownSymbol alias => RenderSQL (Alias alias) where renderSQL = renderAlias
 
 -- | >>> renderAlias #jimbob
 -- "\"jimbob\""

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -98,6 +98,9 @@ module Squeal.PostgreSQL.Schema
   , PGlabel (..)
   , renderLabel
   , renderLabels
+  , LabelOf
+  , LabelsOf
+  , DatatypeLabels
     -- * Schema
   , SchemumType (..)
   , SchemaType
@@ -640,3 +643,13 @@ renderLabels
   :: SOP.All KnownSymbol labels => SOP.NP PGlabel labels -> [ByteString]
 renderLabels = SOP.hcollapse
   . SOP.hcmap (SOP.Proxy @KnownSymbol) (SOP.K . renderLabel)
+
+type family LabelOf (cons :: Type.ConstructorInfo) :: Symbol where
+  LabelOf ('Type.Constructor name) = name
+
+type family LabelsOf (conss :: [Type.ConstructorInfo]) :: [Symbol] where
+  LabelsOf '[] = '[]
+  LabelsOf (cons ': conss) = LabelOf cons ': LabelsOf conss
+
+type family DatatypeLabels (info :: Type.DatatypeInfo) :: [Symbol] where
+  DatatypeLabels ('Type.ADT _module _datatype constructors) = LabelsOf constructors

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -5,7 +5,10 @@ Copyright: (c) Eitan Chatav, 2017
 Maintainer: eitan@morphism.tech
 Stability: experimental
 
-A type-level DSL for kinds of PostgreSQL types, constraints, and aliases.
+This module provides a type-level DSL for kinds of Postgres types,
+tables, schema, constraints, aliases, enumerated labels, and groupings.
+It also defines useful type families to operate on these. Finally,
+it defines an embedding of Haskell types into Postgres types.
 -}
 
 {-# LANGUAGE
@@ -35,6 +38,7 @@ module Squeal.PostgreSQL.Schema
   , HasOid (..)
   , NullityType (..)
   , ColumnType
+    -- * Tables
   , ColumnsType
   , RelationType
   , NilRelation
@@ -43,9 +47,6 @@ module Squeal.PostgreSQL.Schema
     -- * Schema
   , SchemumType (..)
   , SchemaType
-    -- * Grouping
-  , Grouping (..)
-  , GroupedBy
     -- * Constraints
   , (:=>)
   , ColumnConstraint (..)
@@ -67,6 +68,14 @@ module Squeal.PostgreSQL.Schema
   , HasAll
   , IsLabel (..)
   , IsQualified (..)
+    -- * Enumerated Labels
+  , IsPGlabel (..)
+  , PGlabel (..)
+  , renderLabel
+  , renderLabels
+    -- * Grouping
+  , Grouping (..)
+  , GroupedBy
     -- * Type Families
   , Join
   , With
@@ -92,14 +101,6 @@ module Squeal.PostgreSQL.Schema
   , TableToRelation
   , ConstraintInvolves
   , DropIfConstraintsInvolve
-    -- * Generics
-  , MapMaybes (..)
-  , Nulls
-    -- * Enum Labels
-  , IsPGlabel (..)
-  , PGlabel (..)
-  , renderLabel
-  , renderLabels
     -- * Embedding
   , PG
   , EnumFrom
@@ -116,6 +117,8 @@ module Squeal.PostgreSQL.Schema
   , FieldTypeOf
   , FieldTypesOf
   , RecordCodeOf
+  , MapMaybes (..)
+  , Nulls
   ) where
 
 import Control.DeepSeq

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -545,6 +545,10 @@ type family Join xs ys where
 -- `Squeal.PostgreSQL.Definition.addColumn`.
 type family Create alias x xs where
   Create alias x '[] = '[alias ::: x]
+  Create alias x (alias ::: y ': xs) = TypeError
+    ('Text "Create: alias "
+    ':<>: 'ShowType alias
+    ':<>: 'Text "already in use")
   Create alias y (x ': xs) = x ': Create alias y xs
 
 -- | @Drop alias xs@ removes the type associated with @alias@ in @xs@
@@ -631,4 +635,4 @@ type family With
   :: SchemaType where
     With '[] schema = schema
     With (alias ::: rel ': rels) schema =
-      alias ::: 'Table ('[] :=> RelationToColumns rel) ': With rels schema
+      alias ::: 'View rel ': With rels schema

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -395,6 +395,9 @@ deriving instance Eq (expression ty)
   => Eq (Aliased expression (alias ::: ty))
 deriving instance Ord (expression ty)
   => Ord (Aliased expression (alias ::: ty))
+instance (alias0 ~ alias1, alias0 ~ alias2, KnownSymbol alias2)
+  => IsLabel alias0 (Aliased Alias (alias1 ::: alias2)) where
+    fromLabel = fromLabel @alias2 `As` fromLabel @alias1
 
 -- | >>> let renderMaybe = fromString . maybe "Nothing" (const "Just")
 -- >>> renderAliasedAs renderMaybe (Just (3::Int) `As` #an_int)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -99,6 +99,8 @@ module Squeal.PostgreSQL.Schema
     -- * Generics
   , SameField
   , SameFields
+  , SameLabel
+  , SameLabels
     -- * Schema
   , SchemumType (..)
   , SchemaType
@@ -605,6 +607,17 @@ type family SameFields
     ('Type.Newtype _module _datatype ('Type.Record _constructor fields))
     columns
       = SOP.AllZip SameField fields columns
+
+class SameLabel
+  (constrInfo :: Type.ConstructorInfo) (label :: Symbol) where
+instance name ~ label => SameLabel ('Type.Constructor name) label
+
+type family SameLabels
+  (datatypeInfo :: Type.DatatypeInfo) (labels :: [Symbol])
+    :: Constraint where
+  SameLabels
+    ('Type.ADT _module _datatype constructors) labels
+      = SOP.AllZip SameLabel constructors labels
 
 -- | Check if a `TableConstraint` involves a column
 type family ConstraintInvolves column constraint where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -226,10 +226,7 @@ type (:=>) constraint ty = '(constraint,ty)
 infixr 7 :=>
 
 -- | The alias operator `:::` is like a promoted version of `As`,
--- a type level pair between
--- an alias and some type, like a column alias and either a `ColumnType` or
--- `NullityType` or a table alias and either a `TableType` or a `RelationType`
--- or a constraint alias and a `TableConstraint`.
+-- a type level pair between an alias and some type.
 type (:::) (alias :: Symbol) ty = '(alias,ty)
 infixr 6 :::
 

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Transaction.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Transaction.hs
@@ -158,22 +158,22 @@ data IsolationLevel
   = Serializable
   -- ^ Dirty read is not possible.
   -- Nonrepeatable read is not possible.
-  -- Phantom read is not possible. 
+  -- Phantom read is not possible.
   -- Serialization anomaly is not possible.
   | RepeatableRead
   -- ^ Dirty read is not possible.
   -- Nonrepeatable read is not possible.
-  -- Phantom read is not possible. 
+  -- Phantom read is not possible.
   -- Serialization anomaly is possible.
   | ReadCommitted
   -- ^ Dirty read is not possible.
   -- Nonrepeatable read is possible.
-  -- Phantom read is possible. 
+  -- Phantom read is possible.
   -- Serialization anomaly is possible.
   | ReadUncommitted
   -- ^ Dirty read is not possible.
   -- Nonrepeatable read is possible.
-  -- Phantom read is possible. 
+  -- Phantom read is possible.
   -- Serialization anomaly is possible.
   deriving (Show, Eq)
 

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Transaction.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Transaction.hs
@@ -9,16 +9,9 @@ Squeal transaction control language.
 -}
 
 {-# LANGUAGE
-    DataKinds
-  , EmptyCase
-  , FlexibleContexts
-  , FlexibleInstances
+    FlexibleContexts
   , LambdaCase
   , OverloadedStrings
-  , MultiParamTypeClasses
-  , ScopedTypeVariables
-  , TypeFamilies
-  , TypeInType
 #-}
 
 module Squeal.PostgreSQL.Transaction

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-11.1
+resolver: lts-11.14
 packages:
 - squeal-postgresql

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-11.14
+resolver: lts-11.15
 packages:
 - squeal-postgresql


### PR DESCRIPTION
Version 0.3 of Squeal adds views as well as composite and enumerated types to Squeal.
To support these features, a new kind `SchemumType` was added.

```Haskell
data SchemumType
  = Table TableType
  | View RelationType
  | Typedef PGType
```

As a consequence, you will have to update your schema definitions like so:

```Haskell
-- Squeal 0.2
type Schema =
  '[ "users" :::
      '[ "pk_users" ::: 'PrimaryKey '["id"] ] :=>
      '[ "id"   :::   'Def :=> 'NotNull 'PGint4
       , "name" ::: 'NoDef :=> 'NotNull 'PGtext
       ]
   ]

-- Squeal 0.3
type Schema =
  '[ "users" ::: 'Table (
      '[ "pk_users" ::: 'PrimaryKey '["id"] ] :=>
      '[ "id"   :::   'Def :=> 'NotNull 'PGint4
       , "name" ::: 'NoDef :=> 'NotNull 'PGtext
       ])
   ]
```

**Views**

You can now create, drop, and query views.

```Haskell
>>> :{
type ABC =
  ('[] :: TableConstraints) :=>
  '[ "a" ::: 'NoDef :=> 'Null 'PGint4
   , "b" ::: 'NoDef :=> 'Null 'PGint4
   , "c" ::: 'NoDef :=> 'Null 'PGint4
   ]
type BC =
  '[ "b" ::: 'Null 'PGint4
   , "c" ::: 'Null 'PGint4
   ]
:}

>>> :{
let
  definition :: Definition '["abc" ::: 'Table ABC ] '["abc" ::: 'Table ABC, "bc"  ::: 'View BC]
  definition = createView #bc (select (#b :* #c :* Nil) (from (table #abc)))
in printSQL definition
:}
CREATE VIEW "bc" AS SELECT "b" AS "b", "c" AS "c" FROM "abc" AS "abc";

>>> :{
let
  definition :: Definition '["abc" ::: 'Table ABC, "bc"  ::: 'View BC] '["abc" ::: 'Table ABC]
  definition = dropView #bc
in printSQL definition
:}
DROP VIEW "bc";

>>> :{
let
  query :: Query '["abc" ::: 'Table ABC, "bc"  ::: 'View BC] '[] BC
  query = selectStar (from (view #bc))
in printSQL query
:}
SELECT * FROM "bc" AS "bc"
```

**Enumerated Types**

PostgreSQL has a powerful type system. It even allows for user defined types.
For instance, you can define enumerated types which are data types that comprise
a static, ordered set of values. They are equivalent to Haskell algebraic data
types whose constructors are nullary. An example of an enum type might be the days of the week,
or a set of status values for a piece of data.

Enumerated types are created using the `createTypeEnum` command, for example:

```Haskell
>>> :{
let
  definition :: Definition '[] '["mood" ::: 'Typedef ('PGenum '["sad", "ok", "happy"])]
  definition = createTypeEnum #mood (label @"sad" :* label @"ok" :* label @"happy" :* Nil)
:}
>>> printSQL definition
CREATE TYPE "mood" AS ENUM ('sad', 'ok', 'happy');
```

Enumerated types can also be generated from a Haskell algbraic data type with nullary constructors, for example:

```Haskell
>>> data Schwarma = Beef | Lamb | Chicken deriving GHC.Generic
>>> instance SOP.Generic Schwarma
>>> instance SOP.HasDatatypeInfo Schwarma

>>> :kind! EnumFrom Schwarma
EnumFrom Schwarma :: PGType
= 'PGenum '["Beef", "Lamb", "Chicken"]

>>> :{
let
  definition :: Definition '[] '["schwarma" ::: 'Typedef (EnumFrom Schwarma)]
  definition = createTypeEnumFrom @Schwarma #schwarma
:}
>>> printSQL definition
CREATE TYPE "schwarma" AS ENUM ('Beef', 'Lamb', 'Chicken');
```

You can express values of an enum type using `label`, which is an overloaded method
of the `IsPGlabel` typeclass.

```Haskell
>>> :{
let
  expression :: Expression sch rels grp params ('NotNull (EnumFrom Schwarma))
  expression = label @"Chicken"
in printSQL expression
:}
'Chicken'
```

**Composite Types**

In addition to enum types, you can define composite types.
A composite type represents the structure of a row or record;
it is essentially just a list of field names and their data types.


`createTypeComposite` creates a composite type. The composite type is
specified by a list of attribute names and data types.

```Haskell
>>> :{
let
  definition :: Definition '[] '["complex" ::: 'Typedef ('PGcomposite '["real" ::: 'PGfloat8, "imaginary" ::: 'PGfloat8])]
  definition = createTypeComposite #complex (float8 `As` #real :* float8 `As` #imaginary :* Nil)
:}
>>> printSQL definition
CREATE TYPE "complex" AS ("real" float8, "imaginary" float8);
```

Composite types are almost equivalent to Haskell record types.
However, because of the potential presence of `NULL`
all the record fields must be `Maybe`s of basic types.
Composite types can be generated from a Haskell record type, for example:

```Haskell
>>> data Complex = Complex {real :: Maybe Double, imaginary :: Maybe Double} deriving GHC.Generic
>>> instance SOP.Generic Complex
>>> instance SOP.HasDatatypeInfo Complex

>>> :kind! CompositeFrom Complex
CompositeFrom Complex :: PGType
= 'PGcomposite '['("real", 'PGfloat8), '("imaginary", 'PGfloat8)]

>>> :{
let
  definition :: Definition '[] '["complex" ::: 'Typedef (CompositeFrom Complex)]
  definition = createTypeCompositeFrom @Complex #complex
in printSQL definition
:}
CREATE TYPE "complex" AS ("real" float8, "imaginary" float8);
```

A row constructor is an expression that builds a row value
(also called a composite value) using values for its member fields.

```Haskell
>>> :{
let
  i :: Expression '[] '[] 'Ungrouped '[] ('NotNull (CompositeFrom Complex))
  i = row (0 `As` #real :* 1 `As` #imaginary :* Nil)
:}
>>>  printSQL i
ROW(0, 1)
```

You can also use `(&)` to apply a field label to a composite value.

```Haskell
>>> :{
let
  expr :: Expression '[] '[] 'Ungrouped '[] ('Null 'PGfloat8)
  expr = i & #imaginary
in printSQL expr
:}
(ROW(0, 1)).imaginary
```

Both composite and enum types can be automatically encoded from and decoded to their equivalent Haskell types.
And they can be dropped.

```Haskell
>>> :{
let
  definition :: Definition '["mood" ::: 'Typedef ('PGenum '["sad", "ok", "happy"])] '[]
  definition = dropType #mood
:}
>>> printSQL definition
DROP TYPE "mood";
```

**Additional Changes**

Squeal 0.3 also introduces a typeclass `HasAll` similar to `Has` but for a list of aliases.
This makes it possible to clean up some unfortunately messy Squeal 0.2 definitions.

```Haskell
-- Squeal 0.2
>>> unique (Column #a :* Column #b :* Nil)

-- Squeal 0.3
>>> unique (#a :* #b :* Nil)
```

Squeal 0.3 also adds `IsLabel` instances for `Aliased` expressions and tables as well as
heterogeneous lists, allowing for some more economy of code.

```Haskell
-- Squeal 0.2
>>> select (#a `As` #a :* Nil) (from (table (#t `As` #t)))

-- Squeal 0.3
>>> select #a (from (table #t))
```

The above changes required major and minor changes to Squeal DSL functions.
Please consult the documentation.