### PR TITLE
Add support for `DELETE FROM table USING`

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -281,7 +281,7 @@ insertMigration = insertRow_ #schema_migrations
 deleteMigration
   :: Has "schema_migrations" schema ('Table MigrationsTable)
   => Manipulation schema '[ 'NotNull 'PGtext ] '[]
-deleteMigration = deleteFrom_ #schema_migrations (#name .== param @1)
+deleteMigration = deleteFrom_ #schema_migrations NoUsing (#name .== param @1)
 
 -- | Selects a `Migration` from the `MigrationsTable`, returning
 -- the time at which it was executed.


### PR DESCRIPTION
Solution suggested for #71.

This solution is rather redundant with some of the functions that are already available, but I didn't want to risk breaking compability. I would really like to avoid having to resort to the `deleteTarget` but couldn't find a way to avoid it.

Maybe you'll have pointers as to how to improve this.