### PR TITLE
Add a `Selection` type and more `RenderSQL` instances

### DIFF
--- a/squeal-postgresql/exe/Example.hs
+++ b/squeal-postgresql/exe/Example.hs
@@ -68,12 +68,11 @@ insertUser :: Manipulation DB '[ 'NotNull 'PGtext, 'NotNull ('PGvararray ('Null 
   '[ "fromOnly" ::: 'NotNull 'PGint4 ]
 insertUser = insertInto #users
   (Values_ (defaultAs #id :* param @1 `as` #name :* param @2 `as` #vec))
-  (OnConflict (OnConstraint #pk_users) DoNothing) (Returning (#id `as` #fromOnly))
+  (OnConflict (OnConstraint #pk_users) DoNothing) (Returning_ (#id `as` #fromOnly))
 
 insertEmail :: Manipulation DB '[ 'NotNull 'PGint4, 'Null 'PGtext] '[]
-insertEmail = insertInto #emails
+insertEmail = insertInto_ #emails
   (Values_ (defaultAs #id :* param @1 `as` #user_id :* param @2 `as` #email))
-  (OnConflict (OnConstraint #pk_emails) DoNothing) (Returning Nil)
 
 getUsers :: Query DB '[]
   '[ "userName" ::: 'NotNull 'PGtext

--- a/squeal-postgresql/exe/Example.hs
+++ b/squeal-postgresql/exe/Example.hs
@@ -79,7 +79,7 @@ getUsers :: Query DB '[]
   '[ "userName" ::: 'NotNull 'PGtext
    , "userEmail" ::: 'Null 'PGtext
    , "userVec" ::: 'NotNull ('PGvararray ('Null 'PGint2))]
-getUsers = select
+getUsers = select_
   (#u ! #name `as` #userName :* #e ! #email `as` #userEmail :* #u ! #vec `as` #userVec)
   ( from (table (#users `as` #u)
     & innerJoin (table (#emails `as` #e))

--- a/squeal-postgresql/src/Squeal/PostgreSQL.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL.hs
@@ -123,7 +123,7 @@ let
     where
       u = insertInto #users
         (Values_ (defaultAs #id :* param @1 `as` #name))
-        OnConflictDoRaise (Returning (#id :* param @2 `as` #email))
+        OnConflictDoRaise (Returning_ (#id :* param @2 `as` #email))
       e = insertInto_ #emails
         (Select (defaultAs #id :* #u ! #id `as` #user_id :* #u ! #email) (from (common #u)))
 :}
@@ -141,7 +141,7 @@ let
   getUsers :: Query DB '[]
     '[ "userName"  ::: 'NotNull 'PGtext
      , "userEmail" :::    'Null 'PGtext ]
-  getUsers = select
+  getUsers = select_
     (#u ! #name `as` #userName :* #e ! #email `as` #userEmail)
     ( from (table (#users `as` #u)
       & innerJoin (table (#emails `as` #e))

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -296,7 +296,7 @@ check
      , HasAll aliases (TableToRow table) subcolumns )
   => NP Alias aliases
   -- ^ specify the subcolumns which are getting checked
-  -> (forall t. Condition ('[] :=> schemas) '[t ::: subcolumns] 'Ungrouped '[])
+  -> (forall t. Condition ('[] :=> schemas) '[] 'Ungrouped '[t ::: subcolumns])
   -- ^ a closed `Condition` on those subcolumns
   -> TableConstraintExpression sch tab schemas ('Check aliases)
 check _cols condition = UnsafeTableConstraintExpression $

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -331,7 +331,7 @@ unique
   -- ^ specify subcolumns which together are unique for each row
   -> TableConstraintExpression sch tab schemas ('Unique aliases)
 unique columns = UnsafeTableConstraintExpression $
-  "UNIQUE" <+> parenthesized (commaSeparated (renderAliases columns))
+  "UNIQUE" <+> parenthesized (renderSQL columns)
 
 {-| A `primaryKey` constraint indicates that a column, or group of columns,
 can be used as a unique identifier for rows in the table.
@@ -366,7 +366,7 @@ primaryKey
   -- ^ specify the subcolumns which together form a primary key.
   -> TableConstraintExpression sch tab schemas ('PrimaryKey aliases)
 primaryKey columns = UnsafeTableConstraintExpression $
-  "PRIMARY KEY" <+> parenthesized (commaSeparated (renderAliases columns))
+  "PRIMARY KEY" <+> parenthesized (renderSQL columns)
 
 {-| A `foreignKey` specifies that the values in a column
 (or a group of columns) must match the values appearing in some row of
@@ -460,9 +460,9 @@ foreignKey
   -> TableConstraintExpression sch child schemas
       ('ForeignKey columns parent refcolumns)
 foreignKey keys parent refs ondel onupd = UnsafeTableConstraintExpression $
-  "FOREIGN KEY" <+> parenthesized (commaSeparated (renderAliases keys))
+  "FOREIGN KEY" <+> parenthesized (renderSQL keys)
   <+> "REFERENCES" <+> renderSQL parent
-  <+> parenthesized (commaSeparated (renderAliases refs))
+  <+> parenthesized (renderSQL refs)
   <+> renderSQL ondel
   <+> renderSQL onupd
 
@@ -935,7 +935,7 @@ createTypeComposite ty fields = UnsafeDefinition $
   where
     renderField :: Aliased (TypeExpression schemas) x -> ByteString
     renderField (typ `As` alias) =
-      renderSQL alias <+> renderTypeExpression typ
+      renderSQL alias <+> renderSQL typ
 
 -- | Composite types can also be generated from a Haskell type, for example
 --
@@ -995,14 +995,14 @@ instance RenderSQL (ColumnTypeExpression schemas ty) where
 nullable
   :: TypeExpression schemas (nullity ty)
   -> ColumnTypeExpression schemas ('NoDef :=> 'Null ty)
-nullable ty = UnsafeColumnTypeExpression $ renderTypeExpression ty <+> "NULL"
+nullable ty = UnsafeColumnTypeExpression $ renderSQL ty <+> "NULL"
 
 -- | used in `createTable` commands as a column constraint to ensure
 -- @NULL@ is not present in a column
 notNullable
   :: TypeExpression schemas (nullity ty)
   -> ColumnTypeExpression schemas ('NoDef :=> 'NotNull ty)
-notNullable ty = UnsafeColumnTypeExpression $ renderTypeExpression ty <+> "NOT NULL"
+notNullable ty = UnsafeColumnTypeExpression $ renderSQL ty <+> "NOT NULL"
 
 -- | used in `createTable` commands as a column constraint to give a default
 default_

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -219,14 +219,14 @@ and other operations.
 -}
 newtype Expression
   (db :: DBType)
-  (from :: FromType)
-  (grouping :: Grouping)
   (params :: [NullityType])
+  (grp :: Grouping)
+  (from :: FromType)
   (ty :: NullityType)
     = UnsafeExpression { renderExpression :: ByteString }
     deriving (GHC.Generic,Show,Eq,Ord,NFData)
 
-instance RenderSQL (Expression db from grouping params ty) where
+instance RenderSQL (Expression db params grp from ty) where
   renderSQL = renderExpression
 
 {- | A `HasParameter` constraint is used to indicate a value that is
@@ -249,7 +249,7 @@ class KnownNat n => HasParameter
     -- ($1 :: int4)
     parameter
       :: TypeExpression schemas ty
-      -> Expression (commons :=> schemas) from grouping params ty
+      -> Expression (commons :=> schemas) params grp from ty
     parameter ty = UnsafeExpression $ parenthesized $
       "$" <> renderNat @n <+> "::"
         <+> renderTypeExpression ty
@@ -264,84 +264,84 @@ instance {-# OVERLAPPABLE #-} (KnownNat n, HasParameter (n-1) params ty)
 -- >>> printSQL expr
 -- ($1 :: int4)
 param
-  :: forall n db commons schemas params from grouping ty
+  :: forall n db commons schemas params from grp ty
    . (db ~ (commons :=> schemas), PGTyped schemas ty, HasParameter n params ty)
-  => Expression db from grouping params ty -- ^ param
+  => Expression db params grp from ty -- ^ param
 param = parameter @n (pgtype @schemas)
 
 instance (HasUnique tab from row, Has col row ty)
-  => IsLabel col (Expression db from 'Ungrouped params ty) where
+  => IsLabel col (Expression db params 'Ungrouped from ty) where
     fromLabel = UnsafeExpression $ renderAlias (Alias @col)
 instance (HasUnique tab from row, Has col row ty, column ~ (col ::: ty))
   => IsLabel col
-    (Aliased (Expression db from 'Ungrouped params) column) where
+    (Aliased (Expression db params 'Ungrouped from) column) where
     fromLabel = fromLabel @col `As` Alias
 instance (HasUnique tab from row, Has col row ty, columns ~ '[col ::: ty])
   => IsLabel col
-    (NP (Aliased (Expression db from 'Ungrouped params)) columns) where
+    (NP (Aliased (Expression db params 'Ungrouped from)) columns) where
     fromLabel = fromLabel @col :* Nil
 
 instance (Has tab from row, Has col row ty)
-  => IsQualified tab col (Expression db from 'Ungrouped params ty) where
+  => IsQualified tab col (Expression db params 'Ungrouped from ty) where
     tab ! col = UnsafeExpression $
       renderAlias tab <> "." <> renderAlias col
 instance (Has tab from row, Has col row ty, column ~ (col ::: ty))
   => IsQualified tab col
-    (Aliased (Expression db from 'Ungrouped params) column) where
+    (Aliased (Expression db params 'Ungrouped from) column) where
     tab ! col = tab ! col `As` col
 instance (Has tab from row, Has col row ty, columns ~ '[col ::: ty])
   => IsQualified tab col
-    (NP (Aliased (Expression db from 'Ungrouped params)) columns) where
+    (NP (Aliased (Expression db params 'Ungrouped from)) columns) where
     tab ! col = tab ! col :* Nil
 
 instance
-  ( HasUnique table from columns
-  , Has column columns ty
-  , GroupedBy table column bys
-  ) => IsLabel column
-    (Expression db from ('Grouped bys) params ty) where
-      fromLabel = UnsafeExpression $ renderAlias (Alias @column)
+  ( HasUnique tab from row
+  , Has col row ty
+  , GroupedBy tab col bys
+  ) => IsLabel col
+    (Expression db params ('Grouped bys) from ty) where
+      fromLabel = UnsafeExpression $ renderAlias (Alias @col)
 instance
-  ( HasUnique table from columns
-  , Has column columns ty
-  , GroupedBy table column bys
-  ) => IsLabel column
-    ( Aliased (Expression db from ('Grouped bys) params)
-      (column ::: ty) ) where
-      fromLabel = fromLabel @column `As` Alias @column
+  ( HasUnique tab from row
+  , Has col row ty
+  , GroupedBy tab col bys
+  , column ~ (col ::: ty)
+  ) => IsLabel col
+    (Aliased (Expression db params ('Grouped bys) from) column) where
+      fromLabel = fromLabel @col `As` Alias
 instance
-  ( HasUnique table from columns
-  , Has column columns ty
-  , GroupedBy table column bys
-  ) => IsLabel column
-    ( NP (Aliased (Expression db from ('Grouped bys) params))
-      '[column ::: ty] ) where
-      fromLabel = fromLabel @column :* Nil
+  ( HasUnique tab from row
+  , Has col row ty
+  , GroupedBy tab col bys
+  , columns ~ '[col ::: ty]
+  ) => IsLabel col
+    (NP (Aliased (Expression db params ('Grouped bys) from)) columns) where
+      fromLabel = fromLabel @col :* Nil
 
 instance
-  ( Has table from columns
-  , Has column columns ty
-  , GroupedBy table column bys
-  ) => IsQualified table column
-    (Expression db from ('Grouped bys) params ty) where
-      table ! column = UnsafeExpression $
-        renderAlias table <> "." <> renderAlias column
+  ( Has tab from row
+  , Has col row ty
+  , GroupedBy tab col bys
+  ) => IsQualified tab col
+    (Expression db params ('Grouped bys) from ty) where
+      tab ! col = UnsafeExpression $
+        renderAlias tab <> "." <> renderAlias col
 instance
-  ( Has table from columns
-  , Has column columns ty
-  , GroupedBy table column bys
-  ) => IsQualified table column
-    (Aliased (Expression db from ('Grouped bys) params)
-      (column ::: ty)) where
-        table ! column = table ! column `As` column
+  ( Has tab from row
+  , Has col row ty
+  , GroupedBy tab col bys
+  , column ~ (col ::: ty)
+  ) => IsQualified tab col
+    (Aliased (Expression db params ('Grouped bys) from) column) where
+      tab ! col = tab ! col `As` col
 instance
-  ( Has table from columns
-  , Has column columns ty
-  , GroupedBy table column bys
-  ) => IsQualified table column
-    ( NP (Aliased (Expression db from ('Grouped bys) params))
-      '[column ::: ty]) where
-        table ! column = table ! column :* Nil
+  ( Has tab from row
+  , Has col row ty
+  , GroupedBy tab col bys
+  , columns ~ '[col ::: ty]
+  ) => IsQualified tab col
+    (NP (Aliased (Expression db params ('Grouped bys) from)) columns) where
+      tab ! col = tab ! col :* Nil
 
 -- | analagous to `Nothing`
 --
@@ -364,11 +364,11 @@ notNull = UnsafeExpression . renderExpression
 -- >>> printSQL $ coalesce [null_, true] false
 -- COALESCE(NULL, TRUE, FALSE)
 coalesce
-  :: [Expression db from grouping params ('Null ty)]
+  :: [Expression db params grp from ('Null ty)]
   -- ^ @NULL@s may be present
-  -> Expression db from grouping params ('NotNull ty)
+  -> Expression db params grp from ('NotNull ty)
   -- ^ @NULL@ is absent
-  -> Expression db from grouping params ('NotNull ty)
+  -> Expression db params grp from ('NotNull ty)
 coalesce nullxs notNullx = UnsafeExpression $
   "COALESCE" <> parenthesized (commaSeparated
     ((renderExpression <$> nullxs) <> [renderExpression notNullx]))
@@ -378,26 +378,26 @@ coalesce nullxs notNullx = UnsafeExpression $
 -- >>> printSQL $ fromNull true null_
 -- COALESCE(NULL, TRUE)
 fromNull
-  :: Expression db from grouping params ('NotNull ty)
+  :: Expression db params grp from ('NotNull ty)
   -- ^ what to convert @NULL@ to
-  -> Expression db from grouping params ('Null ty)
-  -> Expression db from grouping params ('NotNull ty)
+  -> Expression db params grp from ('Null ty)
+  -> Expression db params grp from ('NotNull ty)
 fromNull notNullx nullx = coalesce [nullx] notNullx
 
 -- | >>> printSQL $ null_ & isNull
 -- NULL IS NULL
 isNull
-  :: Expression db from grouping params ('Null ty)
+  :: Expression db params grp from ('Null ty)
   -- ^ possibly @NULL@
-  -> Condition db from grouping params
+  -> Condition db params grp from
 isNull x = UnsafeExpression $ renderExpression x <+> "IS NULL"
 
 -- | >>> printSQL $ null_ & isNotNull
 -- NULL IS NOT NULL
 isNotNull
-  :: Expression db from grouping params ('Null ty)
+  :: Expression db params grp from ('Null ty)
   -- ^ possibly @NULL@
-  -> Condition db from grouping params
+  -> Condition db params grp from
 isNotNull x = UnsafeExpression $ renderExpression x <+> "IS NOT NULL"
 
 -- | analagous to `maybe` using @IS NULL@
@@ -405,13 +405,13 @@ isNotNull x = UnsafeExpression $ renderExpression x <+> "IS NOT NULL"
 -- >>> printSQL $ matchNull true not_ null_
 -- CASE WHEN NULL IS NULL THEN TRUE ELSE (NOT NULL) END
 matchNull
-  :: Expression db from grouping params (nullty)
+  :: Expression db params grp from (nullty)
   -- ^ what to convert @NULL@ to
-  -> ( Expression db from grouping params ('NotNull ty)
-       -> Expression db from grouping params (nullty) )
+  -> ( Expression db params grp from ('NotNull ty)
+       -> Expression db params grp from (nullty) )
   -- ^ function to perform when @NULL@ is absent
-  -> Expression db from grouping params ('Null ty)
-  -> Expression db from grouping params (nullty)
+  -> Expression db params grp from ('Null ty)
+  -> Expression db params grp from (nullty)
 matchNull y f x = ifThenElse (isNull x) y
   (f (UnsafeExpression (renderExpression x)))
 
@@ -424,20 +424,20 @@ matchNull y f x = ifThenElse (isNull x) y
 NULL IF (FALSE, ($1 :: bool))
 -}
 nullIf
-  :: Expression db from grouping params ('NotNull ty)
+  :: Expression db params grp from ('NotNull ty)
   -- ^ @NULL@ is absent
-  -> Expression db from grouping params ('NotNull ty)
+  -> Expression db params grp from ('NotNull ty)
   -- ^ @NULL@ is absent
-  -> Expression db from grouping params ('Null ty)
+  -> Expression db params grp from ('Null ty)
 nullIf x y = UnsafeExpression $ "NULL IF" <+> parenthesized
   (renderExpression x <> ", " <> renderExpression y)
 
 -- | >>> printSQL $ array [null_, false, true]
 -- ARRAY[NULL, FALSE, TRUE]
 array
-  :: [Expression db from grouping params ty]
+  :: [Expression db params grp from ty]
   -- ^ array elements
-  -> Expression db from grouping params (nullity ('PGvararray ty))
+  -> Expression db params grp from (nullity ('PGvararray ty))
 array xs = UnsafeExpression $
   "ARRAY[" <> commaSeparated (renderExpression <$> xs) <> "]"
 
@@ -445,13 +445,13 @@ array xs = UnsafeExpression $
 -- (ARRAY[NULL, FALSE, TRUE])[2]
 index
   :: Word64 -- ^ index
-  -> Expression db from grouping params (nullity ('PGvararray ty)) -- ^ array
-  -> Expression db from grouping params (NullifyType ty)
+  -> Expression db params grp from (nullity ('PGvararray ty)) -- ^ array
+  -> Expression db params grp from (NullifyType ty)
 index n expr = UnsafeExpression $
   parenthesized (renderExpression expr) <> "[" <> fromString (show n) <> "]"
 
 instance (KnownSymbol label, label `In` labels) => IsPGlabel label
-  (Expression db from grouping params (nullity ('PGenum labels))) where
+  (Expression db params grp from (nullity ('PGenum labels))) where
   label = UnsafeExpression $ renderLabel (PGlabel @label)
 
 -- | A row constructor is an expression that builds a row value
@@ -468,9 +468,9 @@ instance (KnownSymbol label, label `In` labels) => IsPGlabel label
 -- ROW(0, 1)
 row
   :: SListI row
-  => NP (Aliased (Expression db from grouping params)) row
+  => NP (Aliased (Expression db params grp from)) row
   -- ^ zero or more expressions for the row field values
-  -> Expression db from grouping params (nullity ('PGcomposite row))
+  -> Expression db params grp from (nullity ('PGcomposite row))
 row exprs = UnsafeExpression $ "ROW" <> parenthesized
   (renderCommaSeparated (\ (expr `As` _) -> renderExpression expr) exprs)
 
@@ -491,18 +491,18 @@ field
      , Has field row ty)
   => QualifiedAlias sch tydef -- ^ row type
   -> Alias field -- ^ field name
-  -> Expression (commons :=> schemas) from grouping params ('NotNull ('PGcomposite row))
-  -> Expression (commons :=> schemas) from grouping params ty
+  -> Expression (commons :=> schemas) params grp from ('NotNull ('PGcomposite row))
+  -> Expression (commons :=> schemas) params grp from ty
 field td fld expr = UnsafeExpression $
   parenthesized (renderExpression expr <> "::" <> renderQualifiedAlias td)
     <> "." <> renderAlias fld
 
 instance Semigroup
-  (Expression db from grouping params (nullity ('PGvararray ty))) where
+  (Expression db params grp from (nullity ('PGvararray ty))) where
     (<>) = unsafeBinaryOp "||"
 
 instance Monoid
-  (Expression db from grouping params (nullity ('PGvararray ty))) where
+  (Expression db params grp from (nullity ('PGvararray ty))) where
     mempty = array []
     mappend = (<>)
 
@@ -510,22 +510,22 @@ instance Monoid
 -- >>> printSQL expr
 -- GREATEST(CURRENT_TIMESTAMP, ($1 :: timestamp with time zone))
 greatest
-  :: Expression db from grouping params (nullty)
+  :: Expression db params grp from (nullty)
   -- ^ needs at least 1 argument
-  -> [Expression db from grouping params (nullty)]
+  -> [Expression db params grp from (nullty)]
   -- ^ or more
-  -> Expression db from grouping params (nullty)
+  -> Expression db params grp from (nullty)
 greatest x xs = UnsafeExpression $ "GREATEST("
   <> commaSeparated (renderExpression <$> (x:xs)) <> ")"
 
 -- | >>> printSQL $ least currentTimestamp [null_]
 -- LEAST(CURRENT_TIMESTAMP, NULL)
 least
-  :: Expression db from grouping params (nullty)
+  :: Expression db params grp from (nullty)
   -- ^ needs at least 1 argument
-  -> [Expression db from grouping params (nullty)]
+  -> [Expression db params grp from (nullty)]
   -- ^ or more
-  -> Expression db from grouping params (nullty)
+  -> Expression db params grp from (nullty)
 least x xs = UnsafeExpression $ "LEAST("
   <> commaSeparated (renderExpression <$> (x:xs)) <> ")"
 
@@ -534,9 +534,9 @@ least x xs = UnsafeExpression $ "LEAST("
 unsafeBinaryOp
   :: ByteString
   -- ^ operator
-  -> Expression db from grouping params (ty0)
-  -> Expression db from grouping params (ty1)
-  -> Expression db from grouping params (ty2)
+  -> Expression db params grp from (ty0)
+  -> Expression db params grp from (ty1)
+  -> Expression db params grp from (ty2)
 unsafeBinaryOp op x y = UnsafeExpression $ parenthesized $
   renderExpression x <+> op <+> renderExpression y
 
@@ -545,8 +545,8 @@ unsafeBinaryOp op x y = UnsafeExpression $ parenthesized $
 unsafeUnaryOp
   :: ByteString
   -- ^ operator
-  -> Expression db from grouping params (ty0)
-  -> Expression db from grouping params (ty1)
+  -> Expression db params grp from (ty0)
+  -> Expression db params grp from (ty1)
 unsafeUnaryOp op x = UnsafeExpression $ parenthesized $
   op <+> renderExpression x
 
@@ -555,8 +555,8 @@ unsafeUnaryOp op x = UnsafeExpression $ parenthesized $
 unsafeFunction
   :: ByteString
   -- ^ function
-  -> Expression db from grouping params (xty)
-  -> Expression db from grouping params (yty)
+  -> Expression db params grp from (xty)
+  -> Expression db params grp from (yty)
 unsafeFunction fun x = UnsafeExpression $
   fun <> parenthesized (renderExpression x)
 
@@ -565,13 +565,13 @@ unsafeVariadicFunction
   :: SListI elems
   => ByteString
   -- ^ function
-  -> NP (Expression db from grouping params) elems
-  -> Expression db from grouping params ret
+  -> NP (Expression db params grp from) elems
+  -> Expression db params grp from ret
 unsafeVariadicFunction fun x = UnsafeExpression $
   fun <> parenthesized (commaSeparated (hcollapse (hmap (K . renderExpression) x)))
 
 instance ty `In` PGNum
-  => Num (Expression db from grouping params (nullity ty)) where
+  => Num (Expression db params grp from (nullity ty)) where
     (+) = unsafeBinaryOp "+"
     (-) = unsafeBinaryOp "-"
     (*) = unsafeBinaryOp "*"
@@ -583,12 +583,12 @@ instance ty `In` PGNum
       . show
 
 instance (ty `In` PGNum, ty `In` PGFloating) => Fractional
-  (Expression db from grouping params (nullity ty)) where
+  (Expression db params grp from (nullity ty)) where
     (/) = unsafeBinaryOp "/"
     fromRational x = fromInteger (numerator x) / fromInteger (denominator x)
 
 instance (ty `In` PGNum, ty `In` PGFloating) => Floating
-  (Expression db from grouping params (nullity ty)) where
+  (Expression db params grp from (nullity ty)) where
     pi = UnsafeExpression "pi()"
     exp = unsafeFunction "exp"
     log = unsafeFunction "ln"
@@ -611,18 +611,18 @@ instance (ty `In` PGNum, ty `In` PGFloating) => Floating
 
 -- | >>> :{
 -- let
---   expression :: Expression db from grouping params (nullity 'PGfloat4)
+--   expression :: Expression db params grp from (nullity 'PGfloat4)
 --   expression = atan2_ pi 2
 -- in printSQL expression
 -- :}
 -- atan2(pi(), 2)
 atan2_
   :: float `In` PGFloating
-  => Expression db from grouping params (nullity float)
+  => Expression db params grp from (nullity float)
   -- ^ numerator
-  -> Expression db from grouping params (nullity float)
+  -> Expression db params grp from (nullity float)
   -- ^ denominator
-  -> Expression db from grouping params (nullity float)
+  -> Expression db params grp from (nullity float)
 atan2_ y x = UnsafeExpression $
   "atan2(" <> renderExpression y <> ", " <> renderExpression x <> ")"
 
@@ -635,9 +635,9 @@ atan2_ y x = UnsafeExpression $
 cast
   :: TypeExpression schemas ty1
   -- ^ type to cast as
-  -> Expression (commons :=> schemas) from grouping params ty0
+  -> Expression (commons :=> schemas) params grp from ty0
   -- ^ value to convert
-  -> Expression (commons :=> schemas) from grouping params ty1
+  -> Expression (commons :=> schemas) params grp from ty1
 cast ty x = UnsafeExpression $ parenthesized $
   renderExpression x <+> "::" <+> renderTypeExpression ty
 
@@ -645,136 +645,136 @@ cast ty x = UnsafeExpression $ parenthesized $
 --
 -- >>> :{
 -- let
---   expression :: Expression db from grouping params (nullity 'PGint2)
+--   expression :: Expression db params grp from (nullity 'PGint2)
 --   expression = 5 `quot_` 2
 -- in printSQL expression
 -- :}
 -- (5 / 2)
 quot_
   :: int `In` PGIntegral
-  => Expression db from grouping params (nullity int)
+  => Expression db params grp from (nullity int)
   -- ^ numerator
-  -> Expression db from grouping params (nullity int)
+  -> Expression db params grp from (nullity int)
   -- ^ denominator
-  -> Expression db from grouping params (nullity int)
+  -> Expression db params grp from (nullity int)
 quot_ = unsafeBinaryOp "/"
 
 -- | remainder upon integer division
 --
 -- >>> :{
 -- let
---   expression :: Expression db from grouping params (nullity 'PGint2)
+--   expression :: Expression db params grp from (nullity 'PGint2)
 --   expression = 5 `rem_` 2
 -- in printSQL expression
 -- :}
 -- (5 % 2)
 rem_
   :: int `In` PGIntegral
-  => Expression db from grouping params (nullity int)
+  => Expression db params grp from (nullity int)
   -- ^ numerator
-  -> Expression db from grouping params (nullity int)
+  -> Expression db params grp from (nullity int)
   -- ^ denominator
-  -> Expression db from grouping params (nullity int)
+  -> Expression db params grp from (nullity int)
 rem_ = unsafeBinaryOp "%"
 
 -- | >>> :{
 -- let
---   expression :: Expression db from grouping params (nullity 'PGfloat4)
+--   expression :: Expression db params grp from (nullity 'PGfloat4)
 --   expression = trunc pi
 -- in printSQL expression
 -- :}
 -- trunc(pi())
 trunc
   :: frac `In` PGFloating
-  => Expression db from grouping params (nullity frac)
+  => Expression db params grp from (nullity frac)
   -- ^ fractional number
-  -> Expression db from grouping params (nullity frac)
+  -> Expression db params grp from (nullity frac)
 trunc = unsafeFunction "trunc"
 
 -- | >>> :{
 -- let
---   expression :: Expression db from grouping params (nullity 'PGfloat4)
+--   expression :: Expression db params grp from (nullity 'PGfloat4)
 --   expression = round_ pi
 -- in printSQL expression
 -- :}
 -- round(pi())
 round_
   :: frac `In` PGFloating
-  => Expression db from grouping params (nullity frac)
+  => Expression db params grp from (nullity frac)
   -- ^ fractional number
-  -> Expression db from grouping params (nullity frac)
+  -> Expression db params grp from (nullity frac)
 round_ = unsafeFunction "round"
 
 -- | >>> :{
 -- let
---   expression :: Expression db from grouping params (nullity 'PGfloat4)
+--   expression :: Expression db params grp from (nullity 'PGfloat4)
 --   expression = ceiling_ pi
 -- in printSQL expression
 -- :}
 -- ceiling(pi())
 ceiling_
   :: frac `In` PGFloating
-  => Expression db from grouping params (nullity frac)
+  => Expression db params grp from (nullity frac)
   -- ^ fractional number
-  -> Expression db from grouping params (nullity frac)
+  -> Expression db params grp from (nullity frac)
 ceiling_ = unsafeFunction "ceiling"
 
 -- | A `Condition` is an `Expression`, which can evaluate
 -- to `true`, `false` or `null_`. This is because SQL uses
 -- a three valued logic.
-type Condition db from grouping params =
-  Expression db from grouping params ('Null 'PGbool)
+type Condition db params grp from =
+  Expression db params grp from ('Null 'PGbool)
 
 -- | >>> printSQL true
 -- TRUE
-true :: Expression db from grouping params (nullity 'PGbool)
+true :: Expression db params grp from (nullity 'PGbool)
 true = UnsafeExpression "TRUE"
 
 -- | >>> printSQL false
 -- FALSE
-false :: Expression db from grouping params (nullity 'PGbool)
+false :: Expression db params grp from (nullity 'PGbool)
 false = UnsafeExpression "FALSE"
 
 -- | >>> printSQL $ not_ true
 -- (NOT TRUE)
 not_
-  :: Expression db from grouping params (nullity 'PGbool)
-  -> Expression db from grouping params (nullity 'PGbool)
+  :: Expression db params grp from (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 not_ = unsafeUnaryOp "NOT"
 
 -- | >>> printSQL $ true .&& false
 -- (TRUE AND FALSE)
 (.&&)
-  :: Expression db from grouping params (nullity 'PGbool)
-  -> Expression db from grouping params (nullity 'PGbool)
-  -> Expression db from grouping params (nullity 'PGbool)
+  :: Expression db params grp from (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 infixr 3 .&&
 (.&&) = unsafeBinaryOp "AND"
 
 -- | >>> printSQL $ true .|| false
 -- (TRUE OR FALSE)
 (.||)
-  :: Expression db from grouping params (nullity 'PGbool)
-  -> Expression db from grouping params (nullity 'PGbool)
-  -> Expression db from grouping params (nullity 'PGbool)
+  :: Expression db params grp from (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 infixr 2 .||
 (.||) = unsafeBinaryOp "OR"
 
 -- | >>> :{
 -- let
---   expression :: Expression db from grouping params (nullity 'PGint2)
+--   expression :: Expression db params grp from (nullity 'PGint2)
 --   expression = caseWhenThenElse [(true, 1), (false, 2)] 3
 -- in printSQL expression
 -- :}
 -- CASE WHEN TRUE THEN 1 WHEN FALSE THEN 2 ELSE 3 END
 caseWhenThenElse
-  :: [ ( Condition db from grouping params
-       , Expression db from grouping params ty
+  :: [ ( Condition db params grp from
+       , Expression db params grp from ty
      ) ]
   -- ^ whens and thens
-  -> Expression db from grouping params ty
+  -> Expression db params grp from ty
   -- ^ else
-  -> Expression db from grouping params ty
+  -> Expression db params grp from ty
 caseWhenThenElse whenThens else_ = UnsafeExpression $ mconcat
   [ "CASE"
   , mconcat
@@ -790,16 +790,16 @@ caseWhenThenElse whenThens else_ = UnsafeExpression $ mconcat
 
 -- | >>> :{
 -- let
---   expression :: Expression db from grouping params (nullity 'PGint2)
+--   expression :: Expression db params grp from (nullity 'PGint2)
 --   expression = ifThenElse true 1 0
 -- in printSQL expression
 -- :}
 -- CASE WHEN TRUE THEN 1 ELSE 0 END
 ifThenElse
-  :: Condition db from grouping params
-  -> Expression db from grouping params ty -- ^ then
-  -> Expression db from grouping params ty -- ^ else
-  -> Expression db from grouping params ty
+  :: Condition db params grp from
+  -> Expression db params grp from ty -- ^ then
+  -> Expression db params grp from ty -- ^ else
+  -> Expression db params grp from ty
 ifThenElse if_ then_ else_ = caseWhenThenElse [(if_,then_)] else_
 
 -- | Comparison operations like `.==`, `./=`, `.>`, `.>=`, `.<` and `.<=`
@@ -808,85 +808,85 @@ ifThenElse if_ then_ else_ = caseWhenThenElse [(if_,then_)] else_
 -- >>> printSQL $ true .== null_
 -- (TRUE = NULL)
 (.==)
-  :: Expression db from grouping params (nullity0 ty) -- ^ lhs
-  -> Expression db from grouping params (nullity1 ty) -- ^ rhs
-  -> Condition db from grouping params
+  :: Expression db params grp from (nullity0 ty) -- ^ lhs
+  -> Expression db params grp from (nullity1 ty) -- ^ rhs
+  -> Condition db params grp from
 (.==) = unsafeBinaryOp "="
 infix 4 .==
 
 -- | >>> printSQL $ true ./= null_
 -- (TRUE <> NULL)
 (./=)
-  :: Expression db from grouping params (nullity0 ty) -- ^ lhs
-  -> Expression db from grouping params (nullity1 ty) -- ^ rhs
-  -> Condition db from grouping params
+  :: Expression db params grp from (nullity0 ty) -- ^ lhs
+  -> Expression db params grp from (nullity1 ty) -- ^ rhs
+  -> Condition db params grp from
 (./=) = unsafeBinaryOp "<>"
 infix 4 ./=
 
 -- | >>> printSQL $ true .>= null_
 -- (TRUE >= NULL)
 (.>=)
-  :: Expression db from grouping params (nullity0 ty) -- ^ lhs
-  -> Expression db from grouping params (nullity1 ty) -- ^ rhs
-  -> Condition db from grouping params
+  :: Expression db params grp from (nullity0 ty) -- ^ lhs
+  -> Expression db params grp from (nullity1 ty) -- ^ rhs
+  -> Condition db params grp from
 (.>=) = unsafeBinaryOp ">="
 infix 4 .>=
 
 -- | >>> printSQL $ true .< null_
 -- (TRUE < NULL)
 (.<)
-  :: Expression db from grouping params (nullity0 ty) -- ^ lhs
-  -> Expression db from grouping params (nullity1 ty) -- ^ rhs
-  -> Condition db from grouping params
+  :: Expression db params grp from (nullity0 ty) -- ^ lhs
+  -> Expression db params grp from (nullity1 ty) -- ^ rhs
+  -> Condition db params grp from
 (.<) = unsafeBinaryOp "<"
 infix 4 .<
 
 -- | >>> printSQL $ true .<= null_
 -- (TRUE <= NULL)
 (.<=)
-  :: Expression db from grouping params (nullity0 ty) -- ^ lhs
-  -> Expression db from grouping params (nullity1 ty) -- ^ rhs
-  -> Condition db from grouping params
+  :: Expression db params grp from (nullity0 ty) -- ^ lhs
+  -> Expression db params grp from (nullity1 ty) -- ^ rhs
+  -> Condition db params grp from
 (.<=) = unsafeBinaryOp "<="
 infix 4 .<=
 
 -- | >>> printSQL $ true .> null_
 -- (TRUE > NULL)
 (.>)
-  :: Expression db from grouping params (nullity0 ty) -- ^ lhs
-  -> Expression db from grouping params (nullity1 ty) -- ^ rhs
-  -> Condition db from grouping params
+  :: Expression db params grp from (nullity0 ty) -- ^ lhs
+  -> Expression db params grp from (nullity1 ty) -- ^ rhs
+  -> Condition db params grp from
 (.>) = unsafeBinaryOp ">"
 infix 4 .>
 
 -- | >>> printSQL currentDate
 -- CURRENT_DATE
 currentDate
-  :: Expression db from grouping params (nullity 'PGdate)
+  :: Expression db params grp from (nullity 'PGdate)
 currentDate = UnsafeExpression "CURRENT_DATE"
 
 -- | >>> printSQL currentTime
 -- CURRENT_TIME
 currentTime
-  :: Expression db from grouping params (nullity 'PGtimetz)
+  :: Expression db params grp from (nullity 'PGtimetz)
 currentTime = UnsafeExpression "CURRENT_TIME"
 
 -- | >>> printSQL currentTimestamp
 -- CURRENT_TIMESTAMP
 currentTimestamp
-  :: Expression db from grouping params (nullity 'PGtimestamptz)
+  :: Expression db params grp from (nullity 'PGtimestamptz)
 currentTimestamp = UnsafeExpression "CURRENT_TIMESTAMP"
 
 -- | >>> printSQL localTime
 -- LOCALTIME
 localTime
-  :: Expression db from grouping params (nullity 'PGtime)
+  :: Expression db params grp from (nullity 'PGtime)
 localTime = UnsafeExpression "LOCALTIME"
 
 -- | >>> printSQL localTimestamp
 -- LOCALTIMESTAMP
 localTimestamp
-  :: Expression db from grouping params (nullity 'PGtimestamp)
+  :: Expression db params grp from (nullity 'PGtimestamp)
 localTimestamp = UnsafeExpression "LOCALTIMESTAMP"
 
 {-----------------------------------------
@@ -894,7 +894,7 @@ text
 -----------------------------------------}
 
 instance IsString
-  (Expression db from grouping params (nullity 'PGtext)) where
+  (Expression db params grp from (nullity 'PGtext)) where
     fromString str = UnsafeExpression $
       "E\'" <> fromString (escape =<< str) <> "\'"
       where
@@ -910,36 +910,36 @@ instance IsString
           c -> [c]
 
 instance Semigroup
-  (Expression db from grouping params (nullity 'PGtext)) where
+  (Expression db params grp from (nullity 'PGtext)) where
     (<>) = unsafeBinaryOp "||"
 
 instance Monoid
-  (Expression db from grouping params (nullity 'PGtext)) where
+  (Expression db params grp from (nullity 'PGtext)) where
     mempty = fromString ""
     mappend = (<>)
 
 -- | >>> printSQL $ lower "ARRRGGG"
 -- lower(E'ARRRGGG')
 lower
-  :: Expression db from grouping params (nullity 'PGtext)
+  :: Expression db params grp from (nullity 'PGtext)
   -- ^ string to lower case
-  -> Expression db from grouping params (nullity 'PGtext)
+  -> Expression db params grp from (nullity 'PGtext)
 lower = unsafeFunction "lower"
 
 -- | >>> printSQL $ upper "eeee"
 -- upper(E'eeee')
 upper
-  :: Expression db from grouping params (nullity 'PGtext)
+  :: Expression db params grp from (nullity 'PGtext)
   -- ^ string to upper case
-  -> Expression db from grouping params (nullity 'PGtext)
+  -> Expression db params grp from (nullity 'PGtext)
 upper = unsafeFunction "upper"
 
 -- | >>> printSQL $ charLength "four"
 -- char_length(E'four')
 charLength
-  :: Expression db from grouping params (nullity 'PGtext)
+  :: Expression db params grp from (nullity 'PGtext)
   -- ^ string to measure
-  -> Expression db from grouping params (nullity 'PGint4)
+  -> Expression db params grp from (nullity 'PGint4)
 charLength = unsafeFunction "char_length"
 
 -- | The `like` expression returns true if the @string@ matches
@@ -952,11 +952,11 @@ charLength = unsafeFunction "char_length"
 -- >>> printSQL $ "abc" `like` "a%"
 -- (E'abc' LIKE E'a%')
 like
-  :: Expression db from grouping params (nullity 'PGtext)
+  :: Expression db params grp from (nullity 'PGtext)
   -- ^ string
-  -> Expression db from grouping params (nullity 'PGtext)
+  -> Expression db params grp from (nullity 'PGtext)
   -- ^ pattern
-  -> Expression db from grouping params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 like = unsafeBinaryOp "LIKE"
 
 -- | The key word ILIKE can be used instead of LIKE to make the
@@ -965,11 +965,11 @@ like = unsafeBinaryOp "LIKE"
 -- >>> printSQL $ "abc" `ilike` "a%"
 -- (E'abc' ILIKE E'a%')
 ilike
-  :: Expression db from grouping params (nullity 'PGtext)
+  :: Expression db params grp from (nullity 'PGtext)
   -- ^ string
-  -> Expression db from grouping params (nullity 'PGtext)
+  -> Expression db params grp from (nullity 'PGtext)
   -- ^ pattern
-  -> Expression db from grouping params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 ilike = unsafeBinaryOp "ILIKE"
 
 {-----------------------------------------
@@ -984,36 +984,36 @@ Table 9.44: json and jsonb operators
 -- | Get JSON value (object field or array element) at a key.
 (.->)
   :: (json `In` PGJsonType, key `In` PGJsonKey)
-  => Expression db from grouping params (nullity json)
-  -> Expression db from grouping params (nullity key)
-  -> Expression db from grouping params ('Null json)
+  => Expression db params grp from (nullity json)
+  -> Expression db params grp from (nullity key)
+  -> Expression db params grp from ('Null json)
 infixl 8 .->
 (.->) = unsafeBinaryOp "->"
 
 -- | Get JSON value (object field or array element) at a key, as text.
 (.->>)
   :: (json `In` PGJsonType, key `In` PGJsonKey)
-  => Expression db from grouping params (nullity json)
-  -> Expression db from grouping params (nullity key)
-  -> Expression db from grouping params ('Null 'PGtext)
+  => Expression db params grp from (nullity json)
+  -> Expression db params grp from (nullity key)
+  -> Expression db params grp from ('Null 'PGtext)
 infixl 8 .->>
 (.->>) = unsafeBinaryOp "->>"
 
 -- | Get JSON value at a specified path.
 (.#>)
   :: (json `In` PGJsonType, PGTextArray "(.#>)" path)
-  => Expression db from grouping params (nullity json)
-  -> Expression db from grouping params (nullity path)
-  -> Expression db from grouping params ('Null json)
+  => Expression db params grp from (nullity json)
+  -> Expression db params grp from (nullity path)
+  -> Expression db params grp from ('Null json)
 infixl 8 .#>
 (.#>) = unsafeBinaryOp "#>"
 
 -- | Get JSON value at a specified path as text.
 (.#>>)
   :: (json `In` PGJsonType, PGTextArray "(.#>>)" path)
-  => Expression db from grouping params (nullity json)
-  -> Expression db from grouping params (nullity path)
-  -> Expression db from grouping params ('Null 'PGtext)
+  => Expression db params grp from (nullity json)
+  -> Expression db params grp from (nullity path)
+  -> Expression db params grp from ('Null 'PGtext)
 infixl 8 .#>>
 (.#>>) = unsafeBinaryOp "#>>"
 
@@ -1022,42 +1022,42 @@ infixl 8 .#>>
 -- | Does the left JSON value contain the right JSON path/value entries at the
 -- top level?
 (.@>)
-  :: Expression db from grouping params (nullity 'PGjsonb)
-  -> Expression db from grouping params (nullity 'PGjsonb)
-  -> Condition db from grouping params
+  :: Expression db params grp from (nullity 'PGjsonb)
+  -> Expression db params grp from (nullity 'PGjsonb)
+  -> Condition db params grp from
 infixl 9 .@>
 (.@>) = unsafeBinaryOp "@>"
 
 -- | Are the left JSON path/value entries contained at the top level within the
 -- right JSON value?
 (.<@)
-  :: Expression db from grouping params (nullity 'PGjsonb)
-  -> Expression db from grouping params (nullity 'PGjsonb)
-  -> Condition db from grouping params
+  :: Expression db params grp from (nullity 'PGjsonb)
+  -> Expression db params grp from (nullity 'PGjsonb)
+  -> Condition db params grp from
 infixl 9 .<@
 (.<@) = unsafeBinaryOp "<@"
 
 -- | Does the string exist as a top-level key within the JSON value?
 (.?)
-  :: Expression db from grouping params (nullity 'PGjsonb)
-  -> Expression db from grouping params (nullity 'PGtext)
-  -> Condition db from grouping params
+  :: Expression db params grp from (nullity 'PGjsonb)
+  -> Expression db params grp from (nullity 'PGtext)
+  -> Condition db params grp from
 infixl 9 .?
 (.?) = unsafeBinaryOp "?"
 
 -- | Do any of these array strings exist as top-level keys?
 (.?|)
-  :: Expression db from grouping params (nullity 'PGjsonb)
-  -> Expression db from grouping params (nullity ('PGvararray ('NotNull 'PGtext)))
-  -> Condition db from grouping params
+  :: Expression db params grp from (nullity 'PGjsonb)
+  -> Expression db params grp from (nullity ('PGvararray ('NotNull 'PGtext)))
+  -> Condition db params grp from
 infixl 9 .?|
 (.?|) = unsafeBinaryOp "?|"
 
 -- | Do all of these array strings exist as top-level keys?
 (.?&)
-  :: Expression db from grouping params (nullity 'PGjsonb)
-  -> Expression db from grouping params (nullity ('PGvararray ('NotNull 'PGtext)))
-  -> Condition db from grouping params
+  :: Expression db params grp from (nullity 'PGjsonb)
+  -> Expression db params grp from (nullity ('PGvararray ('NotNull 'PGtext)))
+  -> Condition db params grp from
 infixl 9 .?&
 (.?&) = unsafeBinaryOp "?&"
 
@@ -1080,9 +1080,9 @@ instance
 -- count from the end). Throws an error if top level container is not an array.
 (.-.)
   :: (key `In` '[ 'PGtext, 'PGvararray ('NotNull 'PGtext), 'PGint4, 'PGint2 ]) -- hlint error without parens here
-  => Expression db from grouping params (nullity 'PGjsonb)
-  -> Expression db from grouping params (nullity key)
-  -> Expression db from grouping params (nullity 'PGjsonb)
+  => Expression db params grp from (nullity 'PGjsonb)
+  -> Expression db params grp from (nullity key)
+  -> Expression db params grp from (nullity 'PGjsonb)
 infixl 6 .-.
 (.-.) = unsafeBinaryOp "-"
 
@@ -1090,9 +1090,9 @@ infixl 6 .-.
 -- integers count from the end)
 (#-.)
   :: PGTextArray "(#-.)" arrayty
-  => Expression db from grouping params (nullity 'PGjsonb)
-  -> Expression db from grouping params (nullity arrayty)
-  -> Expression db from grouping params (nullity 'PGjsonb)
+  => Expression db params grp from (nullity 'PGjsonb)
+  -> Expression db params grp from (nullity arrayty)
+  -> Expression db params grp from (nullity 'PGjsonb)
 infixl 6 #-.
 (#-.) = unsafeBinaryOp "#-"
 
@@ -1103,14 +1103,14 @@ Table 9.45: JSON creation functions
 -- | Literal binary JSON
 jsonbLit
   :: JSON.ToJSON x
-  => x -> Expression (commons :=> schemas) from grouping params (nullity 'PGjsonb)
+  => x -> Expression (commons :=> schemas) params grp from (nullity 'PGjsonb)
 jsonbLit = cast jsonb . UnsafeExpression
   . singleQuotedUtf8 . toStrict . JSON.encode
 
 -- | Literal JSON
 jsonLit
   :: JSON.ToJSON x
-  => x -> Expression (commons :=> schemas) from grouping params (nullity 'PGjson)
+  => x -> Expression (commons :=> schemas) params grp from (nullity 'PGjson)
 jsonLit = cast json . UnsafeExpression
   . singleQuotedUtf8 . toStrict . JSON.encode
 
@@ -1121,8 +1121,8 @@ jsonLit = cast json . UnsafeExpression
 -- number, a Boolean, or a null value, the text representation will be used, in
 -- such a fashion that it is a valid json value.
 toJson
-  :: Expression db from grouping params (nullity ty)
-  -> Expression db from grouping params (nullity 'PGjson)
+  :: Expression db params grp from (nullity ty)
+  -> Expression db params grp from (nullity 'PGjson)
 toJson = unsafeFunction "to_json"
 
 -- | Returns the value as jsonb. Arrays and composites are converted
@@ -1132,43 +1132,43 @@ toJson = unsafeFunction "to_json"
 -- number, a Boolean, or a null value, the text representation will be used, in
 -- such a fashion that it is a valid jsonb value.
 toJsonb
-  :: Expression db from grouping params (nullity ty)
-  -> Expression db from grouping params (nullity 'PGjsonb)
+  :: Expression db params grp from (nullity ty)
+  -> Expression db params grp from (nullity 'PGjsonb)
 toJsonb = unsafeFunction "to_jsonb"
 
 -- | Returns the array as a JSON array. A PostgreSQL multidimensional array
 -- becomes a JSON array of arrays.
 arrayToJson
   :: PGArray "arrayToJson" arr
-  => Expression db from grouping params (nullity arr)
-  -> Expression db from grouping params (nullity 'PGjson)
+  => Expression db params grp from (nullity arr)
+  -> Expression db params grp from (nullity 'PGjson)
 arrayToJson = unsafeFunction "array_to_json"
 
 -- | Returns the row as a JSON object.
 rowToJson
-  :: Expression db from grouping params (nullity ('PGcomposite ty))
-  -> Expression db from grouping params (nullity 'PGjson)
+  :: Expression db params grp from (nullity ('PGcomposite ty))
+  -> Expression db params grp from (nullity 'PGjson)
 rowToJson = unsafeFunction "row_to_json"
 
 -- | Builds a possibly-heterogeneously-typed JSON array out of a variadic
 -- argument list.
 jsonBuildArray
   :: SListI elems
-  => NP (Expression db from grouping params) elems
-  -> Expression db from grouping params (nullity 'PGjson)
+  => NP (Expression db params grp from) elems
+  -> Expression db params grp from (nullity 'PGjson)
 jsonBuildArray = unsafeVariadicFunction "json_build_array"
 
 -- | Builds a possibly-heterogeneously-typed (binary) JSON array out of a
 -- variadic argument list.
 jsonbBuildArray
   :: SListI elems
-  => NP (Expression db from grouping params) elems
-  -> Expression db from grouping params (nullity 'PGjsonb)
+  => NP (Expression db params grp from) elems
+  -> Expression db params grp from (nullity 'PGjsonb)
 jsonbBuildArray = unsafeVariadicFunction "jsonb_build_array"
 
 unsafeRowFunction
   :: All Top elems
-  => NP (Aliased (Expression db from grouping params)) elems
+  => NP (Aliased (Expression db params grp from)) elems
   -> [ByteString]
 unsafeRowFunction =
   (`appEndo` []) . hcfoldMap (Proxy :: Proxy Top)
@@ -1180,8 +1180,8 @@ unsafeRowFunction =
 -- and values.
 jsonBuildObject
   :: All Top elems
-  => NP (Aliased (Expression db from grouping params)) elems
-  -> Expression db from grouping params (nullity 'PGjson)
+  => NP (Aliased (Expression db params grp from)) elems
+  -> Expression db params grp from (nullity 'PGjson)
 jsonBuildObject
   = unsafeFunction "json_build_object"
   . UnsafeExpression
@@ -1193,8 +1193,8 @@ jsonBuildObject
 -- between text and values.
 jsonbBuildObject
   :: All Top elems
-  => NP (Aliased (Expression db from grouping params)) elems
-  -> Expression db from grouping params (nullity 'PGjsonb)
+  => NP (Aliased (Expression db params grp from)) elems
+  -> Expression db params grp from (nullity 'PGjsonb)
 jsonbBuildObject
   = unsafeFunction "jsonb_build_object"
   . UnsafeExpression
@@ -1207,8 +1207,8 @@ jsonbBuildObject
 -- array has exactly two elements, which are taken as a key/value pair.
 jsonObject
   :: PGArrayOf "jsonObject" arr ('NotNull 'PGtext)
-  => Expression db from grouping params (nullity arr)
-  -> Expression db from grouping params (nullity 'PGjson)
+  => Expression db params grp from (nullity arr)
+  -> Expression db params grp from (nullity 'PGjson)
 jsonObject = unsafeFunction "json_object"
 
 -- | Builds a binary JSON object out of a text array. The array must have either
@@ -1217,8 +1217,8 @@ jsonObject = unsafeFunction "json_object"
 -- array has exactly two elements, which are taken as a key/value pair.
 jsonbObject
   :: PGArrayOf "jsonbObject" arr ('NotNull 'PGtext)
-  => Expression db from grouping params (nullity arr)
-  -> Expression db from grouping params (nullity 'PGjsonb)
+  => Expression db params grp from (nullity arr)
+  -> Expression db params grp from (nullity 'PGjsonb)
 jsonbObject = unsafeFunction "jsonb_object"
 
 -- | This is an alternate form of 'jsonObject' that takes two arrays; one for
@@ -1226,9 +1226,9 @@ jsonbObject = unsafeFunction "jsonb_object"
 jsonZipObject
   :: ( PGArrayOf "jsonZipObject" keysArray ('NotNull 'PGtext)
      , PGArrayOf "jsonZipObject" valuesArray ('NotNull 'PGtext))
-  => Expression db from grouping params (nullity keysArray)
-  -> Expression db from grouping params (nullity valuesArray)
-  -> Expression db from grouping params (nullity 'PGjson)
+  => Expression db params grp from (nullity keysArray)
+  -> Expression db params grp from (nullity valuesArray)
+  -> Expression db params grp from (nullity 'PGjson)
 jsonZipObject ks vs =
   unsafeVariadicFunction "json_object" (ks :* vs :* Nil)
 
@@ -1238,9 +1238,9 @@ jsonZipObject ks vs =
 jsonbZipObject
   :: ( PGArrayOf "jsonbZipObject" keysArray ('NotNull 'PGtext)
      , PGArrayOf "jsonbZipObject" valuesArray ('NotNull 'PGtext))
-  => Expression db from grouping params (nullity keysArray)
-  -> Expression db from grouping params (nullity valuesArray)
-  -> Expression db from grouping params (nullity 'PGjsonb)
+  => Expression db params grp from (nullity keysArray)
+  -> Expression db params grp from (nullity valuesArray)
+  -> Expression db params grp from (nullity 'PGjsonb)
 jsonbZipObject ks vs =
   unsafeVariadicFunction "jsonb_object" (ks :* vs :* Nil)
 
@@ -1250,23 +1250,23 @@ Table 9.46: JSON processing functions
 
 -- | Returns the number of elements in the outermost JSON array.
 jsonArrayLength
-  :: Expression db from grouping params (nullity 'PGjson)
-  -> Expression db from grouping params (nullity 'PGint4)
+  :: Expression db params grp from (nullity 'PGjson)
+  -> Expression db params grp from (nullity 'PGint4)
 jsonArrayLength = unsafeFunction "json_array_length"
 
 -- | Returns the number of elements in the outermost binary JSON array.
 jsonbArrayLength
-  :: Expression db from grouping params (nullity 'PGjsonb)
-  -> Expression db from grouping params (nullity 'PGint4)
+  :: Expression db params grp from (nullity 'PGjsonb)
+  -> Expression db params grp from (nullity 'PGint4)
 jsonbArrayLength = unsafeFunction "jsonb_array_length"
 
 -- | Returns JSON value pointed to by the given path (equivalent to #>
 -- operator).
 jsonExtractPath
   :: SListI elems
-  => Expression db from grouping params (nullity 'PGjson)
-  -> NP (Expression db from grouping params) elems
-  -> Expression db from grouping params (nullity 'PGjsonb)
+  => Expression db params grp from (nullity 'PGjson)
+  -> NP (Expression db params grp from) elems
+  -> Expression db params grp from (nullity 'PGjsonb)
 jsonExtractPath x xs =
   unsafeVariadicFunction "json_extract_path" (x :* xs)
 
@@ -1274,9 +1274,9 @@ jsonExtractPath x xs =
 -- operator).
 jsonbExtractPath
   :: SListI elems
-  => Expression db from grouping params (nullity 'PGjsonb)
-  -> NP (Expression db from grouping params) elems
-  -> Expression db from grouping params (nullity 'PGjsonb)
+  => Expression db params grp from (nullity 'PGjsonb)
+  -> NP (Expression db params grp from) elems
+  -> Expression db params grp from (nullity 'PGjsonb)
 jsonbExtractPath x xs =
   unsafeVariadicFunction "jsonb_extract_path" (x :* xs)
 
@@ -1284,9 +1284,9 @@ jsonbExtractPath x xs =
 -- operator), as text.
 jsonExtractPathAsText
   :: SListI elems
-  => Expression db from grouping params (nullity 'PGjson)
-  -> NP (Expression db from grouping params) elems
-  -> Expression db from grouping params (nullity 'PGjson)
+  => Expression db params grp from (nullity 'PGjson)
+  -> NP (Expression db params grp from) elems
+  -> Expression db params grp from (nullity 'PGjson)
 jsonExtractPathAsText x xs =
   unsafeVariadicFunction "json_extract_path_text" (x :* xs)
 
@@ -1294,38 +1294,38 @@ jsonExtractPathAsText x xs =
 -- operator), as text.
 jsonbExtractPathAsText
   :: SListI elems
-  => Expression db from grouping params (nullity 'PGjsonb)
-  -> NP (Expression db from grouping params) elems
-  -> Expression db from grouping params (nullity 'PGjsonb)
+  => Expression db params grp from (nullity 'PGjsonb)
+  -> NP (Expression db params grp from) elems
+  -> Expression db params grp from (nullity 'PGjsonb)
 jsonbExtractPathAsText x xs =
   unsafeVariadicFunction "jsonb_extract_path_text" (x :* xs)
 
 -- | Returns the type of the outermost JSON value as a text string. Possible
 -- types are object, array, string, number, boolean, and null.
 jsonTypeof
-  :: Expression db from grouping params (nullity 'PGjson)
-  -> Expression db from grouping params (nullity 'PGtext)
+  :: Expression db params grp from (nullity 'PGjson)
+  -> Expression db params grp from (nullity 'PGtext)
 jsonTypeof = unsafeFunction "json_typeof"
 
 -- | Returns the type of the outermost binary JSON value as a text string.
 -- Possible types are object, array, string, number, boolean, and null.
 jsonbTypeof
-  :: Expression db from grouping params (nullity 'PGjsonb)
-  -> Expression db from grouping params (nullity 'PGtext)
+  :: Expression db params grp from (nullity 'PGjsonb)
+  -> Expression db params grp from (nullity 'PGtext)
 jsonbTypeof = unsafeFunction "jsonb_typeof"
 
 -- | Returns its argument with all object fields that have null values omitted.
 -- Other null values are untouched.
 jsonStripNulls
-  :: Expression db from grouping params (nullity 'PGjson)
-  -> Expression db from grouping params (nullity 'PGjson)
+  :: Expression db params grp from (nullity 'PGjson)
+  -> Expression db params grp from (nullity 'PGjson)
 jsonStripNulls = unsafeFunction "json_strip_nulls"
 
 -- | Returns its argument with all object fields that have null values omitted.
 -- Other null values are untouched.
 jsonbStripNulls
-  :: Expression db from grouping params (nullity 'PGjsonb)
-  -> Expression db from grouping params (nullity 'PGjsonb)
+  :: Expression db params grp from (nullity 'PGjsonb)
+  -> Expression db params grp from (nullity 'PGjsonb)
 jsonbStripNulls = unsafeFunction "jsonb_strip_nulls"
 
 -- | @ jsonbSet target path new_value create_missing @
@@ -1337,11 +1337,11 @@ jsonbStripNulls = unsafeFunction "jsonb_strip_nulls"
 -- arrays.
 jsonbSet
   :: PGTextArray "jsonbSet" arr
-  => Expression db from grouping params (nullity 'PGjsonb)
-  -> Expression db from grouping params (nullity arr)
-  -> Expression db from grouping params (nullity 'PGjsonb)
-  -> Maybe (Expression db from grouping params (nullity 'PGbool))
-  -> Expression db from grouping params (nullity 'PGjsonb)
+  => Expression db params grp from (nullity 'PGjsonb)
+  -> Expression db params grp from (nullity arr)
+  -> Expression db params grp from (nullity 'PGjsonb)
+  -> Maybe (Expression db params grp from (nullity 'PGbool))
+  -> Expression db params grp from (nullity 'PGjsonb)
 jsonbSet tgt path val createMissing = case createMissing of
   Just m -> unsafeVariadicFunction "jsonb_set" (tgt :* path :* val :* m :* Nil)
   Nothing -> unsafeVariadicFunction "jsonb_set" (tgt :* path :* val :* Nil)
@@ -1356,19 +1356,19 @@ jsonbSet tgt path val createMissing = case createMissing of
 -- in path count from the end of JSON arrays.
 jsonbInsert
   :: PGTextArray "jsonbInsert" arr
-  => Expression db from grouping params (nullity 'PGjsonb)
-  -> Expression db from grouping params (nullity arr)
-  -> Expression db from grouping params (nullity 'PGjsonb)
-  -> Maybe (Expression db from grouping params (nullity 'PGbool))
-  -> Expression db from grouping params (nullity 'PGjsonb)
+  => Expression db params grp from (nullity 'PGjsonb)
+  -> Expression db params grp from (nullity arr)
+  -> Expression db params grp from (nullity 'PGjsonb)
+  -> Maybe (Expression db params grp from (nullity 'PGbool))
+  -> Expression db params grp from (nullity 'PGjsonb)
 jsonbInsert tgt path val insertAfter = case insertAfter of
   Just i -> unsafeVariadicFunction "jsonb_insert" (tgt :* path :* val :* i :* Nil)
   Nothing -> unsafeVariadicFunction "jsonb_insert" (tgt :* path :* val :* Nil)
 
 -- | Returns its argument as indented JSON text.
 jsonbPretty
-  :: Expression db from grouping params (nullity 'PGjsonb)
-  -> Expression db from grouping params (nullity 'PGtext)
+  :: Expression db params grp from (nullity 'PGjsonb)
+  -> Expression db params grp from (nullity 'PGtext)
 jsonbPretty = unsafeFunction "jsonb_pretty"
 
 {-----------------------------------------

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -452,7 +452,7 @@ index n expr = UnsafeExpression $
 
 instance (KnownSymbol label, label `In` labels) => IsPGlabel label
   (Expression db params grp from (nullity ('PGenum labels))) where
-  label = UnsafeExpression $ renderLabel (PGlabel @label)
+  label = UnsafeExpression $ renderSQL (PGlabel @label)
 
 -- | A row constructor is an expression that builds a row value
 -- (also called a composite value) using values for its member fields.
@@ -494,7 +494,7 @@ field
   -> Expression (commons :=> schemas) params grp from ('NotNull ('PGcomposite row))
   -> Expression (commons :=> schemas) params grp from ty
 field td fld expr = UnsafeExpression $
-  parenthesized (renderSQL expr <> "::" <> renderQualifiedAlias td)
+  parenthesized (renderSQL expr <> "::" <> renderSQL td)
     <> "." <> renderSQL fld
 
 instance Semigroup
@@ -1637,7 +1637,7 @@ typedef
   :: (Has sch schemas schema, Has td schema ('Typedef ty))
   => QualifiedAlias sch td
   -> TypeExpression schemas (nullity ty)
-typedef = UnsafeTypeExpression . renderQualifiedAlias
+typedef = UnsafeTypeExpression . renderSQL
 
 -- | The composite type corresponding to a `Table` definition can be expressed
 -- by its alias.
@@ -1645,7 +1645,7 @@ typetable
   :: (Has sch schemas schema, Has tab schema ('Table table))
   => QualifiedAlias sch tab
   -> TypeExpression schemas (nullity ('PGcomposite (TableToRow table)))
-typetable = UnsafeTypeExpression . renderQualifiedAlias
+typetable = UnsafeTypeExpression . renderSQL
 
 -- | The composite type corresponding to a `View` definition can be expressed
 -- by its alias.
@@ -1653,7 +1653,7 @@ typeview
   :: (Has sch schemas schema, Has vw schema ('View view))
   => QualifiedAlias sch vw
   -> TypeExpression schemas (nullity ('PGcomposite view))
-typeview = UnsafeTypeExpression . renderQualifiedAlias
+typeview = UnsafeTypeExpression . renderSQL
 
 -- | logical Boolean (true/false)
 bool :: TypeExpression schemas (nullity 'PGbool)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
@@ -548,7 +548,7 @@ deleteFrom tab using wh returning = UnsafeManipulation $
   <+> renderSQL tab
   <> case using of
     NoUsing -> ""
-    Using from -> " USING" <+> renderSQL from
+    Using tables -> " USING" <+> renderSQL tables
   <+> "WHERE" <+> renderSQL wh
   <> renderSQL returning
 

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
@@ -240,7 +240,7 @@ insertInto
   -> ReturningClause db params '[tab ::: row0] row1
   -> Manipulation db params row1
 insertInto tab qry conflict ret = UnsafeManipulation $
-  "INSERT" <+> "INTO" <+> renderQualifiedAlias tab
+  "INSERT" <+> "INTO" <+> renderSQL tab
   <+> renderQueryClause qry
   <> renderConflictClause conflict
   <> renderSQL ret
@@ -508,7 +508,7 @@ update
   -> Manipulation db params row1
 update tab columns wh returning = UnsafeManipulation $
   "UPDATE"
-  <+> renderQualifiedAlias tab
+  <+> renderSQL tab
   <+> "SET"
   <+> renderCommaSeparated renderColumnExpression columns
   <+> "WHERE" <+> renderExpression wh
@@ -558,7 +558,7 @@ deleteFrom
   -> Manipulation db params row1
 deleteFrom tab using wh returning = UnsafeManipulation $
   "DELETE FROM"
-  <+> renderQualifiedAlias tab
+  <+> renderSQL tab
   <> case using of
     NoUsing -> ""
     Using tables -> " USING" <+> renderFromClause tables

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -71,7 +71,7 @@ let
     :: Has "migrations" schemas MigrationsSchema
     => PQ schemas schemas IO ()
   numMigrations = do
-    result <- runQuery (selectStar (from (table (#migrations ! #schema_migrations `as` #m))))
+    result <- runQuery (select Star (from (table (#migrations ! #schema_migrations `as` #m))))
     num <- ntuples result
     liftBase $ print num
 :}

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -291,7 +291,7 @@ selectMigration
   :: Has "migrations" schemas MigrationsSchema
   => Query ('[] :=> schemas) '[ 'NotNull 'PGtext ]
     '[ "executed_at" ::: 'NotNull 'PGtimestamptz ]
-selectMigration = select
+selectMigration = select_
   (#executed_at `as` #executed_at)
   ( from (table ((#migrations ! #schema_migrations) `as` #m))
     & where_ (#name .== param @1))

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -401,9 +401,9 @@ SELECT queries
 -- the intermediate table are actually output.
 select
   :: (SListI columns, columns ~ (col ': cols))
-  => NP (Aliased (Expression db from grouping params)) columns
+  => NP (Aliased (Expression db params grp from)) columns
   -- ^ select list
-  -> TableExpression db params from grouping
+  -> TableExpression db params grp from
   -- ^ intermediate virtual table
   -> Query db params columns
 select list rels = UnsafeQuery $
@@ -415,9 +415,9 @@ select list rels = UnsafeQuery $
 -- be subject to the elimination of duplicate rows using `selectDistinct`.
 selectDistinct
   :: (SListI columns, columns ~ (col ': cols))
-  => NP (Aliased (Expression db from 'Ungrouped params)) columns
+  => NP (Aliased (Expression db params 'Ungrouped from)) columns
   -- ^ select list
-  -> TableExpression db params from 'Ungrouped
+  -> TableExpression db params 'Ungrouped from
   -- ^ intermediate virtual table
   -> Query db params columns
 selectDistinct list rels = UnsafeQuery $
@@ -429,7 +429,7 @@ selectDistinct list rels = UnsafeQuery $
 -- that the table expression produces.
 selectStar
   :: HasUnique table from columns
-  => TableExpression db params from 'Ungrouped
+  => TableExpression db params 'Ungrouped from
   -- ^ intermediate virtual table
   -> Query db params columns
 selectStar rels = UnsafeQuery $ "SELECT" <+> "*" <+> renderTableExpression rels
@@ -438,7 +438,7 @@ selectStar rels = UnsafeQuery $ "SELECT" <+> "*" <+> renderTableExpression rels
 -- produces and eliminates duplicate rows.
 selectDistinctStar
   :: HasUnique table from columns
-  => TableExpression db params from 'Ungrouped
+  => TableExpression db params 'Ungrouped from
   -- ^ intermediate virtual table
   -> Query db params columns
 selectDistinctStar rels = UnsafeQuery $
@@ -450,7 +450,7 @@ selectDotStar
   :: Has table from columns
   => Alias table
   -- ^ particular virtual subtable
-  -> TableExpression db params from 'Ungrouped
+  -> TableExpression db params 'Ungrouped from
   -- ^ intermediate virtual table
   -> Query db params columns
 selectDotStar rel tab = UnsafeQuery $
@@ -462,7 +462,7 @@ selectDistinctDotStar
   :: Has table from columns
   => Alias table
   -- ^ particular virtual table
-  -> TableExpression db params from 'Ungrouped
+  -> TableExpression db params 'Ungrouped from
   -- ^ intermediate virtual table
   -> Query db params columns
 selectDistinctDotStar rel tab = UnsafeQuery $
@@ -480,8 +480,8 @@ selectDistinctDotStar rel tab = UnsafeQuery $
 -- SELECT * FROM (VALUES (1, E'one')) AS t ("a", "b")
 values
   :: SListI cols
-  => NP (Aliased (Expression db '[] 'Ungrouped params)) cols
-  -> [NP (Aliased (Expression db '[] 'Ungrouped params)) cols]
+  => NP (Aliased (Expression db params 'Ungrouped '[] )) cols
+  -> [NP (Aliased (Expression db params 'Ungrouped '[] )) cols]
   -- ^ When more than one row is specified, all the rows must
   -- must have the same number of elements
   -> Query db params cols
@@ -495,7 +495,7 @@ values rw rws = UnsafeQuery $ "SELECT * FROM"
   <+> parenthesized (renderCommaSeparated renderAliasPart rw)
   where
     renderAliasPart, renderValuePart
-      :: Aliased (Expression db '[] 'Ungrouped params) ty -> ByteString
+      :: Aliased (Expression db params 'Ungrouped '[] ) ty -> ByteString
     renderAliasPart (_ `As` name) = renderAlias name
     renderValuePart (value `As` _) = renderExpression value
 
@@ -503,7 +503,7 @@ values rw rws = UnsafeQuery $ "SELECT * FROM"
 -- specified by value expressions.
 values_
   :: SListI cols
-  => NP (Aliased (Expression db '[] 'Ungrouped params)) cols
+  => NP (Aliased (Expression db params 'Ungrouped '[] )) cols
   -- ^ one row of values
   -> Query db params cols
 values_ rw = values rw []
@@ -521,13 +521,13 @@ Table Expressions
 data TableExpression
   (db :: DBType)
   (params :: [NullityType])
+  (grp :: Grouping)
   (from :: FromType)
-  (grouping :: Grouping)
     = TableExpression
     { fromClause :: FromClause db params from
     -- ^ A table reference that can be a table name, or a derived table such
     -- as a subquery, a @JOIN@ construct, or complex combinations of these.
-    , whereClause :: [Condition db from 'Ungrouped params]
+    , whereClause :: [Condition db params 'Ungrouped from]
     -- ^ optional search coditions, combined with `.&&`. After the processing
     -- of the `fromClause` is done, each row of the derived virtual table
     -- is checked against the search condition. If the result of the
@@ -536,20 +536,20 @@ data TableExpression
     -- at least one column of the table generated in the `fromClause`;
     -- this is not required, but otherwise the WHERE clause will
     -- be fairly useless.
-    , groupByClause :: GroupByClause from grouping
+    , groupByClause :: GroupByClause grp from
     -- ^ The `groupByClause` is used to group together those rows in a table
     -- that have the same values in all the columns listed. The order in which
     -- the columns are listed does not matter. The effect is to combine each
     -- set of rows having common values into one group row that represents all
     -- rows in the group. This is done to eliminate redundancy in the output
     -- and/or compute aggregates that apply to these groups.
-    , havingClause :: HavingClause db from grouping params
+    , havingClause :: HavingClause db params grp from
     -- ^ If a table has been grouped using `groupBy`, but only certain groups
     -- are of interest, the `havingClause` can be used, much like a
     -- `whereClause`, to eliminate groups from the result. Expressions in the
     -- `havingClause` can refer both to grouped expressions and to ungrouped
     -- expressions (which necessarily involve an aggregate function).
-    , orderByClause :: [SortExpression db from grouping params]
+    , orderByClause :: [SortExpression db params grp from]
     -- ^ The `orderByClause` is for optional sorting. When more than one
     -- `SortExpression` is specified, the later (right) values are used to sort
     -- rows that are equal according to the earlier (left) values.
@@ -567,7 +567,7 @@ data TableExpression
 
 -- | Render a `TableExpression`
 renderTableExpression
-  :: TableExpression db params from grouping
+  :: TableExpression db params grp from
   -> ByteString
 renderTableExpression
   (TableExpression frm' whs' grps' hvs' srts' lims' offs') = mconcat
@@ -602,15 +602,15 @@ renderTableExpression
 -- to match the left-to-right sequencing of their placement in SQL.
 from
   :: FromClause db params from -- ^ table reference
-  -> TableExpression db params from 'Ungrouped
+  -> TableExpression db params 'Ungrouped from
 from rels = TableExpression rels [] NoGroups NoHaving [] [] []
 
 -- | A `where_` is an endomorphism of `TableExpression`s which adds a
 -- search condition to the `whereClause`.
 where_
-  :: Condition db from 'Ungrouped params -- ^ filtering condition
-  -> TableExpression db params from grouping
-  -> TableExpression db params from grouping
+  :: Condition db params 'Ungrouped from -- ^ filtering condition
+  -> TableExpression db params grp from
+  -> TableExpression db params grp from
 where_ wh rels = rels {whereClause = wh : whereClause rels}
 
 -- | A `groupBy` is a transformation of `TableExpression`s which switches
@@ -619,8 +619,8 @@ where_ wh rels = rels {whereClause = wh : whereClause rels}
 groupBy
   :: SListI bys
   => NP (By from) bys -- ^ grouped columns
-  -> TableExpression db params from 'Ungrouped
-  -> TableExpression db params from ('Grouped bys)
+  -> TableExpression db params 'Ungrouped from
+  -> TableExpression db params ('Grouped bys) from
 groupBy bys rels = TableExpression
   { fromClause = fromClause rels
   , whereClause = whereClause rels
@@ -634,34 +634,34 @@ groupBy bys rels = TableExpression
 -- | A `having` is an endomorphism of `TableExpression`s which adds a
 -- search condition to the `havingClause`.
 having
-  :: Condition db from ('Grouped bys) params -- ^ having condition
-  -> TableExpression db params from ('Grouped bys)
-  -> TableExpression db params from ('Grouped bys)
+  :: Condition db params ('Grouped bys) from -- ^ having condition
+  -> TableExpression db params ('Grouped bys) from
+  -> TableExpression db params ('Grouped bys) from
 having hv rels = rels
   { havingClause = case havingClause rels of Having hvs -> Having (hv:hvs) }
 
 -- | An `orderBy` is an endomorphism of `TableExpression`s which appends an
 -- ordering to the right of the `orderByClause`.
 orderBy
-  :: [SortExpression db from grouping params] -- ^ sort expressions
-  -> TableExpression db params from grouping
-  -> TableExpression db params from grouping
+  :: [SortExpression db params grp from] -- ^ sort expressions
+  -> TableExpression db params grp from
+  -> TableExpression db params grp from
 orderBy srts rels = rels {orderByClause = orderByClause rels ++ srts}
 
 -- | A `limit` is an endomorphism of `TableExpression`s which adds to the
 -- `limitClause`.
 limit
   :: Word64 -- ^ limit parameter
-  -> TableExpression db params from grouping
-  -> TableExpression db params from grouping
+  -> TableExpression db params grp from
+  -> TableExpression db params grp from
 limit lim rels = rels {limitClause = lim : limitClause rels}
 
 -- | An `offset` is an endomorphism of `TableExpression`s which adds to the
 -- `offsetClause`.
 offset
   :: Word64 -- ^ offset parameter
-  -> TableExpression db params from grouping
-  -> TableExpression db params from grouping
+  -> TableExpression db params grp from
+  -> TableExpression db params grp from
 offset off rels = rels {offsetClause = off : offsetClause rels}
 
 {-----------------------------------------
@@ -670,55 +670,55 @@ JSON stuff
 
 unsafeSetOfFunction
   :: ByteString
-  -> Expression db '[] 'Ungrouped params ty
+  -> Expression db params 'Ungrouped '[]  ty
   -> Query db params row
 unsafeSetOfFunction fun expr = UnsafeQuery $
   "SELECT * FROM " <> fun <> "(" <> renderExpression expr <> ")"
 
 -- | Expands the outermost JSON object into a set of key/value pairs.
 jsonEach
-  :: Expression db '[] 'Ungrouped params (nullity 'PGjson) -- ^ json object
+  :: Expression db params 'Ungrouped '[]  (nullity 'PGjson) -- ^ json object
   -> Query db params
       '["key" ::: 'NotNull 'PGtext, "value" ::: 'NotNull 'PGjson]
 jsonEach = unsafeSetOfFunction "json_each"
 
 -- | Expands the outermost binary JSON object into a set of key/value pairs.
 jsonbEach
-  :: Expression db '[] 'Ungrouped params (nullity 'PGjsonb) -- ^ jsonb object
+  :: Expression db params 'Ungrouped '[]  (nullity 'PGjsonb) -- ^ jsonb object
   -> Query db params
       '["key" ::: 'NotNull 'PGtext, "value" ::: 'NotNull 'PGjsonb]
 jsonbEach = unsafeSetOfFunction "jsonb_each"
 
 -- | Expands the outermost JSON object into a set of key/value pairs.
 jsonEachAsText
-  :: Expression db '[] 'Ungrouped params (nullity 'PGjson) -- ^ json object
+  :: Expression db params 'Ungrouped '[]  (nullity 'PGjson) -- ^ json object
   -> Query db params
       '["key" ::: 'NotNull 'PGtext, "value" ::: 'NotNull 'PGtext]
 jsonEachAsText = unsafeSetOfFunction "json_each_text"
 
 -- | Expands the outermost binary JSON object into a set of key/value pairs.
 jsonbEachAsText
-  :: Expression db '[] 'Ungrouped params (nullity 'PGjsonb) -- ^ jsonb object
+  :: Expression db params 'Ungrouped '[]  (nullity 'PGjsonb) -- ^ jsonb object
   -> Query db params
     '["key" ::: 'NotNull 'PGtext, "value" ::: 'NotNull 'PGtext]
 jsonbEachAsText = unsafeSetOfFunction "jsonb_each_text"
 
 -- | Returns set of keys in the outermost JSON object.
 jsonObjectKeys
-  :: Expression db '[] 'Ungrouped params (nullity 'PGjson) -- ^ json object
+  :: Expression db params 'Ungrouped '[]  (nullity 'PGjson) -- ^ json object
   -> Query db params '["json_object_keys" ::: 'NotNull 'PGtext]
 jsonObjectKeys = unsafeSetOfFunction "json_object_keys"
 
 -- | Returns set of keys in the outermost JSON object.
 jsonbObjectKeys
-  :: Expression db '[] 'Ungrouped params (nullity 'PGjsonb) -- ^ jsonb object
+  :: Expression db params 'Ungrouped '[]  (nullity 'PGjsonb) -- ^ jsonb object
   -> Query db params '["jsonb_object_keys" ::: 'NotNull 'PGtext]
 jsonbObjectKeys = unsafeSetOfFunction "jsonb_object_keys"
 
 unsafePopulateFunction
   :: ByteString
   -> TypeExpression schemas (nullity ('PGcomposite row))
-  -> Expression (commons :=> schemas) '[] 'Ungrouped params ty
+  -> Expression (commons :=> schemas) params 'Ungrouped '[]  ty
   -> Query (commons :=> schemas) params row
 unsafePopulateFunction fun ty expr = UnsafeQuery $
   "SELECT * FROM " <> fun <> "("
@@ -729,7 +729,7 @@ unsafePopulateFunction fun ty expr = UnsafeQuery $
 -- type defined by the given table.
 jsonPopulateRecord
   :: TypeExpression schemas (nullity ('PGcomposite row)) -- ^ row type
-  -> Expression (commons :=> schemas) '[] 'Ungrouped params (nullity 'PGjson) -- ^ json object
+  -> Expression (commons :=> schemas) params 'Ungrouped '[]  (nullity 'PGjson) -- ^ json object
   -> Query (commons :=> schemas) params row
 jsonPopulateRecord = unsafePopulateFunction "json_populate_record"
 
@@ -737,7 +737,7 @@ jsonPopulateRecord = unsafePopulateFunction "json_populate_record"
 -- type defined by the given table.
 jsonbPopulateRecord
   :: TypeExpression schemas (nullity ('PGcomposite row)) -- ^ row type
-  -> Expression (commons :=> schemas) '[] 'Ungrouped params (nullity 'PGjsonb) -- ^ jsonb object
+  -> Expression (commons :=> schemas) params 'Ungrouped '[]  (nullity 'PGjsonb) -- ^ jsonb object
   -> Query (commons :=> schemas) params row
 jsonbPopulateRecord = unsafePopulateFunction "jsonb_populate_record"
 
@@ -745,7 +745,7 @@ jsonbPopulateRecord = unsafePopulateFunction "jsonb_populate_record"
 -- set of rows whose columns match the record type defined by the given table.
 jsonPopulateRecordSet
   :: TypeExpression schemas (nullity ('PGcomposite row)) -- ^ row type
-  -> Expression (commons :=> schemas) '[] 'Ungrouped params (nullity 'PGjson) -- ^ json array
+  -> Expression (commons :=> schemas) params 'Ungrouped '[]  (nullity 'PGjson) -- ^ json array
   -> Query (commons :=> schemas) params row
 jsonPopulateRecordSet = unsafePopulateFunction "json_populate_record_set"
 
@@ -754,14 +754,14 @@ jsonPopulateRecordSet = unsafePopulateFunction "json_populate_record_set"
 -- table.
 jsonbPopulateRecordSet
   :: TypeExpression schemas (nullity ('PGcomposite row)) -- ^ row type
-  -> Expression (commons :=> schemas) '[] 'Ungrouped params (nullity 'PGjsonb) -- ^ jsonb array
+  -> Expression (commons :=> schemas) params 'Ungrouped '[]  (nullity 'PGjsonb) -- ^ jsonb array
   -> Query (commons :=> schemas) params row
 jsonbPopulateRecordSet = unsafePopulateFunction "jsonb_populate_record_set"
 
 unsafeRecordFunction
   :: (SListI record, json `In` PGJsonType)
   => ByteString
-  -> Expression (commons :=> schemas) '[] 'Ungrouped params (nullity json)
+  -> Expression (commons :=> schemas) params 'Ungrouped '[]  (nullity json)
   -> NP (Aliased (TypeExpression schemas)) record
   -> Query (commons :=> schemas) params record
 unsafeRecordFunction fun expr types = UnsafeQuery $
@@ -776,7 +776,7 @@ unsafeRecordFunction fun expr types = UnsafeQuery $
 -- | Builds an arbitrary record from a JSON object.
 jsonToRecord
   :: SListI record
-  => Expression (commons :=> schemas) '[] 'Ungrouped params (nullity 'PGjson) -- ^ json object
+  => Expression (commons :=> schemas) params 'Ungrouped '[]  (nullity 'PGjson) -- ^ json object
   -> NP (Aliased (TypeExpression schemas)) record -- ^ record types
   -> Query (commons :=> schemas) params record
 jsonToRecord = unsafeRecordFunction "json_to_record"
@@ -784,7 +784,7 @@ jsonToRecord = unsafeRecordFunction "json_to_record"
 -- | Builds an arbitrary record from a binary JSON object.
 jsonbToRecord
   :: SListI record
-  => Expression (commons :=> schemas) '[] 'Ungrouped params (nullity 'PGjsonb) -- ^ jsonb object
+  => Expression (commons :=> schemas) params 'Ungrouped '[]  (nullity 'PGjsonb) -- ^ jsonb object
   -> NP (Aliased (TypeExpression schemas)) record -- ^ record types
   -> Query (commons :=> schemas) params record
 jsonbToRecord = unsafeRecordFunction "jsonb_to_record"
@@ -792,7 +792,7 @@ jsonbToRecord = unsafeRecordFunction "jsonb_to_record"
 -- | Builds an arbitrary set of records from a JSON array of objects.
 jsonToRecordSet
   :: SListI record
-  => Expression (commons :=> schemas) '[] 'Ungrouped params (nullity 'PGjson) -- ^ json array
+  => Expression (commons :=> schemas) params 'Ungrouped '[]  (nullity 'PGjson) -- ^ json array
   -> NP (Aliased (TypeExpression schemas)) record -- ^ record types
   -> Query (commons :=> schemas) params record
 jsonToRecordSet = unsafeRecordFunction "json_to_record_set"
@@ -800,7 +800,7 @@ jsonToRecordSet = unsafeRecordFunction "json_to_record_set"
 -- | Builds an arbitrary set of records from a binary JSON array of objects.
 jsonbToRecordSet
   :: SListI record
-  => Expression (commons :=> schemas) '[] 'Ungrouped params (nullity 'PGjsonb) -- ^ jsonb array
+  => Expression (commons :=> schemas) params 'Ungrouped '[]  (nullity 'PGjsonb) -- ^ jsonb array
   -> NP (Aliased (TypeExpression schemas)) record -- ^ record types
   -> Query (commons :=> schemas) params record
 jsonbToRecordSet = unsafeRecordFunction "jsonb_to_record_set"
@@ -867,7 +867,7 @@ the @on@ condition.
 innerJoin
   :: FromClause db params right
   -- ^ right
-  -> Condition db (Join left right) 'Ungrouped params
+  -> Condition db params 'Ungrouped (Join left right)
   -- ^ @on@ condition
   -> FromClause db params left
   -- ^ left
@@ -884,7 +884,7 @@ innerJoin right on left = UnsafeFromClause $
 leftOuterJoin
   :: FromClause db params right
   -- ^ right
-  -> Condition db (Join left right) 'Ungrouped params
+  -> Condition db params 'Ungrouped (Join left right)
   -- ^ @on@ condition
   -> FromClause db params left
   -- ^ left
@@ -902,7 +902,7 @@ leftOuterJoin right on left = UnsafeFromClause $
 rightOuterJoin
   :: FromClause db params right
   -- ^ right
-  -> Condition db (Join left right) 'Ungrouped params
+  -> Condition db params 'Ungrouped (Join left right)
   -- ^ @on@ condition
   -> FromClause db params left
   -- ^ left
@@ -921,7 +921,7 @@ rightOuterJoin right on left = UnsafeFromClause $
 fullOuterJoin
   :: FromClause db params right
   -- ^ right
-  -> Condition db (Join left right) 'Ungrouped params
+  -> Condition db params 'Ungrouped (Join left right)
   -- ^ @on@ condition
   -> FromClause db params left
   -- ^ left
@@ -978,15 +978,15 @@ renderBy = \case
 -- done on @NoGroups@ while all output `Expression`s must be aggregated
 -- in @Group Nil@. In general, all output `Expression`s in the
 -- complement of @bys@ must be aggregated in @Group bys@.
-data GroupByClause from grouping where
-  NoGroups :: GroupByClause from 'Ungrouped
+data GroupByClause grp from where
+  NoGroups :: GroupByClause 'Ungrouped from
   Group
     :: SListI bys
     => NP (By from) bys
-    -> GroupByClause from ('Grouped bys)
+    -> GroupByClause ('Grouped bys) from
 
 -- | Renders a `GroupByClause`.
-renderGroupByClause :: GroupByClause from grouping -> ByteString
+renderGroupByClause :: GroupByClause grp from -> ByteString
 renderGroupByClause = \case
   NoGroups -> ""
   Group Nil -> ""
@@ -996,17 +996,17 @@ renderGroupByClause = \case
 -- An `Ungrouped` `TableExpression` may only use `NoHaving` while a `Grouped`
 -- `TableExpression` must use `Having` whose conditions are combined with
 -- `.&&`.
-data HavingClause db from grouping params where
-  NoHaving :: HavingClause db from 'Ungrouped params
+data HavingClause db params grp from where
+  NoHaving :: HavingClause db params 'Ungrouped from
   Having
-    :: [Condition db from ('Grouped bys) params]
-    -> HavingClause db from ('Grouped bys) params
-deriving instance Show (HavingClause db from grouping params)
-deriving instance Eq (HavingClause db from grouping params)
-deriving instance Ord (HavingClause db from grouping params)
+    :: [Condition db params ('Grouped bys) from]
+    -> HavingClause db params ('Grouped bys) from
+deriving instance Show (HavingClause db params grp from)
+deriving instance Eq (HavingClause db params grp from)
+deriving instance Ord (HavingClause db params grp from)
 
 -- | Render a `HavingClause`.
-renderHavingClause :: HavingClause db from grouping params -> ByteString
+renderHavingClause :: HavingClause db params grp from -> ByteString
 renderHavingClause = \case
   NoHaving -> ""
   Having [] -> ""
@@ -1025,29 +1025,29 @@ Sorting
 -- `AscNullsLast`, `DescNullsFirst` and `DescNullsLast` options are used to
 -- determine whether nulls appear before or after non-null values in the sort
 -- ordering of a `Null` result column.
-data SortExpression db from grouping params where
+data SortExpression db params grp from where
     Asc
-      :: Expression db from grouping params ('NotNull ty)
-      -> SortExpression db from grouping params
+      :: Expression db params grp from ('NotNull ty)
+      -> SortExpression db params grp from
     Desc
-      :: Expression db from grouping params ('NotNull ty)
-      -> SortExpression db from grouping params
+      :: Expression db params grp from ('NotNull ty)
+      -> SortExpression db params grp from
     AscNullsFirst
-      :: Expression db from grouping params  ('Null ty)
-      -> SortExpression db from grouping params
+      :: Expression db params grp from  ('Null ty)
+      -> SortExpression db params grp from
     AscNullsLast
-      :: Expression db from grouping params  ('Null ty)
-      -> SortExpression db from grouping params
+      :: Expression db params grp from  ('Null ty)
+      -> SortExpression db params grp from
     DescNullsFirst
-      :: Expression db from grouping params  ('Null ty)
-      -> SortExpression db from grouping params
+      :: Expression db params grp from  ('Null ty)
+      -> SortExpression db params grp from
     DescNullsLast
-      :: Expression db from grouping params  ('Null ty)
-      -> SortExpression db from grouping params
-deriving instance Show (SortExpression db from grouping params)
+      :: Expression db params grp from  ('Null ty)
+      -> SortExpression db params grp from
+deriving instance Show (SortExpression db params grp from)
 
 -- | Render a `SortExpression`.
-renderSortExpression :: SortExpression db from grouping params -> ByteString
+renderSortExpression :: SortExpression db params grp from -> ByteString
 renderSortExpression = \case
   Asc expression -> renderExpression expression <+> "ASC"
   Desc expression -> renderExpression expression <+> "DESC"
@@ -1060,18 +1060,18 @@ renderSortExpression = \case
 
 unsafeSubqueryExpression
   :: ByteString
-  -> Expression db from grp params ty
+  -> Expression db params grp from ty
   -> Query db params '[alias ::: ty]
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 unsafeSubqueryExpression op x q = UnsafeExpression $
   renderExpression x <+> op <+> parenthesized (renderQuery q)
 
 unsafeRowSubqueryExpression
   :: SListI row
   => ByteString
-  -> NP (Aliased (Expression db from grp params)) row
+  -> NP (Aliased (Expression db params grp from)) row
   -> Query db params row
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 unsafeRowSubqueryExpression op xs q = UnsafeExpression $
   renderExpression (row xs) <+> op <+> parenthesized (renderQuery q)
 
@@ -1084,9 +1084,9 @@ unsafeRowSubqueryExpression op xs q = UnsafeExpression $
 -- >>> printSQL $ true `in_` values_ (true `as` #foo)
 -- TRUE IN (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 in_
-  :: Expression db from grp params ty -- ^ expression
+  :: Expression db params grp from ty -- ^ expression
   -> Query db params '[alias ::: ty] -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 in_ = unsafeSubqueryExpression "IN"
 
 {- | The left-hand side of this form of `rowIn` is a row constructor.
@@ -1099,231 +1099,231 @@ is `true` if any equal subquery row is found.
 The result is `false` if no equal row is found
 (including the case where the subquery returns no rows).
 
->>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db from grp params)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+>>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db params grp from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 >>> printSQL $ myRow `rowIn` values_ myRow
 ROW(1, FALSE) IN (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 -}
 rowIn
   :: SListI row
-  => NP (Aliased (Expression db from grp params)) row -- ^ row constructor
+  => NP (Aliased (Expression db params grp from)) row -- ^ row constructor
   -> Query db params row -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 rowIn = unsafeRowSubqueryExpression "IN"
 
 -- | >>> printSQL $ true `eqAll` values_ (true `as` #foo)
 -- TRUE = ALL (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 eqAll
-  :: Expression db from grp params ty -- ^ expression
+  :: Expression db params grp from ty -- ^ expression
   -> Query db params '[alias ::: ty] -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 eqAll = unsafeSubqueryExpression "= ALL"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db from grp params)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db params grp from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowEqAll` values_ myRow
 -- ROW(1, FALSE) = ALL (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowEqAll
   :: SListI row
-  => NP (Aliased (Expression db from grp params)) row -- ^ row constructor
+  => NP (Aliased (Expression db params grp from)) row -- ^ row constructor
   -> Query db params row -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 rowEqAll = unsafeRowSubqueryExpression "= ALL"
 
 -- | >>> printSQL $ true `eqAny` values_ (true `as` #foo)
 -- TRUE = ANY (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 eqAny
-  :: Expression db from grp params ty -- ^ expression
+  :: Expression db params grp from ty -- ^ expression
   -> Query db params '[alias ::: ty] -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 eqAny = unsafeSubqueryExpression "= ANY"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db from grp params)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db params grp from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowEqAny` values_ myRow
 -- ROW(1, FALSE) = ANY (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowEqAny
   :: SListI row
-  => NP (Aliased (Expression db from grp params)) row -- ^ row constructor
+  => NP (Aliased (Expression db params grp from)) row -- ^ row constructor
   -> Query db params row -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 rowEqAny = unsafeRowSubqueryExpression "= ANY"
 
 -- | >>> printSQL $ true `neqAll` values_ (true `as` #foo)
 -- TRUE <> ALL (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 neqAll
-  :: Expression db from grp params ty -- ^ expression
+  :: Expression db params grp from ty -- ^ expression
   -> Query db params '[alias ::: ty] -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 neqAll = unsafeSubqueryExpression "<> ALL"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db from grp params)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db params grp from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowNeqAll` values_ myRow
 -- ROW(1, FALSE) <> ALL (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowNeqAll
   :: SListI row
-  => NP (Aliased (Expression db from grp params)) row -- ^ row constructor
+  => NP (Aliased (Expression db params grp from)) row -- ^ row constructor
   -> Query db params row -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 rowNeqAll = unsafeRowSubqueryExpression "<> ALL"
 
 -- | >>> printSQL $ true `neqAny` values_ (true `as` #foo)
 -- TRUE <> ANY (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 neqAny
-  :: Expression db from grp params ty -- ^ expression
+  :: Expression db params grp from ty -- ^ expression
   -> Query db params '[alias ::: ty] -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 neqAny = unsafeSubqueryExpression "<> ANY"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db from grp params)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db params grp from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowNeqAny` values_ myRow
 -- ROW(1, FALSE) <> ANY (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowNeqAny
   :: SListI row
-  => NP (Aliased (Expression db from grp params)) row -- ^ row constructor
+  => NP (Aliased (Expression db params grp from)) row -- ^ row constructor
   -> Query db params row -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 rowNeqAny = unsafeRowSubqueryExpression "<> ANY"
 
 -- | >>> printSQL $ true `allLt` values_ (true `as` #foo)
 -- TRUE ALL < (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 allLt
-  :: Expression db from grp params ty -- ^ expression
+  :: Expression db params grp from ty -- ^ expression
   -> Query db params '[alias ::: ty] -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 allLt = unsafeSubqueryExpression "ALL <"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db from grp params)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db params grp from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowLtAll` values_ myRow
 -- ROW(1, FALSE) ALL < (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowLtAll
   :: SListI row
-  => NP (Aliased (Expression db from grp params)) row -- ^ row constructor
+  => NP (Aliased (Expression db params grp from)) row -- ^ row constructor
   -> Query db params row -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 rowLtAll = unsafeRowSubqueryExpression "ALL <"
 
 -- | >>> printSQL $ true `ltAny` values_ (true `as` #foo)
 -- TRUE ANY < (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 ltAny
-  :: Expression db from grp params ty -- ^ expression
+  :: Expression db params grp from ty -- ^ expression
   -> Query db params '[alias ::: ty] -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 ltAny = unsafeSubqueryExpression "ANY <"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db from grp params)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db params grp from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowLtAll` values_ myRow
 -- ROW(1, FALSE) ALL < (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowLtAny
   :: SListI row
-  => NP (Aliased (Expression db from grp params)) row -- ^ row constructor
+  => NP (Aliased (Expression db params grp from)) row -- ^ row constructor
   -> Query db params row -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 rowLtAny = unsafeRowSubqueryExpression "ANY <"
 
 -- | >>> printSQL $ true `lteAll` values_ (true `as` #foo)
 -- TRUE <= ALL (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 lteAll
-  :: Expression db from grp params ty -- ^ expression
+  :: Expression db params grp from ty -- ^ expression
   -> Query db params '[alias ::: ty] -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 lteAll = unsafeSubqueryExpression "<= ALL"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db from grp params)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db params grp from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowLteAll` values_ myRow
 -- ROW(1, FALSE) <= ALL (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowLteAll
   :: SListI row
-  => NP (Aliased (Expression db from grp params)) row -- ^ row constructor
+  => NP (Aliased (Expression db params grp from)) row -- ^ row constructor
   -> Query db params row -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 rowLteAll = unsafeRowSubqueryExpression "<= ALL"
 
 -- | >>> printSQL $ true `lteAny` values_ (true `as` #foo)
 -- TRUE <= ANY (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 lteAny
-  :: Expression db from grp params ty -- ^ expression
+  :: Expression db params grp from ty -- ^ expression
   -> Query db params '[alias ::: ty] -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 lteAny = unsafeSubqueryExpression "<= ANY"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db from grp params)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db params grp from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowLteAny` values_ myRow
 -- ROW(1, FALSE) <= ANY (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowLteAny
   :: SListI row
-  => NP (Aliased (Expression db from grp params)) row -- ^ row constructor
+  => NP (Aliased (Expression db params grp from)) row -- ^ row constructor
   -> Query db params row -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 rowLteAny = unsafeRowSubqueryExpression "<= ANY"
 
 -- | >>> printSQL $ true `gtAll` values_ (true `as` #foo)
 -- TRUE > ALL (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 gtAll
-  :: Expression db from grp params ty -- ^ expression
+  :: Expression db params grp from ty -- ^ expression
   -> Query db params '[alias ::: ty] -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 gtAll = unsafeSubqueryExpression "> ALL"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db from grp params)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db params grp from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowGtAll` values_ myRow
 -- ROW(1, FALSE) > ALL (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowGtAll
   :: SListI row
-  => NP (Aliased (Expression db from grp params)) row -- ^ row constructor
+  => NP (Aliased (Expression db params grp from)) row -- ^ row constructor
   -> Query db params row -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 rowGtAll = unsafeRowSubqueryExpression "> ALL"
 
 -- | >>> printSQL $ true `gtAny` values_ (true `as` #foo)
 -- TRUE > ANY (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 gtAny
-  :: Expression db from grp params ty -- ^ expression
+  :: Expression db params grp from ty -- ^ expression
   -> Query db params '[alias ::: ty] -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 gtAny = unsafeSubqueryExpression "> ANY"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db from grp params)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db params grp from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowGtAny` values_ myRow
 -- ROW(1, FALSE) > ANY (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowGtAny
   :: SListI row
-  => NP (Aliased (Expression db from grp params)) row -- ^ row constructor
+  => NP (Aliased (Expression db params grp from)) row -- ^ row constructor
   -> Query db params row -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 rowGtAny = unsafeRowSubqueryExpression "> ANY"
 
 -- | >>> printSQL $ true `gteAll` values_ (true `as` #foo)
 -- TRUE >= ALL (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 gteAll
-  :: Expression db from grp params ty -- ^ expression
+  :: Expression db params grp from ty -- ^ expression
   -> Query db params '[alias ::: ty] -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 gteAll = unsafeSubqueryExpression ">= ALL"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db from grp params)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db params grp from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowGteAll` values_ myRow
 -- ROW(1, FALSE) >= ALL (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowGteAll
   :: SListI row
-  => NP (Aliased (Expression db from grp params)) row -- ^ row constructor
+  => NP (Aliased (Expression db params grp from)) row -- ^ row constructor
   -> Query db params row -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 rowGteAll = unsafeRowSubqueryExpression ">= ALL"
 
 -- | >>> printSQL $ true `gteAny` values_ (true `as` #foo)
 -- TRUE >= ANY (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 gteAny
-  :: Expression db from grp params ty -- ^ expression
+  :: Expression db params grp from ty -- ^ expression
   -> Query db params '[alias ::: ty] -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 gteAny = unsafeSubqueryExpression ">= ANY"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db from grp params)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression db params grp from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowGteAny` values_ myRow
 -- ROW(1, FALSE) >= ANY (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowGteAny
   :: SListI row
-  => NP (Aliased (Expression db from grp params)) row -- ^ row constructor
+  => NP (Aliased (Expression db params grp from)) row -- ^ row constructor
   -> Query db params row -- ^ subquery
-  -> Expression db from grp params (nullity 'PGbool)
+  -> Expression db params grp from (nullity 'PGbool)
 rowGteAny = unsafeRowSubqueryExpression ">= ANY"
 
 -- | A `CommonTableExpression` is an auxiliary statement in a `with` clause.

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -447,7 +447,7 @@ instance RenderSQL (Selection db params grp from row) where
 -- | the `TableExpression` in the `select` command constructs an intermediate
 -- virtual table by possibly combining tables, views, eliminating rows,
 -- grouping, etc. This table is finally passed on to processing by
--- the select list. The select list determines which columns of
+-- the select list. The `Selection` determines which columns of
 -- the intermediate table are actually output.
 select
   :: (SListI row, row ~ (x ': xs))

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -68,8 +68,6 @@ module Squeal.PostgreSQL.Schema
   , (:::)
   , Alias (..)
   , IsLabel (..)
-  , renderAliasString
-  , renderAliases
   , Aliased (As)
   , Aliasable (as)
   , renderAliasedAs
@@ -381,18 +379,14 @@ instance aliases ~ '[alias] => IsLabel alias (NP Alias aliases) where
 instance KnownSymbol alias => RenderSQL (Alias alias) where
   renderSQL = doubleQuoted . fromString . symbolVal
 
--- | >>> renderAliasString #ohmahgerd
--- "'ohmahgerd'"
-renderAliasString :: KnownSymbol alias => Alias alias -> ByteString
-renderAliasString = singleQuotedText . fromString . symbolVal
-
 -- | >>> import Generics.SOP (NP(..))
 -- >>> renderAliases (#jimbob :* #kandi)
 -- ["\"jimbob\"","\"kandi\""]
-renderAliases
-  :: All KnownSymbol aliases => NP Alias aliases -> [ByteString]
-renderAliases = hcollapse
-  . hcmap (Proxy @KnownSymbol) (K . renderSQL)
+instance All KnownSymbol aliases => RenderSQL (NP Alias aliases) where
+  renderSQL
+    = commaSeparated
+    . hcollapse
+    . hcmap (Proxy @KnownSymbol) (K . renderSQL)
 
 -- | The `As` operator is used to name an expression. `As` is like a demoted
 -- version of `:::`.


### PR DESCRIPTION
Introduces a `Selection` type

```Haskell
data Selection db params grp from row where
  List
    :: SListI row
    => NP (Aliased (Expression db params grp from)) row
    -> Selection db params grp from row
  Star
    :: HasUnique tab from row
    => Selection db params 'Ungrouped from row
  DotStar
    :: Has tab from row
    => Alias tab
    -> Selection db params 'Ungrouped from row
  Also
    :: Selection db params grp from right
    -> Selection db params grp from left
    -> Selection db params grp from (Join left right)
```

`Also` appends two `Selection`s, even selections of different forms, by rendering as ", ". It's analogous to `also` which is similar but for `TableExpressions`.

It also removes a lot of boilerplate by using the extant RenderSQL typeclass to abstract and remove various render___ functions. More could possibly be abstracted via QuantifiedConstraints but I haven't been able to get the latest GHC to work :-(

This PR is #79 without the work on window functions. I'm not confident in the window functions stuff just yet.