### PR TITLE
JSON operator/function support WIP

### DIFF
--- a/RELEASE NOTES.md
+++ b/RELEASE NOTES.md
@@ -3,7 +3,8 @@
 ### Version 0.3.2 - August 4, 2018
 
 Version 0.3.2 features extensive support for `JSON` functionality.
-This work is entirely due to [Mike Ledger](https://github.com/mikeplus64).
+This work is entirely due to [Mike Ledger](https://github.com/mikeplus64)
+who has been making terrific contributions to Squeal. Thanks!
 
 ### Version 0.3.1 - July 7, 2018
 

--- a/RELEASE NOTES.md
+++ b/RELEASE NOTES.md
@@ -97,7 +97,7 @@ let
 CREATE TYPE "mood" AS ENUM ('sad', 'ok', 'happy');
 ```
 
-Enumerated types can also be generated from a Haskell algbraic data type with nullary constructors, for example:
+Enumerated types can also be generated from a Haskell algebraic data type with nullary constructors, for example:
 
 ```Haskell
 >>> data Schwarma = Beef | Lamb | Chicken deriving GHC.Generic

--- a/RELEASE NOTES.md
+++ b/RELEASE NOTES.md
@@ -1,5 +1,10 @@
 ## RELEASE NOTES
 
+### Version 0.3.2 - August 4, 2018
+
+Version 0.3.2 features extensive support for `JSON` functionality.
+This work is entirely due to [Mike Ledger](https://github.com/mikeplus64).
+
 ### Version 0.3.1 - July 7, 2018
 
 Version 0.3.1 of Squeal enables the "Scrap your Nils" trick for

--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -1,5 +1,5 @@
 name: squeal-postgresql
-version: 0.3.1.0
+version: 0.3.2.0
 synopsis: Squeal PostgreSQL Library
 description: Squeal is a type-safe embedding of PostgreSQL in Haskell
 homepage: https://github.com/morphismtech/squeal

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -1071,7 +1071,7 @@ toJson = unsafeFunction "to_json"
 toJsonb
   :: Expression schema relations grouping params (nullity ty)
   -> Expression schema relations grouping params (nullity 'PGjsonb)
-toJsonb = unsafeUnaryOp "to_jsonb"
+toJsonb = unsafeFunction "to_jsonb"
 
 -- | Returns the array as a JSON array. A PostgreSQL multidimensional array
 -- becomes a JSON array of arrays.

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -89,7 +89,7 @@ module Squeal.PostgreSQL.Expression
   , PGarray
   , PGarrayOf
   , PGjsonKey
-  , PGjson
+  , PGjson_
   , (.->)
   , (.->>)
   , (.#>)
@@ -108,6 +108,8 @@ module Squeal.PostgreSQL.Expression
   , toJsonb
   , arrayToJson
   , rowToJson
+  , jsonObjectKeys
+  , jsonbObjectKeys
     -- ** Aggregation
   , unsafeAggregate, unsafeAggregateDistinct
   , sum_, sumDistinct
@@ -1076,6 +1078,16 @@ rowToJson
   :: Expression schema relations grouping params (nullity ('PGcomposite ty))
   -> Expression schema relations grouping params (nullity 'PGjson)
 rowToJson = unsafeFunction "row_to_json"
+
+jsonObjectKeys
+  :: Expression schema relations grouping params (nullity 'PGjson)
+  -> Expression schema relations grouping params (nullity 'PGtext)
+jsonObjectKeys = unsafeFunction "json_object_keys"
+
+jsonbObjectKeys
+  :: Expression schema relations grouping params (nullity 'PGjsonb)
+  -> Expression schema relations grouping params (nullity 'PGtext)
+jsonbObjectKeys = unsafeFunction "jsonb_object_keys"
 
 -- TODO: jsonBuildArray, jsonbBuildArray, jsonObject, jsonbObject
 -- probably something like

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -114,6 +114,14 @@ module Squeal.PostgreSQL.Expression
   , jsonbBuildArray
   , jsonBuildObject
   , jsonbBuildObject
+  , jsonObject
+  , jsonbObject
+  , jsonZipObject
+  , jsonbZipObject
+  , jsonArrayLength
+  , jsonbArrayLength
+  , jsonEachAsComposite
+  , jsonbEachAsComposite
   , jsonObjectKeys
   , jsonbObjectKeys
     -- ** Aggregation
@@ -1158,11 +1166,87 @@ jsonbArrayLength
   -> Expression schema relations grouping params (nullity 'PGint4)
 jsonbArrayLength = unsafeFunction "jsonb_array_length"
 
+-- | Expands the outermost JSON object into a set of key/value pairs. 
+--
+-- See also 'Squeal.PostgreSQL.Query.jsonEach'.
+jsonEachAsComposite
+  :: Expression schema relations grouping params (nullity 'PGjson)
+  -> Expression schema relations grouping params
+     (nullity ('PGcomposite '[ "key" ::: 'PGtext, "value" ::: 'PGjson ]))
+jsonEachAsComposite = unsafeFunction "json_each"
+
+-- | Expands the outermost JSON object into a set of key/value pairs.
+--
+-- See also 'Squeal.PostgreSQL.Query.jsonbEach'
+jsonbEachAsComposite
+  :: Expression schema relations grouping params (nullity 'PGjsonb)
+  -> Expression schema relations grouping params
+     (nullity ('PGcomposite '[ "key" ::: 'PGtext, "value" ::: 'PGjsonb ]))
+jsonbEachAsComposite = unsafeFunction "jsonb_each"
+
+-- | Expands the outermost JSON object into a set of key/value pairs. 
+--
+-- See also 'Squeal.PostgreSQL.Query.jsonEachText'.
+jsonEachTextAsComposite
+  :: Expression schema relations grouping params (nullity 'PGjson)
+  -> Expression schema relations grouping params
+     (nullity ('PGcomposite '[ "key" ::: 'PGtext, "value" ::: 'PGtext ]))
+jsonEachTextAsComposite = unsafeFunction "json_each_text"
+
+-- | Expands the outermost JSON object into a set of key/value pairs.
+--
+-- See also 'Squeal.PostgreSQL.Query.jsonbEachText'
+jsonbEachTextAsComposite
+  :: Expression schema relations grouping params (nullity 'PGjsonb)
+  -> Expression schema relations grouping params
+     (nullity ('PGcomposite '[ "key" ::: 'PGtext, "value" ::: 'PGtext ]))
+jsonbEachTextAsComposite = unsafeFunction "jsonb_each_text"
+
+-- | Returns JSON value pointed to by path_elems (equivalent to #> operator).
+jsonExtractPath
+  :: SListI elems 
+  => Expression schema relations grouping params (nullity 'PGjson)
+  -> NP (Expression schema relations grouping params) elems
+  -> Expression schema relations grouping params (nullity 'PGjsonb)
+jsonExtractPath x xs =
+  unsafeVariadicFunction "json_extract_path" (x :* xs)
+
+-- | Returns JSON value pointed to by path_elems (equivalent to #> operator).
+jsonbExtractPath
+  :: SListI elems 
+  => Expression schema relations grouping params (nullity 'PGjsonb)
+  -> NP (Expression schema relations grouping params) elems
+  -> Expression schema relations grouping params (nullity 'PGjsonb)
+jsonbExtractPath x xs =
+  unsafeVariadicFunction "jsonb_extract_path" (x :* xs)
+
+-- | Returns JSON value pointed to by path_elems (equivalent to #> operator),
+-- as text.
+jsonExtractPathText
+  :: SListI elems 
+  => Expression schema relations grouping params (nullity 'PGjson)
+  -> NP (Expression schema relations grouping params) elems
+  -> Expression schema relations grouping params (nullity 'PGjsonb)
+jsonExtractPathText x xs =
+  unsafeVariadicFunction "json_extract_path_text" (x :* xs)
+
+-- | Returns JSON value pointed to by path_elems (equivalent to #> operator),
+-- as text.
+jsonbExtractPathText
+  :: SListI elems 
+  => Expression schema relations grouping params (nullity 'PGjsonb)
+  -> NP (Expression schema relations grouping params) elems
+  -> Expression schema relations grouping params (nullity 'PGjsonb)
+jsonbExtractPathText x xs =
+  unsafeVariadicFunction "jsonb_extract_path_text" (x :* xs)
+
+-- | Returns set of keys in the outermost JSON object.
 jsonObjectKeys
   :: Expression schema relations grouping params (nullity 'PGjson)
   -> Expression schema relations grouping params (nullity 'PGtext)
 jsonObjectKeys = unsafeFunction "json_object_keys"
 
+-- | Returns set of keys in the outermost JSON object.
 jsonbObjectKeys
   :: Expression schema relations grouping params (nullity 'PGjsonb)
   -> Expression schema relations grouping params (nullity 'PGtext)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -902,8 +902,8 @@ json and jsonb operators
 see https://www.postgresql.org/docs/10/static/functions-json.html
 -----------------------------------------}
 
-type IsJSONKey key = key `In` '[ 'PGint2, 'PGint4, 'PGtext ]
-type IsJSON json = json `In` '[ 'PGjson, 'PGjsonb ]
+type PGjsonKey key = key `In` '[ 'PGint2, 'PGint4, 'PGtext ]
+type PGjson_ json = json `In` '[ 'PGjson, 'PGjsonb ]
 
 type Placeholder k
   =     'Text "(_"
@@ -937,7 +937,7 @@ type IsPGtextArray arr = PGarrayOf arr 'PGtext
 
 -- | Get JSON value (object field or array element) at a key.
 (.->)
-  :: (IsJSON json, IsJSONKey key)
+  :: (PGjson_ json, PGjsonKey key)
   => Expression schema relations grouping params (jnull json)
   -> Expression schema relations grouping params (knull key)
   -> Expression schema relations grouping params ('Null json)
@@ -945,7 +945,7 @@ type IsPGtextArray arr = PGarrayOf arr 'PGtext
 
 -- | Get JSON value (object field or array element) at a key, as text.
 (.->>)
-  :: (IsJSON json, IsJSONKey key)
+  :: (PGjson_ json, PGjsonKey key)
   => Expression schema relations grouping params (jnull json)
   -> Expression schema relations grouping params (knull key)
   -> Expression schema relations grouping params ('Null 'PGtext)
@@ -953,7 +953,7 @@ type IsPGtextArray arr = PGarrayOf arr 'PGtext
 
 -- | Get JSON value at a specified path.
 (.#>)
-  :: (IsJSON json, IsPGtextArray path)
+  :: (PGjson_ json, IsPGtextArray path)
   => Expression schema relations grouping params (jnull json)
   -> Expression schema relations grouping params (knull path)
   -> Expression schema relations grouping params ('Null json)
@@ -961,7 +961,7 @@ type IsPGtextArray arr = PGarrayOf arr 'PGtext
 
 -- | Get JSON value at a specified path as text.
 (.#>>)
-  :: (IsJSON json, IsPGtextArray path)
+  :: (PGjson_ json, IsPGtextArray path)
   => Expression schema relations grouping params (jnull json)
   -> Expression schema relations grouping params (knull path)
   -> Expression schema relations grouping params ('Null 'PGtext)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -88,6 +88,8 @@ module Squeal.PostgreSQL.Expression
     -- ** json or jsonb operators
   , PGarray
   , PGarrayOf
+  , PGjsonKey
+  , PGjson
   , (.->)
   , (.->>)
   , (.#>)
@@ -903,6 +905,7 @@ see https://www.postgresql.org/docs/10/static/functions-json.html
 -----------------------------------------}
 
 type PGjsonKey key = key `In` '[ 'PGint2, 'PGint4, 'PGtext ]
+
 type PGjson_ json = json `In` '[ 'PGjson, 'PGjsonb ]
 
 type Placeholder k

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -128,6 +128,11 @@ module Squeal.PostgreSQL.Expression
   , jsonbObjectKeys
   , jsonTypeof
   , jsonbTypeof
+  , jsonStripNulls
+  , jsonbStripNulls
+  , jsonbSet
+  , jsonbInsert
+  , jsonbPretty
     -- ** Aggregation
   , unsafeAggregate, unsafeAggregateDistinct
   , sum_, sumDistinct
@@ -1171,7 +1176,7 @@ jsonbArrayLength = unsafeFunction "jsonb_array_length"
 
 -- | Returns JSON value pointed to by path_elems (equivalent to #> operator).
 jsonExtractPath
-  :: SListI elems 
+  :: SListI elems
   => Expression schema relations grouping params (nullity 'PGjson)
   -> NP (Expression schema relations grouping params) elems
   -> Expression schema relations grouping params (nullity 'PGjsonb)
@@ -1180,7 +1185,7 @@ jsonExtractPath x xs =
 
 -- | Returns JSON value pointed to by path_elems (equivalent to #> operator).
 jsonbExtractPath
-  :: SListI elems 
+  :: SListI elems
   => Expression schema relations grouping params (nullity 'PGjsonb)
   -> NP (Expression schema relations grouping params) elems
   -> Expression schema relations grouping params (nullity 'PGjsonb)
@@ -1190,17 +1195,17 @@ jsonbExtractPath x xs =
 -- | Returns JSON value pointed to by path_elems (equivalent to #> operator),
 -- as text.
 jsonExtractPathAsText
-  :: SListI elems 
+  :: SListI elems
   => Expression schema relations grouping params (nullity 'PGjson)
   -> NP (Expression schema relations grouping params) elems
-  -> Expression schema relations grouping params (nullity 'PGjsonb)
+  -> Expression schema relations grouping params (nullity 'PGjson)
 jsonExtractPathAsText x xs =
   unsafeVariadicFunction "json_extract_path_text" (x :* xs)
 
 -- | Returns JSON value pointed to by path_elems (equivalent to #> operator),
 -- as text.
 jsonbExtractPathAsText
-  :: SListI elems 
+  :: SListI elems
   => Expression schema relations grouping params (nullity 'PGjsonb)
   -> NP (Expression schema relations grouping params) elems
   -> Expression schema relations grouping params (nullity 'PGjsonb)
@@ -1232,6 +1237,63 @@ jsonbTypeof
   :: Expression schema relations grouping params (nullity 'PGjsonb)
   -> Expression schema relations grouping params (nullity 'PGtext)
 jsonbTypeof = unsafeFunction "jsonb_typeof"
+
+-- | Returns its argument with all object fields that have null values omitted.
+-- Other null values are untouched.
+jsonStripNulls
+  :: Expression schema relations grouping params (nullity 'PGjson)
+  -> Expression schema relations grouping params (nullity 'PGjson)
+jsonStripNulls = unsafeFunction "json_strip_nulls"
+
+-- | Returns its argument with all object fields that have null values omitted.
+-- Other null values are untouched.
+jsonbStripNulls
+  :: Expression schema relations grouping params (nullity 'PGjsonb)
+  -> Expression schema relations grouping params (nullity 'PGjsonb)
+jsonbStripNulls = unsafeFunction "jsonb_strip_nulls"
+
+-- | @ jsonbSet target path new_value create_missing @
+--
+-- Returns target with the section designated by path replaced by new_value,
+-- or with new_value added if create_missing is true ( default is true) and the
+-- item designated by path does not exist. As with the path orientated
+-- operators, negative integers that appear in path count from the end of JSON
+-- arrays.
+jsonbSet
+  :: PGtextArray "jsonbSet" arr
+  => Expression schema relations grouping params (nullity 'PGjsonb)
+  -> Expression schema relations grouping params (nullity arr)
+  -> Expression schema relations grouping params (nullity 'PGjsonb)
+  -> Maybe (Expression schema relations grouping params (nullity 'PGbool))
+  -> Expression schema relations grouping params (nullity 'PGjsonb)
+jsonbSet tgt path val createMissing = case createMissing of
+  Just m -> unsafeVariadicFunction "jsonb_set" (tgt :* path :* val :* m :* Nil)
+  Nothing -> unsafeVariadicFunction "jsonb_set" (tgt :* path :* val :* Nil)
+
+-- | @ jsonbInsert target path new_value insert_after @
+--
+-- Returns target with new_value inserted. If target section designated by
+-- path is in a JSONB array, new_value will be inserted before target or after
+-- if insert_after is true (default is false). If target section designated by
+-- path is in JSONB object, new_value will be inserted only if target does not
+-- exist. As with the path orientated operators, negative integers that appear
+-- in path count from the end of JSON arrays.
+jsonbInsert
+  :: PGtextArray "jsonbInsert" arr
+  => Expression schema relations grouping params (nullity 'PGjsonb)
+  -> Expression schema relations grouping params (nullity arr)
+  -> Expression schema relations grouping params (nullity 'PGjsonb)
+  -> Maybe (Expression schema relations grouping params (nullity 'PGbool))
+  -> Expression schema relations grouping params (nullity 'PGjsonb)
+jsonbInsert tgt path val insertAfter = case insertAfter of
+  Just i -> unsafeVariadicFunction "jsonb_insert" (tgt :* path :* val :* i :* Nil)
+  Nothing -> unsafeVariadicFunction "jsonb_insert" (tgt :* path :* val :* Nil)
+
+-- | Returns its argument as indented JSON text.
+jsonbPretty
+  :: Expression schema relations grouping params (nullity 'PGjsonb)
+  -> Expression schema relations grouping params (nullity 'PGtext)
+jsonbPretty = unsafeFunction "jsonb_pretty"
 
 {-----------------------------------------
 aggregation

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -965,7 +965,7 @@ type IsPGtextArray arr = PGarrayOf arr 'PGtext
   => Expression schema relations grouping params (jnull json)
   -> Expression schema relations grouping params (knull path)
   -> Expression schema relations grouping params ('Null 'PGtext)
-(.#>>) = unsafeBinaryOp "#>"
+(.#>>) = unsafeBinaryOp "#>>"
 
 -- Additional jsonb operators
 

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -120,10 +120,14 @@ module Squeal.PostgreSQL.Expression
   , jsonbZipObject
   , jsonArrayLength
   , jsonbArrayLength
-  , jsonEachAsComposite
-  , jsonbEachAsComposite
+  , jsonExtractPath
+  , jsonbExtractPath
+  , jsonExtractPathAsText
+  , jsonbExtractPathAsText
   , jsonObjectKeys
   , jsonbObjectKeys
+  , jsonTypeof
+  , jsonbTypeof
     -- ** Aggregation
   , unsafeAggregate, unsafeAggregateDistinct
   , sum_, sumDistinct
@@ -181,7 +185,6 @@ import Data.Semigroup
 import Data.Ratio
 import Data.String
 import Generics.SOP hiding (from)
-import GHC.Exts (Constraint)
 import GHC.OverloadedLabels
 import GHC.TypeLits
 import Prelude hiding (id, (.))
@@ -1166,42 +1169,6 @@ jsonbArrayLength
   -> Expression schema relations grouping params (nullity 'PGint4)
 jsonbArrayLength = unsafeFunction "jsonb_array_length"
 
--- | Expands the outermost JSON object into a set of key/value pairs. 
---
--- See also 'Squeal.PostgreSQL.Query.jsonEach'.
-jsonEachAsComposite
-  :: Expression schema relations grouping params (nullity 'PGjson)
-  -> Expression schema relations grouping params
-     (nullity ('PGcomposite '[ "key" ::: 'PGtext, "value" ::: 'PGjson ]))
-jsonEachAsComposite = unsafeFunction "json_each"
-
--- | Expands the outermost JSON object into a set of key/value pairs.
---
--- See also 'Squeal.PostgreSQL.Query.jsonbEach'
-jsonbEachAsComposite
-  :: Expression schema relations grouping params (nullity 'PGjsonb)
-  -> Expression schema relations grouping params
-     (nullity ('PGcomposite '[ "key" ::: 'PGtext, "value" ::: 'PGjsonb ]))
-jsonbEachAsComposite = unsafeFunction "jsonb_each"
-
--- | Expands the outermost JSON object into a set of key/value pairs. 
---
--- See also 'Squeal.PostgreSQL.Query.jsonEachText'.
-jsonEachTextAsComposite
-  :: Expression schema relations grouping params (nullity 'PGjson)
-  -> Expression schema relations grouping params
-     (nullity ('PGcomposite '[ "key" ::: 'PGtext, "value" ::: 'PGtext ]))
-jsonEachTextAsComposite = unsafeFunction "json_each_text"
-
--- | Expands the outermost JSON object into a set of key/value pairs.
---
--- See also 'Squeal.PostgreSQL.Query.jsonbEachText'
-jsonbEachTextAsComposite
-  :: Expression schema relations grouping params (nullity 'PGjsonb)
-  -> Expression schema relations grouping params
-     (nullity ('PGcomposite '[ "key" ::: 'PGtext, "value" ::: 'PGtext ]))
-jsonbEachTextAsComposite = unsafeFunction "jsonb_each_text"
-
 -- | Returns JSON value pointed to by path_elems (equivalent to #> operator).
 jsonExtractPath
   :: SListI elems 
@@ -1222,22 +1189,22 @@ jsonbExtractPath x xs =
 
 -- | Returns JSON value pointed to by path_elems (equivalent to #> operator),
 -- as text.
-jsonExtractPathText
+jsonExtractPathAsText
   :: SListI elems 
   => Expression schema relations grouping params (nullity 'PGjson)
   -> NP (Expression schema relations grouping params) elems
   -> Expression schema relations grouping params (nullity 'PGjsonb)
-jsonExtractPathText x xs =
+jsonExtractPathAsText x xs =
   unsafeVariadicFunction "json_extract_path_text" (x :* xs)
 
 -- | Returns JSON value pointed to by path_elems (equivalent to #> operator),
 -- as text.
-jsonbExtractPathText
+jsonbExtractPathAsText
   :: SListI elems 
   => Expression schema relations grouping params (nullity 'PGjsonb)
   -> NP (Expression schema relations grouping params) elems
   -> Expression schema relations grouping params (nullity 'PGjsonb)
-jsonbExtractPathText x xs =
+jsonbExtractPathAsText x xs =
   unsafeVariadicFunction "jsonb_extract_path_text" (x :* xs)
 
 -- | Returns set of keys in the outermost JSON object.
@@ -1251,6 +1218,20 @@ jsonbObjectKeys
   :: Expression schema relations grouping params (nullity 'PGjsonb)
   -> Expression schema relations grouping params (nullity 'PGtext)
 jsonbObjectKeys = unsafeFunction "jsonb_object_keys"
+
+-- | Returns the type of the outermost JSON value as a text string. Possible
+-- types are object, array, string, number, boolean, and null.
+jsonTypeof
+  :: Expression schema relations grouping params (nullity 'PGjson)
+  -> Expression schema relations grouping params (nullity 'PGtext)
+jsonTypeof = unsafeFunction "json_typeof"
+
+-- | Returns the type of the outermost binary JSON value as a text string.
+-- Possible types are object, array, string, number, boolean, and null.
+jsonbTypeof
+  :: Expression schema relations grouping params (nullity 'PGjsonb)
+  -> Expression schema relations grouping params (nullity 'PGtext)
+jsonbTypeof = unsafeFunction "jsonb_typeof"
 
 {-----------------------------------------
 aggregation

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -529,6 +529,7 @@ unsafeFunction
 unsafeFunction fun x = UnsafeExpression $
   fun <> parenthesized (renderExpression x)
 
+-- | Helper for defining variadic functions.
 unsafeVariadicFunction
   :: SListI elems
   => ByteString

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -746,8 +746,8 @@ renderTableTypeExpression
   :: All Top types
   => Aliased (NP (Aliased (TypeExpression schema))) (tab ::: types)
   -> ByteString
-renderTableTypeExpression (hc `As` tab) =
-  (renderAlias tab <>)
+renderTableTypeExpression (hc `As` tab)
+  = (renderAlias tab <>)
   . parenthesized
   . commaSeparated
   . flip appEndo []

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -660,28 +660,28 @@ unsafeAliasedFromClauseExpression aliasedExpr = UnsafeFromClause
 
 -- | Expands the outermost JSON object into a set of key/value pairs.
 jsonEach
-  :: Aliased (Expression schema relations 'Ungrouped params) '(tab, nullity 'PGjson)
+  :: Aliased (Expression schema '[] 'Ungrouped params) '(tab, nullity 'PGjson)
   -> FromClause schema params (PGjson_each tab)
 jsonEach (As jexpr jname) = unsafeAliasedFromClauseExpression
   (As (unsafeFunction "json_each" jexpr) jname)
 
 -- | Expands the outermost binary JSON object into a set of key/value pairs.
 jsonbEach
-  :: Aliased (Expression schema relations 'Ungrouped params) '(tab, nullity 'PGjsonb)
+  :: Aliased (Expression schema '[] 'Ungrouped params) '(tab, nullity 'PGjsonb)
   -> FromClause schema params (PGjsonb_each tab)
 jsonbEach (As jexpr jname) = unsafeAliasedFromClauseExpression
   (As (unsafeFunction "jsonb_each" jexpr) jname)
 
 -- | Expands the outermost JSON object into a set of key/value pairs.
 jsonEachAsText
-  :: Aliased (Expression schema relations 'Ungrouped params) '(tab, nullity 'PGjson)
+  :: Aliased (Expression schema '[] 'Ungrouped params) '(tab, nullity 'PGjson)
   -> FromClause schema params (PGjson_each_text tab)
 jsonEachAsText (As jexpr jname) = unsafeAliasedFromClauseExpression
   (As (unsafeFunction "json_each" jexpr) jname)
 
 -- | Expands the outermost binary JSON object into a set of key/value pairs.
 jsonbEachAsText
-  :: Aliased (Expression schema relations 'Ungrouped params) '(tab, nullity 'PGjsonb)
+  :: Aliased (Expression schema '[] 'Ungrouped params) '(tab, nullity 'PGjsonb)
   -> FromClause schema params (PGjsonb_each_text tab)
 jsonbEachAsText (As jexpr jname) = unsafeAliasedFromClauseExpression
   (As (unsafeFunction "jsonb_each" jexpr) jname)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -743,7 +743,7 @@ jsonbPopulateRecordSetAs tableName expr alias = unsafeAliasedFromClauseExpressio
    (nullRow tableName :* expr :* Nil) `As` alias)
 
 renderTableTypeExpression
-  :: All Top types -- ^ always satisfiable
+  :: All Top types
   => Aliased (NP (Aliased (TypeExpression schema))) (tab ::: types)
   -> ByteString
 renderTableTypeExpression (hc `As` tab) =

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -651,9 +651,13 @@ JSON stuff
 type PGjson_each_variant val tab =
   '[ tab ::: '[ "key" ::: 'NotNull 'PGtext, "value" ::: 'NotNull val ] ]
 
+-- | The type of a `json_each` `FromClause`.
 type PGjson_each tab = PGjson_each_variant 'PGjson tab
+-- | The type of a `jsonb_each` `FromClause`.
 type PGjsonb_each tab = PGjson_each_variant 'PGjsonb tab
+-- | The type of a `json_each_text` `FromClause`.
 type PGjson_each_text tab = PGjson_each_variant 'PGtext tab
+-- | The type of a `jsonb_each_text` `FromClause`.
 type PGjsonb_each_text tab = PGjson_each_variant 'PGtext tab
 
 unsafeAliasedFromClauseExpression

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
@@ -23,6 +23,8 @@ module Squeal.PostgreSQL.Render
   , (<+>)
   , commaSeparated
   , doubleQuoted
+  , singleQuotedText
+  , singleQuotedUtf8
   , renderCommaSeparated
   , renderCommaSeparatedMaybe
   , renderNat
@@ -34,10 +36,12 @@ import Control.Monad.Base
 import Data.ByteString (ByteString)
 import Data.Maybe
 import Data.Monoid ((<>))
+import Data.Text (Text)
 import Generics.SOP
 import GHC.Exts
 import GHC.TypeLits
-
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Char8 as Char8
 
@@ -56,6 +60,12 @@ commaSeparated = ByteString.intercalate ", "
 -- | Add double quotes around a `ByteString`.
 doubleQuoted :: ByteString -> ByteString
 doubleQuoted str = "\"" <> str <> "\""
+
+singleQuotedText :: Text -> ByteString
+singleQuotedText str = "'" <> T.encodeUtf8 (T.replace "'" "''" str) <> "'"
+
+singleQuotedUtf8 :: ByteString -> ByteString
+singleQuotedUtf8 = singleQuotedText . T.decodeUtf8
 
 -- | Comma separate the renderings of a heterogeneous list.
 renderCommaSeparated

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
@@ -61,9 +61,11 @@ commaSeparated = ByteString.intercalate ", "
 doubleQuoted :: ByteString -> ByteString
 doubleQuoted str = "\"" <> str <> "\""
 
+-- | Add single quotes around a `Text` and escape single quotes within it.
 singleQuotedText :: Text -> ByteString
 singleQuotedText str = "'" <> T.encodeUtf8 (T.replace "'" "''" str) <> "'"
 
+-- | Add single quotes around a `ByteString` and escape single quotes within it.
 singleQuotedUtf8 :: ByteString -> ByteString
 singleQuotedUtf8 = singleQuotedText . T.decodeUtf8
 

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -103,6 +103,7 @@ module Squeal.PostgreSQL.Schema
   , ColumnsToRelation
   , TableToColumns
   , TableToRelation
+  , RelationToRowType
   , ConstraintInvolves
   , DropIfConstraintsInvolve
     -- ** JSON support
@@ -601,6 +602,11 @@ type family NullifyRelations (tables :: RelationsType) :: RelationsType where
   NullifyRelations '[] = '[]
   NullifyRelations (table ::: columns ': tables) =
     table ::: NullifyRelation columns ': NullifyRelations tables
+
+-- | 'RelationToRowType' drops the nullity constraints of its argument relations.
+type family RelationToRowType (tables :: RelationType) :: [(Symbol, PGType)] where
+  RelationToRowType (nullity x : xs) = x : RelationToRowType xs
+  RelationToRowType '[] = '[]
 
 -- | `Join` is simply promoted `++` and is used in @JOIN@s in
 -- `Squeal.PostgreSQL.Query.FromClause`s.

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -380,6 +380,8 @@ instance KnownSymbol alias => RenderSQL (Alias alias) where renderSQL = renderAl
 renderAlias :: KnownSymbol alias => Alias alias -> ByteString
 renderAlias = doubleQuoted . fromString . symbolVal
 
+-- | >>> renderAliasString #ohmahgerd
+-- "'ohmahgerd'"
 renderAliasString :: KnownSymbol alias => Alias alias -> ByteString
 renderAliasString = singleQuotedText . fromString . symbolVal
 
@@ -616,11 +618,12 @@ type family NullifyRelations (tables :: RelationsType) :: RelationsType where
   NullifyRelations (table ::: columns ': tables) =
     table ::: NullifyRelation columns ': NullifyRelations tables
 
--- | 'RelationToRowType' drops the nullity constraints of its argument relations.
+-- | `RelationToRowType` drops the nullity constraints of its argument relations.
 type family RelationToRowType (tables :: RelationType) :: [(Symbol, PGType)] where
   RelationToRowType (nullity x : xs) = x : RelationToRowType xs
   RelationToRowType '[] = '[]
 
+-- | `RelationToNullityTypes` drops the column constraints.
 type family RelationToNullityTypes (rel :: RelationType) :: [NullityType] where
   RelationToNullityTypes ('(k, x) : xs) = x : RelationToNullityTypes xs
   RelationToNullityTypes '[]            = '[]


### PR DESCRIPTION
Fixes #35 @ChShersh 

WIP

Tricky bits:
1. many functions accept either json or jsonb
2. many functions also overloaded on operand types
3. nullity of many results depends on nullity of either argument; which does not need to be the same

Unimplemented: most of table 9.45 and 9.46 at https://www.postgresql.org/docs/10/static/functions-json.html

