### PR TITLE
better error messages for traversePrepare{,_}

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
@@ -70,6 +70,7 @@ import Control.Monad.Except
 import Control.Monad.Morph
 import Control.Monad.Trans.Control
 import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as C8 (unpack)
 import Data.Foldable
 import Data.Function ((&))
 import Data.Kind
@@ -394,8 +395,8 @@ errorOnPrepareNotOk pfix r = do
     _               -> do
       msg <- LibPQ.resultErrorMessage r
       error $ pfix <>
-        "status: " <> show status <> "\n\
-        \message: " <> maybe "(no message)" show msg
+        "status: " <> show status <> "\n" <>
+        maybe "(no message)" C8.unpack msg
 
 instance (MonadBase IO io, schema0 ~ schema, schema1 ~ schema)
   => MonadPQ schema (PQ schema0 schema1 io) where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
@@ -393,9 +393,8 @@ errorOnPrepareNotOk pfix r = do
     LibPQ.CommandOk -> return ()
     _               -> do
       msg <- LibPQ.resultErrorMessage r
-      error $
-        pfix <>
-        "status:" <> show status <> "\n\
+      error $ pfix <>
+        "status: " <> show status <> "\n\
         \message: " <> maybe "(no message)" show msg
 
 instance (MonadBase IO io, schema0 ~ schema, schema1 ~ schema)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
@@ -412,8 +412,13 @@ instance (MonadBase IO io, schema0 ~ schema, schema1 ~ schema)
             "traversePrepared: LibPQ.prepare returned no results"
           Just prepResult -> do
             status <- LibPQ.resultStatus prepResult
-            unless (status == LibPQ.CommandOk) . error $
-              "traversePrepared: LibPQ.prepare status " <> show status
+            case status of
+              LibPQ.CommandOk -> return ()
+              _               -> do
+                msg <- LibPQ.resultErrorMessage prepResult
+                error $
+                  "traversePrepared: LibPQ.prepare status " <> show status <> "\n\
+                  \error message: " <> maybe "(no message)" show msg
         results <- for list $ \ params -> do
           let
             toParam' bytes = (bytes,LibPQ.Binary)


### PR DESCRIPTION
e.g.
```
*** Exception: traversePrepared_: LibPQ.prepare
status: FatalError
message: "ERROR:  column l.lineName does not exist\nLINE 1: ...FROM \"fleet\" AS \"f\" INNER JOIN \"line\" AS \"l\" ON ((\"l\".\"lineN...\n                                                             ^\n"
```
