### PR TITLE
Require update values to be ordered subset of row, remove Same

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
@@ -16,7 +16,6 @@ Rendering helper functions.
   , PolyKinds
   , RankNTypes
   , ScopedTypeVariables
-  , TypeApplications
 #-}
 
 module Squeal.PostgreSQL.Render
@@ -28,7 +27,6 @@ module Squeal.PostgreSQL.Render
   , singleQuotedText
   , singleQuotedUtf8
   , renderCommaSeparated
-  , renderCommaSeparatedMaybe
   , renderNat
   , renderSymbol
   , RenderSQL (..)
@@ -37,7 +35,6 @@ module Squeal.PostgreSQL.Render
 
 import Control.Monad.Base
 import Data.ByteString (ByteString)
-import Data.Maybe
 import Data.Monoid ((<>))
 import Data.Text (Text)
 import Generics.SOP
@@ -80,18 +77,6 @@ renderCommaSeparated
   -> NP expression xs -> ByteString
 renderCommaSeparated render
   = commaSeparated
-  . hcollapse
-  . hmap (K . render)
-
--- | Comma separate the `Maybe` renderings of a heterogeneous list, dropping
--- `Nothing`s.
-renderCommaSeparatedMaybe
-  :: SListI xs
-  => (forall x. expression x -> Maybe ByteString)
-  -> NP expression xs -> ByteString
-renderCommaSeparatedMaybe render
-  = commaSeparated
-  . catMaybes
   . hcollapse
   . hmap (K . render)
 


### PR DESCRIPTION
This is another breaking change (sorry) which improves a couple of issues I've run into via the power of 5 (!) new language extensions:

- Updates for tables with more than a small number of columns require many `Same` expressions, which can get noisy
- An `update` or `OnConflictDoUpdate` where every `ColumnValue` is `Same` produces invalid syntax

I was wary that this may result in new ambiguous type errors, but I've yet to notice any.