### PR TITLE
0.4

### DIFF
--- a/squeal-postgresql/exe/Example.hs
+++ b/squeal-postgresql/exe/Example.hs
@@ -29,7 +29,7 @@ type Schema =
        '[ "pk_users" ::: 'PrimaryKey '["id"] ] :=>
        '[ "id" ::: 'Def :=> 'NotNull 'PGint4
         , "name" ::: 'NoDef :=> 'NotNull 'PGtext
-        , "vec" ::: 'NoDef :=> 'NotNull ('PGvararray 'PGint2)
+        , "vec" ::: 'NoDef :=> 'NotNull ('PGvararray ('Null 'PGint2))
         ])
    , "emails" ::: 'Table (
        '[  "pk_emails" ::: 'PrimaryKey '["id"]
@@ -60,7 +60,7 @@ setup =
 teardown :: Definition Schema '[]
 teardown = dropTable #emails >>> dropTable #users
 
-insertUser :: Manipulation Schema '[ 'NotNull 'PGtext, 'NotNull ('PGvararray 'PGint2)]
+insertUser :: Manipulation Schema '[ 'NotNull 'PGtext, 'NotNull ('PGvararray ('Null 'PGint2))]
   '[ "fromOnly" ::: 'NotNull 'PGint4 ]
 insertUser = insertRows #users
   (Default `as` #id :* Set (param @1) `as` #name :* Set (param @2) `as` #vec) []
@@ -76,7 +76,7 @@ insertEmail = insertRows #emails
 getUsers :: Query Schema '[]
   '[ "userName" ::: 'NotNull 'PGtext
    , "userEmail" ::: 'Null 'PGtext
-   , "userVec" ::: 'NotNull ('PGvararray 'PGint2)]
+   , "userVec" ::: 'NotNull ('PGvararray ('Null 'PGint2))]
 getUsers = select
   (#u ! #name `as` #userName :* #e ! #email `as` #userEmail :* #u ! #vec `as` #userVec)
   ( from (table (#users `as` #u)

--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -1,5 +1,5 @@
 name: squeal-postgresql
-version: 0.3.1.0
+version: 0.4.0.0
 synopsis: Squeal PostgreSQL Library
 description: Squeal is a type-safe embedding of PostgreSQL in Haskell
 homepage: https://github.com/morphismtech/squeal

--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -51,6 +51,7 @@ library
     , postgresql-binary >= 0.12.1
     , postgresql-libpq >= 0.9.4.1
     , profunctors >= 5.2.2
+    , records-sop >= 0.1.0.0
     , resource-pool >= 0.2.3.2
     , scientific >= 0.3.5.3
     , text >= 1.2.3.0

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -349,7 +349,7 @@ instance (SListI tys, IsProductType x xs, AllZip ToNullityParam xs tys)
 -- a PostgreSQL `PGType` into a Haskell `Type`.
 class FromValue (pg :: PGType) (y :: Type) where
   -- | >>> newtype Id = Id { getId :: Int16 } deriving Show
-  -- >>> instance FromValue 'PGint2 Id where fromValue = fmap Id . fromValue
+  -- >>> instance FromValue 'PGint2 Id where fromValue = Id <$> fromValue @'PGint2
   fromValue :: Decoding.Value y
 instance FromValue 'PGbool Bool where fromValue = Decoding.bool
 instance FromValue 'PGint2 Int16 where fromValue = Decoding.int
@@ -484,7 +484,7 @@ class SListI result => FromRow (result :: RelationType) y where
   -- | >>> :set -XOverloadedStrings
   -- >>> import Data.Text
   -- >>> newtype UserId = UserId { getUserId :: Int16 } deriving Show
-  -- >>> instance FromValue 'PGint2 UserId where fromValue = fmap UserId . fromValue
+  -- >>> instance FromValue 'PGint2 UserId where fromValue = UserId <$> fromValue @'PGint2
   -- >>> data UserRow = UserRow { userId :: UserId, userName :: Maybe Text } deriving (Show, GHC.Generic)
   -- >>> instance Generic UserRow
   -- >>> instance HasDatatypeInfo UserRow

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -235,8 +235,12 @@ instance ToParam DiffTime 'PGinterval where toParam = K . Encoding.interval_int
 instance ToParam Value 'PGjson where toParam = K . Encoding.json_ast
 instance ToParam Value 'PGjsonb where toParam = K . Encoding.jsonb_ast
 instance (HasOid pg, ToParam x pg)
-  => ToParam (Vector (Maybe x)) ('PGvararray pg) where
+  => ToParam (Vector (Maybe x)) ('PGvararray ('Null pg)) where
     toParam = K . Encoding.nullableArray_vector
+      (oid @pg) (unK . toParam @x @pg)
+instance (HasOid pg, ToParam x pg)
+  => ToParam (Vector x) ('PGvararray ('NotNull pg)) where
+    toParam = K . Encoding.array_vector
       (oid @pg) (unK . toParam @x @pg)
 instance
   ( IsEnumType x
@@ -386,14 +390,26 @@ instance FromValue 'PGinterval DiffTime where
   fromValue _ = Decoding.interval_int
 instance FromValue 'PGjson Value where fromValue _ = Decoding.json_ast
 instance FromValue 'PGjsonb Value where fromValue _ = Decoding.jsonb_ast
-instance FromValue pg y => FromValue ('PGvararray pg) (Vector (Maybe y)) where
-  fromValue _ = Decoding.array
-    (Decoding.dimensionArray Vector.replicateM
-      (Decoding.nullableValueArray (fromValue (Proxy @pg))))
-instance FromValue pg y => FromValue ('PGfixarray n pg) (Vector (Maybe y)) where
-  fromValue _ = Decoding.array
-    (Decoding.dimensionArray Vector.replicateM
-      (Decoding.nullableValueArray (fromValue (Proxy @pg))))
+instance FromValue pg y
+  => FromValue ('PGvararray ('Null pg)) (Vector (Maybe y)) where
+    fromValue _ = Decoding.array
+      (Decoding.dimensionArray Vector.replicateM
+        (Decoding.nullableValueArray (fromValue (Proxy @pg))))
+instance FromValue pg y
+  => FromValue ('PGvararray ('NotNull pg)) (Vector y) where
+    fromValue _ = Decoding.array
+      (Decoding.dimensionArray Vector.replicateM
+        (Decoding.valueArray (fromValue (Proxy @pg))))
+instance FromValue pg y
+  => FromValue ('PGfixarray n ('Null pg)) (Vector (Maybe y)) where
+    fromValue _ = Decoding.array
+      (Decoding.dimensionArray Vector.replicateM
+        (Decoding.nullableValueArray (fromValue (Proxy @pg))))
+instance FromValue pg y
+  => FromValue ('PGfixarray n ('NotNull pg)) (Vector y) where
+    fromValue _ = Decoding.array
+      (Decoding.dimensionArray Vector.replicateM
+        (Decoding.valueArray (fromValue (Proxy @pg))))
 instance
   ( IsEnumType y
   , HasDatatypeInfo y

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -473,14 +473,6 @@ instance
 -- decoding `Null`s to `Maybe`s. You should not define instances for
 -- `FromColumnValue`, just use the provided instances.
 class FromColumnValue (pg :: (Symbol, NullityType)) (y :: (Symbol, Type)) where
-  -- | >>> :set -XTypeOperators -XOverloadedStrings
-  -- >>> newtype Id = Id { getId :: Int16 } deriving Show
-  -- >>> instance FromValue 'PGint2 Id where fromValue = fmap Id . fromValue
-  -- >>> fromColumnValue @("col" ::: 'NotNull 'PGint2) @Id (K (Just "\NUL\SOH"))
-  -- Id {getId = 1}
-  --
-  -- >>> fromColumnValue @("col" ::: 'Null 'PGint2) @(Maybe Id) (K (Just "\NUL\SOH"))
-  -- Just (Id {getId = 1})
   fromColumnValue
     :: K (Maybe Strict.ByteString) pg
     -> (Either Strict.Text :.: P) y
@@ -512,7 +504,7 @@ class SListI result => FromRow (result :: RelationType) y where
   -- >>> instance HasDatatypeInfo UserRow
   -- >>> type User = '["userId" ::: 'NotNull 'PGint2, "userName" ::: 'Null 'PGtext]
   -- >>> fromRow @User @UserRow (K (Just "\NUL\SOH") :* K (Just "bloodninja") :* Nil)
-  -- UserRow {userId = UserId {getUserId = 1}, userName = Just "bloodninja"}
+  -- Right (UserRow {userId = UserId {getUserId = 1}, userName = Just "bloodninja"})
   fromRow :: NP (K (Maybe Strict.ByteString)) result -> Either Strict.Text y
 instance
   ( SListI result
@@ -532,7 +524,7 @@ instance
 -- K (Just "foo") :* Nil
 --
 -- >>> fromRow @'["fromOnly" ::: 'Null 'PGtext] @(Only (Maybe Text)) (K (Just "bar") :* Nil)
--- Only {fromOnly = Just "bar"}
+-- Right (Only {fromOnly = Just "bar"})
 newtype Only x = Only { fromOnly :: x }
   deriving (Functor,Foldable,Traversable,Eq,Ord,Read,Show,GHC.Generic)
 instance Generic (Only x)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -171,6 +171,7 @@ import Data.UUID.Types
 import Data.Vector (Vector)
 import Data.Word
 import Generics.SOP
+import Generics.SOP.Record
 import GHC.TypeLits
 import Network.IP.Addr
 
@@ -262,10 +263,8 @@ instance
         . from
 instance
   ( SListI fields
-  , MapMaybes xs
-  , IsProductType x (Maybes xs)
+  , IsRecord x xs
   , AllZip ToAliasedParam xs fields
-  , FieldNamesFrom x ~ AliasesOf fields
   , All HasAliasedOid fields
   ) => ToParam x ('PGcomposite fields) where
     toParam =
@@ -435,10 +434,8 @@ instance
 
 instance
   ( SListI fields
-  , MapMaybes ys
-  , IsProductType y (Maybes ys)
+  , IsRecord y ys
   , AllZip FromAliasedValue fields ys
-  , FieldNamesFrom y ~ AliasesOf fields
   ) => FromValue ('PGcomposite fields) y where
     fromValue =
       let
@@ -529,9 +526,8 @@ class SListI results => FromRow (results :: RelationType) y where
   fromRow :: NP (K (Maybe Strict.ByteString)) results -> y
 instance
   ( SListI results
-  , IsProductType y ys
+  , IsRecord y ys
   , AllZip FromColumnValue results ys
-  , FieldNamesFrom y ~ AliasesOf results
   ) => FromRow results y where
     fromRow
       = to . SOP . Z . htrans (Proxy @FromColumnValue) (I . fromColumnValue)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -908,22 +908,20 @@ createTypeComposite ty fields = UnsafeDefinition $
 -- CREATE TYPE "complex" AS ("real" float8, "imaginary" float8);
 createTypeCompositeFrom
   :: forall hask ty schema.
-  ( SOP.All (BaseTyped schema) (PGFieldsFrom hask)
-  , KnownSymbol ty
-  )
+  ( SOP.All (FieldTyped schema) (PGFieldsFrom hask)
+  , KnownSymbol ty )
   => Alias ty
   -- ^ name of the user defined composite type
   -> Definition schema (Create ty ( 'Typedef (CompositeFrom hask)) schema)
 createTypeCompositeFrom ty = createTypeComposite ty
-  (SOP.hcpure (SOP.Proxy :: SOP.Proxy (BaseTyped schema)) basetype
+  (SOP.hcpure (SOP.Proxy :: SOP.Proxy (FieldTyped schema)) fieldtype
     :: NP (Aliased (TypeExpression schema)) (PGFieldsFrom hask))
-    
 
-class BaseTyped (schema :: SchemaType) (ty :: (Symbol,NullityType)) where
-  basetype :: Aliased (TypeExpression schema) ty
+class FieldTyped schema ty where
+  fieldtype :: Aliased (TypeExpression schema) ty
 instance (KnownSymbol alias, PGTyped schema ty)
-  => BaseTyped schema (alias ::: nullity ty) where
-    basetype = pgtype @schema @ty `As` Alias @alias
+  => FieldTyped schema (alias ::: ty) where
+    fieldtype = pgtype `As` Alias
 
 -- | Drop a type.
 --

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -869,7 +869,11 @@ createTypeEnumFrom enum = createTypeEnum enum
 {- | `createTypeComposite` creates a composite type. The composite type is
 specified by a list of attribute names and data types.
 
->>> type PGcomplex = 'PGcomposite '["real" ::: 'PGfloat8, "imaginary" ::: 'PGfloat8]
+>>> :{
+type PGcomplex = 'PGcomposite
+  '[ "real"      ::: 'NotNull 'PGfloat8
+   , "imaginary" ::: 'NotNull 'PGfloat8 ]
+:}
 
 >>> :{
 let
@@ -897,7 +901,7 @@ createTypeComposite ty fields = UnsafeDefinition $
 
 -- | Composite types can also be generated from a Haskell type, for example
 --
--- >>> data Complex = Complex {real :: Maybe Double, imaginary :: Maybe Double} deriving GHC.Generic
+-- >>> data Complex = Complex {real :: Double, imaginary :: Double} deriving GHC.Generic
 -- >>> instance SOP.Generic Complex
 -- >>> instance SOP.HasDatatypeInfo Complex
 -- >>> printSQL $ createTypeCompositeFrom @Complex #complex
@@ -951,7 +955,7 @@ nullable ty = UnsafeColumnTypeExpression $ renderTypeExpression ty <+> "NULL"
 -- @NULL@ is not present in a column
 notNullable
   :: TypeExpression schema (nullity ty)
-  -> ColumnTypeExpression schema (def :=> 'NotNull ty)
+  -> ColumnTypeExpression schema ('NoDef :=> 'NotNull ty)
 notNullable ty = UnsafeColumnTypeExpression $ renderTypeExpression ty <+> "NOT NULL"
 
 -- | used in `createTable` commands as a column constraint to give a default

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -943,14 +943,14 @@ newtype ColumnTypeExpression (schema :: SchemaType) (ty :: ColumnType)
 -- | used in `createTable` commands as a column constraint to note that
 -- @NULL@ may be present in a column
 nullable
-  :: (forall nullity. TypeExpression schema (nullity ty))
+  :: TypeExpression schema (nullity ty)
   -> ColumnTypeExpression schema ('NoDef :=> 'Null ty)
 nullable ty = UnsafeColumnTypeExpression $ renderTypeExpression ty <+> "NULL"
 
 -- | used in `createTable` commands as a column constraint to ensure
 -- @NULL@ is not present in a column
 notNullable
-  :: (forall nullity. TypeExpression schema (nullity ty))
+  :: TypeExpression schema (nullity ty)
   -> ColumnTypeExpression schema (def :=> 'NotNull ty)
 notNullable ty = UnsafeColumnTypeExpression $ renderTypeExpression ty <+> "NOT NULL"
 

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -198,7 +198,7 @@ class KnownNat n => HasParameter
       :: TypeExpression schema ty
       -> Expression schema relations grouping params ty
     parameter ty = UnsafeExpression $ parenthesized $
-      "$" <> renderNat (Proxy @n) <+> "::"
+      "$" <> renderNat @n <+> "::"
         <+> renderTypeExpression ty
 instance {-# OVERLAPPING #-} HasParameter 1 schema (ty1:tys) ty1
 instance {-# OVERLAPPABLE #-} (KnownNat n, HasParameter (n-1) schema params ty)
@@ -1157,19 +1157,17 @@ text :: TypeExpression schema (nullity 'PGtext)
 text = UnsafeTypeExpression "text"
 -- | fixed-length character string
 char, character
-  :: (KnownNat n, 1 <= n)
-  => proxy n
-  -> TypeExpression schema (nullity ('PGchar n))
-char p = UnsafeTypeExpression $ "char(" <> renderNat p <> ")"
-character p = UnsafeTypeExpression $  "character(" <> renderNat p <> ")"
+  :: forall n schema nullity. (KnownNat n, 1 <= n)
+  => TypeExpression schema (nullity ('PGchar n))
+char = UnsafeTypeExpression $ "char(" <> renderNat @n <> ")"
+character = UnsafeTypeExpression $  "character(" <> renderNat @n <> ")"
 -- | variable-length character string
 varchar, characterVarying
-  :: (KnownNat n, 1 <= n)
-  => proxy n
-  -> TypeExpression schema (nullity ('PGvarchar n))
-varchar p = UnsafeTypeExpression $ "varchar(" <> renderNat p <> ")"
-characterVarying p = UnsafeTypeExpression $
-  "character varying(" <> renderNat p <> ")"
+  :: forall n schema nullity. (KnownNat n, 1 <= n)
+  => TypeExpression schema (nullity ('PGvarchar n))
+varchar = UnsafeTypeExpression $ "varchar(" <> renderNat @n <> ")"
+characterVarying = UnsafeTypeExpression $
+  "character varying(" <> renderNat @n <> ")"
 -- | binary data ("byte array")
 bytea :: TypeExpression schema (nullity 'PGbytea)
 bytea = UnsafeTypeExpression "bytea"
@@ -1217,7 +1215,7 @@ fixarray
   => TypeExpression schema pg
   -> TypeExpression schema (nullity ('PGfixarray n pg))
 fixarray ty = UnsafeTypeExpression $
-  renderTypeExpression ty <> "[" <> renderNat (Proxy @n) <> "]"
+  renderTypeExpression ty <> "[" <> renderNat @n <> "]"
 
 -- | `pgtype` is a demoted version of a `PGType`
 class PGTyped schema (ty :: PGType) where pgtype :: TypeExpression schema (nullity ty)
@@ -1230,9 +1228,9 @@ instance PGTyped schema 'PGfloat4 where pgtype = float4
 instance PGTyped schema 'PGfloat8 where pgtype = float8
 instance PGTyped schema 'PGtext where pgtype = text
 instance (KnownNat n, 1 <= n)
-  => PGTyped schema ('PGchar n) where pgtype = char (Proxy @n)
+  => PGTyped schema ('PGchar n) where pgtype = char @n
 instance (KnownNat n, 1 <= n)
-  => PGTyped schema ('PGvarchar n) where pgtype = varchar (Proxy @n)
+  => PGTyped schema ('PGvarchar n) where pgtype = varchar @n
 instance PGTyped schema 'PGbytea where pgtype = bytea
 instance PGTyped schema 'PGtimestamp where pgtype = timestamp
 instance PGTyped schema 'PGtimestamptz where pgtype = timestampWithTimeZone

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -195,7 +195,7 @@ class KnownNat n => HasParameter
     -- >>> printSQL expr
     -- ($1 :: int4)
     parameter
-      :: TypeExpression schema (PGTypeOf ty)
+      :: TypeExpression schema ty
       -> Expression schema relations grouping params ty
     parameter ty = UnsafeExpression $ parenthesized $
       "$" <> renderNat (Proxy @n) <+> "::"
@@ -211,9 +211,9 @@ instance {-# OVERLAPPABLE #-} (KnownNat n, HasParameter (n-1) schema params ty)
 -- >>> printSQL expr
 -- ($1 :: int4)
 param
-  :: forall n schema params relations grouping ty
-   . (PGTyped schema (PGTypeOf ty), HasParameter n schema params ty)
-  => Expression schema relations grouping params ty -- ^ param
+  :: forall n schema params relations grouping nullity ty
+   . (PGTyped schema ty, HasParameter n schema params (nullity ty))
+  => Expression schema relations grouping params (nullity ty) -- ^ param
 param = parameter @n pgtype
 
 instance (HasUnique relation relations columns, Has column columns ty)
@@ -400,16 +400,16 @@ instance (KnownSymbol label, label `In` labels) => IsPGlabel label
 -- >>> printSQL i
 -- ROW(0, 1)
 row
-  :: SListI (Nulls fields)
-  => NP (Aliased (Expression schema relations grouping params)) (Nulls fields)
+  :: SListI fields
+  => NP (Aliased (Expression schema relations grouping params)) fields
   -- ^ zero or more expressions for the row field values
   -> Expression schema relations grouping params (nullity ('PGcomposite fields))
 row exprs = UnsafeExpression $ "ROW" <> parenthesized
   (renderCommaSeparated (\ (expr `As` _) -> renderExpression expr) exprs)
 
 instance Has field fields ty => IsLabel field
-  (   Expression schema relation grouping params (nullity ('PGcomposite fields))
-   -> Expression schema relation grouping params ('Null ty) ) where
+  (   Expression schema relation grouping params ('NotNull ('PGcomposite fields))
+   -> Expression schema relation grouping params ty ) where
     fromLabel expr = UnsafeExpression $
       parenthesized (renderExpression expr) <> "." <>
         fromString (symbolVal (Proxy @field))
@@ -1117,96 +1117,96 @@ type expressions
 -----------------------------------------}
 
 -- | `TypeExpression`s are used in `cast`s and `createTable` commands.
-newtype TypeExpression (schema :: SchemaType) (ty :: PGType)
+newtype TypeExpression (schema :: SchemaType) (ty :: NullityType)
   = UnsafeTypeExpression { renderTypeExpression :: ByteString }
   deriving (GHC.Generic,Show,Eq,Ord,NFData)
 
 instance (Has alias schema ('Typedef ty))
-  => IsLabel alias (TypeExpression schema ty) where
+  => IsLabel alias (TypeExpression schema (nullity ty)) where
     fromLabel = UnsafeTypeExpression (renderAlias (fromLabel @alias))
 
 -- | logical Boolean (true/false)
-bool :: TypeExpression schema 'PGbool
+bool :: TypeExpression schema (nullity 'PGbool)
 bool = UnsafeTypeExpression "bool"
 -- | signed two-byte integer
-int2, smallint :: TypeExpression schema 'PGint2
+int2, smallint :: TypeExpression schema (nullity 'PGint2)
 int2 = UnsafeTypeExpression "int2"
 smallint = UnsafeTypeExpression "smallint"
 -- | signed four-byte integer
-int4, int, integer :: TypeExpression schema 'PGint4
+int4, int, integer :: TypeExpression schema (nullity 'PGint4)
 int4 = UnsafeTypeExpression "int4"
 int = UnsafeTypeExpression "int"
 integer = UnsafeTypeExpression "integer"
 -- | signed eight-byte integer
-int8, bigint :: TypeExpression schema 'PGint8
+int8, bigint :: TypeExpression schema (nullity 'PGint8)
 int8 = UnsafeTypeExpression "int8"
 bigint = UnsafeTypeExpression "bigint"
 -- | arbitrary precision numeric type
-numeric :: TypeExpression schema 'PGnumeric
+numeric :: TypeExpression schema (nullity 'PGnumeric)
 numeric = UnsafeTypeExpression "numeric"
 -- | single precision floating-point number (4 bytes)
-float4, real :: TypeExpression schema 'PGfloat4
+float4, real :: TypeExpression schema (nullity 'PGfloat4)
 float4 = UnsafeTypeExpression "float4"
 real = UnsafeTypeExpression "real"
 -- | double precision floating-point number (8 bytes)
-float8, doublePrecision :: TypeExpression schema 'PGfloat8
+float8, doublePrecision :: TypeExpression schema (nullity 'PGfloat8)
 float8 = UnsafeTypeExpression "float8"
 doublePrecision = UnsafeTypeExpression "double precision"
 -- | variable-length character string
-text :: TypeExpression schema 'PGtext
+text :: TypeExpression schema (nullity 'PGtext)
 text = UnsafeTypeExpression "text"
 -- | fixed-length character string
 char, character
   :: (KnownNat n, 1 <= n)
   => proxy n
-  -> TypeExpression schema ('PGchar n)
+  -> TypeExpression schema (nullity ('PGchar n))
 char p = UnsafeTypeExpression $ "char(" <> renderNat p <> ")"
 character p = UnsafeTypeExpression $  "character(" <> renderNat p <> ")"
 -- | variable-length character string
 varchar, characterVarying
   :: (KnownNat n, 1 <= n)
   => proxy n
-  -> TypeExpression schema ('PGvarchar n)
+  -> TypeExpression schema (nullity ('PGvarchar n))
 varchar p = UnsafeTypeExpression $ "varchar(" <> renderNat p <> ")"
 characterVarying p = UnsafeTypeExpression $
   "character varying(" <> renderNat p <> ")"
 -- | binary data ("byte array")
-bytea :: TypeExpression schema 'PGbytea
+bytea :: TypeExpression schema (nullity 'PGbytea)
 bytea = UnsafeTypeExpression "bytea"
 -- | date and time (no time zone)
-timestamp :: TypeExpression schema 'PGtimestamp
+timestamp :: TypeExpression schema (nullity 'PGtimestamp)
 timestamp = UnsafeTypeExpression "timestamp"
 -- | date and time, including time zone
-timestampWithTimeZone :: TypeExpression schema 'PGtimestamptz
+timestampWithTimeZone :: TypeExpression schema (nullity 'PGtimestamptz)
 timestampWithTimeZone = UnsafeTypeExpression "timestamp with time zone"
 -- | calendar date (year, month, day)
-date :: TypeExpression schema 'PGdate
+date :: TypeExpression schema (nullity 'PGdate)
 date = UnsafeTypeExpression "date"
 -- | time of day (no time zone)
-time :: TypeExpression schema 'PGtime
+time :: TypeExpression schema (nullity 'PGtime)
 time = UnsafeTypeExpression "time"
 -- | time of day, including time zone
-timeWithTimeZone :: TypeExpression schema 'PGtimetz
+timeWithTimeZone :: TypeExpression schema (nullity 'PGtimetz)
 timeWithTimeZone = UnsafeTypeExpression "time with time zone"
 -- | time span
-interval :: TypeExpression schema 'PGinterval
+interval :: TypeExpression schema (nullity 'PGinterval)
 interval = UnsafeTypeExpression "interval"
 -- | universally unique identifier
-uuid :: TypeExpression schema 'PGuuid
+uuid :: TypeExpression schema (nullity 'PGuuid)
 uuid = UnsafeTypeExpression "uuid"
 -- | IPv4 or IPv6 host address
-inet :: TypeExpression schema 'PGinet
+inet :: TypeExpression schema (nullity 'PGinet)
 inet = UnsafeTypeExpression "inet"
 -- | textual JSON data
-json :: TypeExpression schema 'PGjson
+json :: TypeExpression schema (nullity 'PGjson)
 json = UnsafeTypeExpression "json"
 -- | binary JSON data, decomposed
-jsonb :: TypeExpression schema 'PGjsonb
+jsonb :: TypeExpression schema (nullity 'PGjsonb)
 jsonb = UnsafeTypeExpression "jsonb"
 -- | variable length array
 vararray
   :: TypeExpression schema pg
-  -> TypeExpression schema ('PGvararray (nullity pg))
+  -> TypeExpression schema (nullity ('PGvararray pg))
 vararray ty = UnsafeTypeExpression $ renderTypeExpression ty <> "[]"
 -- | fixed length array
 --
@@ -1215,12 +1215,12 @@ vararray ty = UnsafeTypeExpression $ renderTypeExpression ty <> "[]"
 fixarray
   :: forall n schema nullity pg. KnownNat n
   => TypeExpression schema pg
-  -> TypeExpression schema ('PGfixarray n (nullity pg))
+  -> TypeExpression schema (nullity ('PGfixarray n pg))
 fixarray ty = UnsafeTypeExpression $
   renderTypeExpression ty <> "[" <> renderNat (Proxy @n) <> "]"
 
 -- | `pgtype` is a demoted version of a `PGType`
-class PGTyped schema (ty :: PGType) where pgtype :: TypeExpression schema ty
+class PGTyped schema (ty :: PGType) where pgtype :: TypeExpression schema (nullity ty)
 instance PGTyped schema 'PGbool where pgtype = bool
 instance PGTyped schema 'PGint2 where pgtype = int2
 instance PGTyped schema 'PGint4 where pgtype = int4

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -417,7 +417,7 @@ instance Has field fields ty => IsLabel field
    -> Expression schema relation grouping params ty ) where
     fromLabel expr = UnsafeExpression $
       parenthesized (renderExpression expr) <> "." <>
-        fromString (symbolVal (Proxy @field))
+        renderSymbol @field
 
 instance Semigroup
   (Expression schema relations grouping params (nullity ('PGvararray ty))) where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -211,9 +211,9 @@ instance {-# OVERLAPPABLE #-} (KnownNat n, HasParameter (n-1) schema params ty)
 -- >>> printSQL expr
 -- ($1 :: int4)
 param
-  :: forall n schema params relations grouping nullity ty
-   . (PGTyped schema ty, HasParameter n schema params (nullity ty))
-  => Expression schema relations grouping params (nullity ty) -- ^ param
+  :: forall n schema params relations grouping ty
+   . (PGTyped schema ty, HasParameter n schema params ty)
+  => Expression schema relations grouping params ty -- ^ param
 param = parameter @n pgtype
 
 instance (HasUnique relation relations columns, Has column columns ty)
@@ -1223,32 +1223,33 @@ fixarray ty = UnsafeTypeExpression $
   renderTypeExpression ty <> "[" <> renderNat @n <> "]"
 
 -- | `pgtype` is a demoted version of a `PGType`
-class PGTyped schema (ty :: PGType) where pgtype :: TypeExpression schema (nullity ty)
-instance PGTyped schema 'PGbool where pgtype = bool
-instance PGTyped schema 'PGint2 where pgtype = int2
-instance PGTyped schema 'PGint4 where pgtype = int4
-instance PGTyped schema 'PGint8 where pgtype = int8
-instance PGTyped schema 'PGnumeric where pgtype = numeric
-instance PGTyped schema 'PGfloat4 where pgtype = float4
-instance PGTyped schema 'PGfloat8 where pgtype = float8
-instance PGTyped schema 'PGtext where pgtype = text
+class PGTyped schema (ty :: NullityType) where
+  pgtype :: TypeExpression schema ty
+instance PGTyped schema (nullity 'PGbool) where pgtype = bool
+instance PGTyped schema (nullity 'PGint2) where pgtype = int2
+instance PGTyped schema (nullity 'PGint4) where pgtype = int4
+instance PGTyped schema (nullity 'PGint8) where pgtype = int8
+instance PGTyped schema (nullity 'PGnumeric) where pgtype = numeric
+instance PGTyped schema (nullity 'PGfloat4) where pgtype = float4
+instance PGTyped schema (nullity 'PGfloat8) where pgtype = float8
+instance PGTyped schema (nullity 'PGtext) where pgtype = text
 instance (KnownNat n, 1 <= n)
-  => PGTyped schema ('PGchar n) where pgtype = char @n
+  => PGTyped schema (nullity ('PGchar n)) where pgtype = char @n
 instance (KnownNat n, 1 <= n)
-  => PGTyped schema ('PGvarchar n) where pgtype = varchar @n
-instance PGTyped schema 'PGbytea where pgtype = bytea
-instance PGTyped schema 'PGtimestamp where pgtype = timestamp
-instance PGTyped schema 'PGtimestamptz where pgtype = timestampWithTimeZone
-instance PGTyped schema 'PGdate where pgtype = date
-instance PGTyped schema 'PGtime where pgtype = time
-instance PGTyped schema 'PGtimetz where pgtype = timeWithTimeZone
-instance PGTyped schema 'PGinterval where pgtype = interval
-instance PGTyped schema 'PGuuid where pgtype = uuid
-instance PGTyped schema 'PGjson where pgtype = json
-instance PGTyped schema 'PGjsonb where pgtype = jsonb
+  => PGTyped schema (nullity ('PGvarchar n)) where pgtype = varchar @n
+instance PGTyped schema (nullity 'PGbytea) where pgtype = bytea
+instance PGTyped schema (nullity 'PGtimestamp) where pgtype = timestamp
+instance PGTyped schema (nullity 'PGtimestamptz) where pgtype = timestampWithTimeZone
+instance PGTyped schema (nullity 'PGdate) where pgtype = date
+instance PGTyped schema (nullity 'PGtime) where pgtype = time
+instance PGTyped schema (nullity 'PGtimetz) where pgtype = timeWithTimeZone
+instance PGTyped schema (nullity 'PGinterval) where pgtype = interval
+instance PGTyped schema (nullity 'PGuuid) where pgtype = uuid
+instance PGTyped schema (nullity 'PGjson) where pgtype = json
+instance PGTyped schema (nullity 'PGjsonb) where pgtype = jsonb
 instance PGTyped schema ty
-  => PGTyped schema ('PGvararray (nullity ty)) where
+  => PGTyped schema (nullity ('PGvararray ty)) where
     pgtype = vararray (pgtype @schema @ty)
 instance (KnownNat n, PGTyped schema ty)
-  => PGTyped schema ('PGfixarray n (nullity ty)) where
+  => PGTyped schema (nullity ('PGfixarray n ty)) where
     pgtype = fixarray @n (pgtype @schema @ty)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -395,7 +395,12 @@ instance (KnownSymbol label, label `In` labels) => IsPGlabel label
 -- | A row constructor is an expression that builds a row value
 -- (also called a composite value) using values for its member fields.
 --
--- >>> type Complex = PGcomposite '["real" ::: 'PGfloat8, "imaginary" ::: 'PGfloat8]
+-- >>> :{
+-- type Complex = 'PGcomposite
+--   '[ "real"      ::: 'NotNull 'PGfloat8
+--    , "imaginary" ::: 'NotNull 'PGfloat8 ]
+-- :}
+--
 -- >>> let i = row (0 `as` #real :* 1 `as` #imaginary) :: Expression '[] '[] 'Ungrouped '[] ('NotNull Complex)
 -- >>> printSQL i
 -- ROW(0, 1)
@@ -542,9 +547,9 @@ atan2_ y x = UnsafeExpression $
 cast
   :: TypeExpression schema ty1
   -- ^ type to cast as
-  -> Expression schema relations grouping params (nullity ty0)
+  -> Expression schema relations grouping params ty0
   -- ^ value to convert
-  -> Expression schema relations grouping params (nullity ty1)
+  -> Expression schema relations grouping params ty1
 cast ty x = UnsafeExpression $ parenthesized $
   renderExpression x <+> "::" <+> renderTypeExpression ty
 
@@ -1208,7 +1213,7 @@ vararray
 vararray ty = UnsafeTypeExpression $ renderTypeExpression ty <> "[]"
 -- | fixed length array
 --
--- >>> renderTypeExpression (fixarray (Proxy @2) json)
+-- >>> renderTypeExpression (fixarray @2 json)
 -- "json[2]"
 fixarray
   :: forall n schema nullity pg. KnownNat n

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
@@ -9,12 +9,14 @@ Rendering helper functions.
 -}
 
 {-# LANGUAGE
-    FlexibleContexts
+    AllowAmbiguousTypes
+  , FlexibleContexts
   , MagicHash
   , OverloadedStrings
   , PolyKinds
   , RankNTypes
   , ScopedTypeVariables
+  , TypeApplications
 #-}
 
 module Squeal.PostgreSQL.Render
@@ -80,8 +82,8 @@ renderCommaSeparatedMaybe render
   . hmap (K . render)
 
 -- | Render a promoted `Nat`.
-renderNat :: KnownNat n => proxy n -> ByteString
-renderNat (_ :: proxy n) = fromString (show (natVal' (proxy# :: Proxy# n)))
+renderNat :: forall n. KnownNat n => ByteString
+renderNat = fromString (show (natVal (Proxy @n)))
 
 -- | A class for rendering SQL
 class RenderSQL sql where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
@@ -28,6 +28,7 @@ module Squeal.PostgreSQL.Render
   , renderCommaSeparated
   , renderCommaSeparatedMaybe
   , renderNat
+  , renderSymbol
   , RenderSQL (..)
   , printSQL
   ) where
@@ -83,7 +84,11 @@ renderCommaSeparatedMaybe render
 
 -- | Render a promoted `Nat`.
 renderNat :: forall n. KnownNat n => ByteString
-renderNat = fromString (show (natVal (Proxy @n)))
+renderNat = fromString (show (natVal' (proxy# :: Proxy# n)))
+
+-- | Render a promoted `Symbol`.
+renderSymbol :: forall s. KnownSymbol s => ByteString
+renderSymbol = fromString (symbolVal' (proxy# :: Proxy# s))
 
 -- | A class for rendering SQL
 class RenderSQL sql where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -735,7 +735,7 @@ type family LabelsFrom (hask :: Type) :: [Type.ConstructorName] where
 -- >>> instance HasDatatypeInfo Row
 -- >>> :kind! CompositeFrom Row
 -- CompositeFrom Row :: PGType
--- = 'PGcomposite '['("a", 'PGint2), '("b", 'PGtimestamp)]
+-- = 'PGcomposite '["a" ::: 'Null 'PGint2, "b" ::: 'Null 'PGtimestamp]
 type family CompositeFrom (hask :: Type) :: PGType where
   CompositeFrom hask = 'PGcomposite (PGFieldsFrom hask)
 

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -88,7 +88,6 @@ module Squeal.PostgreSQL.Schema
   , PGNum
   , PGIntegral
   , PGFloating
-  , PGTypeOf
   , SameTypes
   , SamePGType
   , AllNotNull
@@ -488,10 +487,6 @@ type PGFloating ty = In ty '[ 'PGfloat4, 'PGfloat8, 'PGnumeric]
 -- have `Squeal.PostgreSQL.Expression.div_` and
 -- `Squeal.PostgreSQL.Expression.mod_` functions.
 type PGIntegral ty = In ty '[ 'PGint2, 'PGint4, 'PGint8]
-
--- | `PGTypeOf` forgets about @NULL@ and any column constraints.
-type family PGTypeOf (ty :: NullityType) :: PGType where
-  PGTypeOf (nullity pg) = pg
 
 -- | `SameTypes` is a constraint that proves two `ColumnsType`s have the same
 -- length and the same `ColumnType`s.

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -174,8 +174,8 @@ data PGType
   | PGinet -- ^ IPv4 or IPv6 host address
   | PGjson -- ^	textual JSON data
   | PGjsonb -- ^ binary JSON data, decomposed
-  | PGvararray PGType -- ^ variable length array
-  | PGfixarray Nat PGType -- ^ fixed length array
+  | PGvararray NullityType -- ^ variable length array
+  | PGfixarray Nat NullityType -- ^ fixed length array
   | PGenum [Symbol] -- ^ enumerated (enum) types are data types that comprise a static, ordered set of values.
   | PGcomposite [(Symbol, PGType)] -- ^ a composite type represents the structure of a row or record; it is essentially just a list of field names and their data types.
   | UnsafePGType Symbol -- ^ an escape hatch for unsupported PostgreSQL types

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -632,7 +632,7 @@ data PGlabel (label :: Symbol) = PGlabel
 -- | Renders a label
 renderLabel :: KnownSymbol label => proxy label -> ByteString
 renderLabel (_ :: proxy label) =
-  "\'" <> fromString (symbolVal (Proxy @label)) <> "\'"
+  "\'" <> renderSymbol @label <> "\'"
 -- | Renders a list of labels
 renderLabels
   :: All KnownSymbol labels => NP PGlabel labels -> [ByteString]

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -111,8 +111,6 @@ module Squeal.PostgreSQL.Schema
   , ConstructorsOf
   , ConstructorNameOf
   , ConstructorNamesOf
-  , MapMaybes (..)
-  , Nulls
   ) where
 
 import Control.DeepSeq
@@ -583,26 +581,6 @@ type family Alter alias x xs where
 type family Rename alias0 alias1 xs where
   Rename alias0 alias1 ((alias0 ::: x0) ': xs) = (alias1 ::: x0) ': xs
   Rename alias0 alias1 (x ': xs) = x ': Rename alias0 alias1 xs
-
--- | `MapMaybes` is used in the binary instances of composite types.
-class MapMaybes xs where
-  type family Maybes (xs :: [Type]) = (mxs :: [Type]) | mxs -> xs
-  maybes :: NP Maybe xs -> NP I (Maybes xs)
-  unMaybes :: NP I (Maybes xs) -> NP Maybe xs
-instance MapMaybes '[] where
-  type Maybes '[] = '[]
-  maybes Nil = Nil
-  unMaybes Nil = Nil
-instance MapMaybes xs => MapMaybes (x ': xs) where
-  type Maybes (x ': xs) = Maybe x ': Maybes xs
-  maybes (x :* xs) = I x :* maybes xs
-  unMaybes (I mx :* xs) = mx :* unMaybes xs
-
--- | `Nulls` is used to construct a `Squeal.Postgresql.Expression.row`
--- of a composite type.
-type family Nulls tys where
-  Nulls '[] = '[]
-  Nulls (field ::: ty ': tys) = field ::: 'Null ty ': Nulls tys
 
 -- | Check if a `TableConstraint` involves a column
 type family ConstraintInvolves column constraint where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -176,8 +176,8 @@ data PGType
   | PGjsonb -- ^ binary JSON data, decomposed
   | PGvararray PGType -- ^ variable length array
   | PGfixarray Nat PGType -- ^ fixed length array
-  | PGenum [Symbol]
-  | PGcomposite [(Symbol, PGType)]
+  | PGenum [Symbol] -- ^ enumerated (enum) types are data types that comprise a static, ordered set of values.
+  | PGcomposite [(Symbol, PGType)] -- ^ a composite type represents the structure of a row or record; it is essentially just a list of field names and their data types.
   | UnsafePGType Symbol -- ^ an escape hatch for unsupported PostgreSQL types
 
 -- | The object identifier of a `PGType`.

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,5 @@
 resolver: lts-11.15
 packages:
 - squeal-postgresql
+extra-deps:
+- records-sop-0.1.0.0


### PR DESCRIPTION
This PR adds more null safety to container types such as arrays and composites. Additionally, generic record logic was offloaded to the `records-sop` package and some functions which take proxy arguments had there arguments removed in favor of type application.