### PR TITLE
Add `Query_` and `Manipulation_` type families

### DIFF
--- a/squeal-postgresql/exe/Example.hs
+++ b/squeal-postgresql/exe/Example.hs
@@ -43,8 +43,6 @@ type Schema =
 
 type Schemas = Public Schema
 
-type DB = DBof Schemas
-
 setup :: Definition (Public '[]) Schemas
 setup = 
   createTable #users
@@ -64,17 +62,17 @@ setup =
 teardown :: Definition Schemas (Public '[])
 teardown = dropTable #emails >>> dropTable #users
 
-insertUser :: Manipulation DB '[ 'NotNull 'PGtext, 'NotNull ('PGvararray ('Null 'PGint2))]
+insertUser :: Manipulation '[] Schemas '[ 'NotNull 'PGtext, 'NotNull ('PGvararray ('Null 'PGint2))]
   '[ "fromOnly" ::: 'NotNull 'PGint4 ]
 insertUser = insertInto #users
   (Values_ (defaultAs #id :* param @1 `as` #name :* param @2 `as` #vec))
   (OnConflict (OnConstraint #pk_users) DoNothing) (Returning_ (#id `as` #fromOnly))
 
-insertEmail :: Manipulation DB '[ 'NotNull 'PGint4, 'Null 'PGtext] '[]
+insertEmail :: Manipulation '[] Schemas '[ 'NotNull 'PGint4, 'Null 'PGtext] '[]
 insertEmail = insertInto_ #emails
   (Values_ (defaultAs #id :* param @1 `as` #user_id :* param @2 `as` #email))
 
-getUsers :: Query DB '[]
+getUsers :: Query '[] Schemas '[]
   '[ "userName" ::: 'NotNull 'PGtext
    , "userEmail" ::: 'Null 'PGtext
    , "userVec" ::: 'NotNull ('PGvararray ('Null 'PGint2))]

--- a/squeal-postgresql/src/Squeal/PostgreSQL.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL.hs
@@ -115,9 +115,18 @@ need to retrieve the user id that the insert generates and insert it into
 the emails table. Take a careful look at the type and definition of both
 of our inserts.
 
+We'll need a Haskell type for users. We give the type `Generics.SOP.Generic` and
+`Generics.SOP.HasDatatypeInfo` instances so that we can decode the rows
+we receive when we run @getUsers@. Notice that the record fields of the
+@User@ type match the column names of @getUsers@.
+ 
+>>> data User = User { userName :: Text, userEmail :: Maybe Text } deriving (Show, GHC.Generic)
+>>> instance SOP.Generic User
+>>> instance SOP.HasDatatypeInfo User
+
 >>> :{
 let
-  insertUser :: Manipulation '[] Schemas '[ 'NotNull 'PGtext, 'Null 'PGtext ] '[]
+  insertUser :: Manipulation_ Schemas User ()
   insertUser = with (u `as` #u) e
     where
       u = insertInto #users
@@ -137,9 +146,7 @@ need to use an inner join to get the right result. A `Query` is like a
 
 >>> :{
 let
-  getUsers :: Query '[] Schemas '[]
-    '[ "userName"  ::: 'NotNull 'PGtext
-     , "userEmail" :::    'Null 'PGtext ]
+  getUsers :: Query_ Schemas () User
   getUsers = select_
     (#u ! #name `as` #userName :* #e ! #email `as` #userEmail)
     ( from (table (#users `as` #u)
@@ -150,17 +157,7 @@ let
 >>> printSQL getUsers
 SELECT "u"."name" AS "userName", "e"."email" AS "userEmail" FROM "users" AS "u" INNER JOIN "emails" AS "e" ON ("u"."id" = "e"."user_id")
 
-Now that we've defined the SQL side of things, we'll need a Haskell type
-for users. We give the type `Generics.SOP.Generic` and
-`Generics.SOP.HasDatatypeInfo` instances so that we can decode the rows
-we receive when we run @getUsers@. Notice that the record fields of the
-@User@ type match the column names of @getUsers@.
- 
->>> data User = User { userName :: Text, userEmail :: Maybe Text } deriving (Show, GHC.Generic)
->>> instance SOP.Generic User
->>> instance SOP.HasDatatypeInfo User
-
-Let's also create some users to add to the database.
+Let's create some users to add to the database.
 
 >>> :{
 let

--- a/squeal-postgresql/src/Squeal/PostgreSQL.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL.hs
@@ -47,7 +47,6 @@ type Schema =
   '[ "users" ::: 'Table (UsersConstraints :=> UsersColumns)
    , "emails" ::: 'Table (EmailsConstraints :=> EmailsColumns) ]
 type Schemas = Public Schema
-type DB = DBof Schemas
 :}
 
 Notice the use of type operators.
@@ -118,7 +117,7 @@ of our inserts.
 
 >>> :{
 let
-  insertUser :: Manipulation DB '[ 'NotNull 'PGtext, 'Null 'PGtext ] '[]
+  insertUser :: Manipulation '[] Schemas '[ 'NotNull 'PGtext, 'Null 'PGtext ] '[]
   insertUser = with (u `as` #u) e
     where
       u = insertInto #users
@@ -138,7 +137,7 @@ need to use an inner join to get the right result. A `Query` is like a
 
 >>> :{
 let
-  getUsers :: Query DB '[]
+  getUsers :: Query '[] Schemas '[]
     '[ "userName"  ::: 'NotNull 'PGtext
      , "userEmail" :::    'Null 'PGtext ]
   getUsers = select_

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -27,7 +27,7 @@ round trip query.
 >>> instance HasDatatypeInfo Row
 >>> :{
 let
-  roundTrip :: Query (DBof (Public '[])) (TuplePG Row) (RowPG Row)
+  roundTrip :: Query_ (Public '[]) Row Row
   roundTrip = values_ $
     parameter @1 int2 `as` #col1 :*
     parameter @2 text `as` #col2 :*
@@ -68,7 +68,7 @@ Once again, we define a simple round trip query.
 
 >>> :{
 let
-  roundTrip :: Query (DBof (Public '[])) (TuplePG Row) (RowPG Row)
+  roundTrip :: Query_ (Public '[]) Row Row
   roundTrip = values_ $
     parameter @1 (int2 & vararray)                  `as` #col1 :*
     parameter @2 (int2 & fixarray @2)               `as` #col2 :*
@@ -146,7 +146,7 @@ Once again, define a round trip query.
 
 >>> :{
 let
-  roundTrip :: Query (DBof (Public Schema)) (TuplePG Row) (RowPG Row)
+  roundTrip :: Query_ (Public Schema) Row Row
   roundTrip = values_ $
     parameter @1 (typedef #schwarma) `as` #schwarma :*
     parameter @2 (typedef #person)   `as` #person1  :*

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -297,7 +297,7 @@ check
      , HasAll aliases (TableToRow table) subcolumns )
   => NP Alias aliases
   -- ^ specify the subcolumns which are getting checked
-  -> (forall t. Condition ('[] :=> schemas) '[] 'Ungrouped '[t ::: subcolumns])
+  -> (forall t. Condition '[] schemas '[] 'Ungrouped '[t ::: subcolumns])
   -- ^ a closed `Condition` on those subcolumns
   -> TableConstraintExpression sch tab schemas ('Check aliases)
 check _cols condition = UnsafeTableConstraintExpression $
@@ -758,7 +758,7 @@ newtype AlterColumn (schemas :: SchemasType) (ty0 :: ColumnType) (ty1 :: ColumnT
 -- :}
 -- ALTER TABLE "tab" ALTER COLUMN "col" SET DEFAULT 5;
 setDefault
-  :: Expression ('[] :=> schemas) '[] 'Ungrouped '[] ty -- ^ default value to set
+  :: Expression '[] schemas '[] 'Ungrouped '[] ty -- ^ default value to set
   -> AlterColumn schemas (constraint :=> ty) ('Def :=> ty)
 setDefault expression = UnsafeAlterColumn $
   "SET DEFAULT" <+> renderExpression expression
@@ -843,7 +843,7 @@ CREATE VIEW "bc" AS SELECT "b" AS "b", "c" AS "c" FROM "abc" AS "abc";
 createView
   :: (KnownSymbol sch, KnownSymbol vw, Has sch schemas schema)
   => QualifiedAlias sch vw -- ^ the name of the view to add
-  -> Query ('[] :=> schemas) '[] view -- ^ query
+  -> Query '[] schemas '[] view -- ^ query
   -> Definition schemas (Alter sch (Create vw ('View view) schema) schemas)
 createView alias query = UnsafeDefinition $
   "CREATE" <+> "VIEW" <+> renderSQL alias <+> "AS"
@@ -1009,7 +1009,7 @@ notNullable ty = UnsafeColumnTypeExpression $ renderSQL ty <+> "NOT NULL"
 
 -- | used in `createTable` commands as a column constraint to give a default
 default_
-  :: Expression ('[] :=> schemas) '[] 'Ungrouped '[] ty
+  :: Expression '[] schemas '[] 'Ungrouped '[] ty
   -> ColumnTypeExpression schemas ('NoDef :=> ty)
   -> ColumnTypeExpression schemas ('Def :=> ty)
 default_ x ty = UnsafeColumnTypeExpression $

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -245,7 +245,7 @@ class KnownNat n => HasParameter
   | n params -> ty where
     -- | `parameter` takes a `Nat` using type application and a `TypeExpression`.
     --
-    -- >>> let expr = parameter @1 int4 :: Expression (DBof schemas) '[ 'Null 'PGint4] grp from ('Null 'PGint4)
+    -- >>> let expr = parameter @1 int4 :: Expression '[] schemas '[ 'Null 'PGint4] grp from ('Null 'PGint4)
     -- >>> printSQL expr
     -- ($1 :: int4)
     parameter
@@ -420,7 +420,7 @@ matchNull y f x = ifThenElse (isNull x) y
 `nullIf` gives @NULL@.
 
 >>> :set -XTypeApplications -XDataKinds
->>> let expr = nullIf false (param @1) :: Expression (commons :=> schema) '[ 'NotNull 'PGbool] grp from ('Null 'PGbool)
+>>> let expr = nullIf false (param @1) :: Expression commons schemas '[ 'NotNull 'PGbool] grp from ('Null 'PGbool)
 >>> printSQL expr
 NULL IF (FALSE, ($1 :: bool))
 -}
@@ -480,10 +480,9 @@ row exprs = UnsafeExpression $ "ROW" <> parenthesized
 --   '[ "real"      ::: 'NotNull 'PGfloat8
 --    , "imaginary" ::: 'NotNull 'PGfloat8 ]
 -- type Schema = '["complex" ::: 'Typedef Complex]
--- type DB = DBof (Public Schema)
 -- :}
 --
--- >>> let i = row (0 `as` #real :* 1 `as` #imaginary) :: Expression DB from grp params ('NotNull Complex)
+-- >>> let i = row (0 `as` #real :* 1 `as` #imaginary) :: Expression '[] (Public Schema) from grp params ('NotNull Complex)
 -- >>> printSQL $ i & field #complex #imaginary
 -- (ROW(0, 1)::"complex")."imaginary"
 field

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
@@ -78,7 +78,7 @@ simple insert:
 >>> type Schema = '["tab" ::: 'Table ('[] :=> Columns)]
 >>> :{
 let
-  manipulation :: Manipulation (DBof (Public Schema)) '[] '[]
+  manipulation :: Manipulation '[] (Public Schema) '[] '[]
   manipulation =
     insertInto_ #tab (Values_ (2 `as` #col1 :* defaultAs #col2))
 in printSQL manipulation
@@ -91,7 +91,7 @@ parameterized insert:
 >>> type Schema = '["tab" ::: 'Table ('[] :=> Columns)]
 >>> :{
 let
-  manipulation :: Manipulation (DBof (Public Schema)) '[ 'NotNull 'PGint4, 'NotNull 'PGint4 ] '[]
+  manipulation :: Manipulation '[] (Public Schema) '[ 'NotNull 'PGint4, 'NotNull 'PGint4 ] '[]
   manipulation =
     insertInto_ #tab (Values_ (param @1 `as` #col1 :* param @2 `as` #col2))
 in printSQL manipulation
@@ -102,7 +102,7 @@ returning insert:
 
 >>> :{
 let
-  manipulation :: Manipulation (DBof (Public Schema)) '[] '["fromOnly" ::: 'NotNull 'PGint4]
+  manipulation :: Manipulation '[] (Public Schema) '[] '["fromOnly" ::: 'NotNull 'PGint4]
   manipulation =
     insertInto #tab (Values_ (2 `as` #col1 :* 3 `as` #col2))
       OnConflictDoRaise (Returning (#col1 `as` #fromOnly))
@@ -117,7 +117,7 @@ upsert:
 >>> type CustomersSchema = '["customers" ::: 'Table (CustomersConstraints :=> CustomersColumns)]
 >>> :{
 let
-  manipulation :: Manipulation (DBof (Public CustomersSchema)) '[] '[]
+  manipulation :: Manipulation '[] (Public CustomersSchema) '[] '[]
   manipulation =
     insertInto #customers
       (Values_ ("John Smith" `as` #name :* "john@smith.com" `as` #email))
@@ -132,7 +132,7 @@ query insert:
 
 >>> :{
 let
-  manipulation :: Manipulation (DBof (Public Schema)) '[] '[]
+  manipulation :: Manipulation '[] (Public Schema) '[] '[]
   manipulation = insertInto_ #tab (Subquery (select Star (from (table #tab))))
 in printSQL manipulation
 :}
@@ -142,7 +142,7 @@ update:
 
 >>> :{
 let
-  manipulation :: Manipulation (DBof (Public Schema)) '[] '[]
+  manipulation :: Manipulation '[] (Public Schema) '[] '[]
   manipulation = update_ #tab (2 `as` #col1) (#col1 ./= #col2)
 in printSQL manipulation
 :}
@@ -152,7 +152,7 @@ delete:
 
 >>> :{
 let
-  manipulation :: Manipulation (DBof (Public Schema)) '[]
+  manipulation :: Manipulation '[] (Public Schema) '[]
     '[ "col1" ::: 'NotNull 'PGint4
      , "col2" ::: 'NotNull 'PGint4 ]
   manipulation = deleteFrom #tab NoUsing (#col1 .== #col2) (Returning Star)
@@ -171,7 +171,7 @@ type Schema3 =
 
 >>> :{
 let
-  manipulation :: Manipulation (DBof (Public Schema3)) '[] '[]
+  manipulation :: Manipulation '[] (Public Schema3) '[] '[]
   manipulation =
     deleteFrom_ #tab (Using (table #other_tab & also (table #third_tab)))
     ( (#tab ! #col2 .== #other_tab ! #col2)
@@ -186,7 +186,7 @@ with manipulation:
 >>> type ProductsSchema = '["products" ::: 'Table ('[] :=> ProductsColumns), "products_deleted" ::: 'Table ('[] :=> ProductsColumns)]
 >>> :{
 let
-  manipulation :: Manipulation (DBof (Public ProductsSchema)) '[ 'NotNull 'PGdate] '[]
+  manipulation :: Manipulation '[] (Public ProductsSchema) '[ 'NotNull 'PGdate] '[]
   manipulation = with
     (deleteFrom #products NoUsing (#date .< param @1) (Returning Star) `as` #del)
     (insertInto_ #products_deleted (Subquery (select Star (from (common #del)))))

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
@@ -231,8 +231,7 @@ more than one row, but there is no way to insert less than one row.
 Even if you know only some column values, a complete row must be created.
 -}
 insertInto
-  :: ( db ~ (commons :=> schemas)
-     , Has sch schemas schema
+  :: ( Has sch schemas schema
      , Has tab schema ('Table table)
      , columns ~ TableToColumns table
      , row0 ~ TableToRow table
@@ -250,8 +249,7 @@ insertInto tab qry conflict ret = UnsafeManipulation $
   <> renderSQL ret
 
 insertInto_
-  :: ( db ~ (commons :=> schemas)
-     , Has sch schemas schema
+  :: ( Has sch schemas schema
      , Has tab schema ('Table table)
      , columns ~ TableToColumns table
      , row ~ TableToRow table
@@ -276,7 +274,7 @@ data QueryClause commons schemas params columns where
   Subquery
     :: ColumnsToRow columns ~ row
     => Query commons schemas params row
-    -> QueryClause commmons schemas params columns
+    -> QueryClause commons schemas params columns
 
 instance RenderSQL (QueryClause commons schemas params columns) where
   renderSQL = \case

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -275,21 +275,21 @@ createMigrations =
 -- | Inserts a `Migration` into the `MigrationsTable`
 insertMigration
   :: Has "migrations" schemas MigrationsSchema
-  => Manipulation ('[] :=> schemas) '[ 'NotNull 'PGtext] '[]
+  => Manipulation '[] schemas '[ 'NotNull 'PGtext] '[]
 insertMigration = insertInto_ (#migrations ! #schema_migrations) . Values_ $
   (param @1) `as` #name :* defaultAs #executed_at
 
 -- | Deletes a `Migration` from the `MigrationsTable`
 deleteMigration
   :: Has "migrations" schemas MigrationsSchema
-  => Manipulation ('[] :=> schemas) '[ 'NotNull 'PGtext ] '[]
+  => Manipulation '[] schemas '[ 'NotNull 'PGtext ] '[]
 deleteMigration = deleteFrom_ (#migrations ! #schema_migrations) NoUsing (#name .== param @1)
 
 -- | Selects a `Migration` from the `MigrationsTable`, returning
 -- the time at which it was executed.
 selectMigration
   :: Has "migrations" schemas MigrationsSchema
-  => Query ('[] :=> schemas) '[ 'NotNull 'PGtext ]
+  => Query '[] schemas '[ 'NotNull 'PGtext ]
     '[ "executed_at" ::: 'NotNull 'PGtimestamptz ]
 selectMigration = select_
   (#executed_at `as` #executed_at)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
@@ -315,63 +315,63 @@ a default instance.
 class Monad pq => MonadPQ schemas pq | pq -> schemas where
   manipulateParams
     :: ToParams x params
-    => Manipulation ('[] :=> schemas) params ys
+    => Manipulation '[] schemas params ys
     -- ^ `insertRows`, `update` or `deleteFrom`
     -> x -> pq (K LibPQ.Result ys)
   default manipulateParams
     :: (MonadTrans t, MonadPQ schemas pq1, pq ~ t pq1)
     => ToParams x params
-    => Manipulation ('[] :=> schemas) params ys
+    => Manipulation '[] schemas params ys
     -- ^ `insertRows`, `update` or `deleteFrom`
     -> x -> pq (K LibPQ.Result ys)
   manipulateParams manipulation params = lift $
     manipulateParams manipulation params
 
-  manipulate :: Manipulation ('[] :=> schemas) '[] ys -> pq (K LibPQ.Result ys)
+  manipulate :: Manipulation '[] schemas '[] ys -> pq (K LibPQ.Result ys)
   manipulate statement = manipulateParams statement ()
 
   runQueryParams
     :: ToParams x params
-    => Query ('[] :=> schemas) params ys
+    => Query '[] schemas params ys
     -- ^ `select` and friends
     -> x -> pq (K LibPQ.Result ys)
   runQueryParams = manipulateParams . queryStatement
 
   runQuery
-    :: Query ('[] :=> schemas) '[] ys
+    :: Query '[] schemas '[] ys
     -- ^ `select` and friends
     -> pq (K LibPQ.Result ys)
   runQuery q = runQueryParams q ()
 
   traversePrepared
     :: (ToParams x params, Traversable list)
-    => Manipulation ('[] :=> schemas) params ys
+    => Manipulation '[] schemas params ys
     -- ^ `insertRows`, `update`, or `deleteFrom`, and friends
     -> list x -> pq (list (K LibPQ.Result ys))
   default traversePrepared
     :: (MonadTrans t, MonadPQ schemas pq1, pq ~ t pq1)
     => (ToParams x params, Traversable list)
-    => Manipulation ('[] :=> schemas) params ys -> list x -> pq (list (K LibPQ.Result ys))
+    => Manipulation '[] schemas params ys -> list x -> pq (list (K LibPQ.Result ys))
   traversePrepared manipulation params = lift $
     traversePrepared manipulation params
 
   forPrepared
     :: (ToParams x params, Traversable list)
     => list x
-    -> Manipulation ('[] :=> schemas) params ys
+    -> Manipulation '[] schemas params ys
     -- ^ `insertRows`, `update` or `deleteFrom`
     -> pq (list (K LibPQ.Result ys))
   forPrepared = flip traversePrepared
 
   traversePrepared_
     :: (ToParams x params, Foldable list)
-    => Manipulation ('[] :=> schemas) params '[]
+    => Manipulation '[] schemas params '[]
     -- ^ `insertRows`, `update` or `deleteFrom`
     -> list x -> pq ()
   default traversePrepared_
     :: (MonadTrans t, MonadPQ schemas pq1, pq ~ t pq1)
     => (ToParams x params, Foldable list)
-    => Manipulation ('[] :=> schemas) params '[]
+    => Manipulation '[] schemas params '[]
     -- ^ `insertRows`, `update` or `deleteFrom`
     -> list x -> pq ()
   traversePrepared_ manipulation params = lift $
@@ -380,7 +380,7 @@ class Monad pq => MonadPQ schemas pq | pq -> schemas where
   forPrepared_
     :: (ToParams x params, Foldable list)
     => list x
-    -> Manipulation ('[] :=> schemas) params '[]
+    -> Manipulation '[] schemas params '[]
     -- ^ `insertRows`, `update` or `deleteFrom`
     -> pq ()
   forPrepared_ = flip traversePrepared_
@@ -395,7 +395,7 @@ instance (MonadBase IO io, schemas0 ~ schemas, schemas1 ~ schemas)
   => MonadPQ schemas (PQ schemas0 schemas1 io) where
 
   manipulateParams
-    (UnsafeManipulation q :: Manipulation ('[] :=> schemas) ps ys) (params :: x) =
+    (UnsafeManipulation q :: Manipulation '[] schemas ps ys) (params :: x) =
       PQ $ \ (K conn) -> do
         let
           toParam' encoding =
@@ -411,7 +411,7 @@ instance (MonadBase IO io, schemas0 ~ schemas, schemas1 ~ schemas)
             return $ K (K result)
 
   traversePrepared
-    (UnsafeManipulation q :: Manipulation ('[] :=> schemas) xs ys) (list :: list x) =
+    (UnsafeManipulation q :: Manipulation '[] schemas xs ys) (list :: list x) =
       PQ $ \ (K conn) -> liftBase $ do
         let temp = "temporary_statement"
         prepResultMaybe <- LibPQ.prepare conn temp q Nothing
@@ -438,7 +438,7 @@ instance (MonadBase IO io, schemas0 ~ schemas, schemas1 ~ schemas)
         return (K results)
 
   traversePrepared_
-    (UnsafeManipulation q :: Manipulation ('[] :=> schemas) xs '[]) (list :: list x) =
+    (UnsafeManipulation q :: Manipulation '[] schemas xs '[]) (list :: list x) =
       PQ $ \ (K conn) -> liftBase $ do
         let temp = "temporary_statement"
         prepResultMaybe <- LibPQ.prepare conn temp q Nothing

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -147,7 +147,7 @@ simple query:
 >>> type Schema = '["tab" ::: 'Table ('[] :=> Columns)]
 >>> :{
 let
-  query :: Query (DBof (Public Schema)) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = select Star (from (table #tab))
 in printSQL query
 :}
@@ -157,7 +157,7 @@ restricted query:
 
 >>> :{
 let
-  query :: Query (DBof (Public Schema)) '[] '["sum" ::: 'NotNull 'PGint4, "col1" ::: 'NotNull 'PGint4]
+  query :: Query '[] (Public Schema) '[] '["sum" ::: 'NotNull 'PGint4, "col1" ::: 'NotNull 'PGint4]
   query =
     select_ ((#col1 + #col2) `as` #sum :* #col1)
       ( from (table #tab)
@@ -171,7 +171,7 @@ subquery:
 
 >>> :{
 let
-  query :: Query (DBof (Public Schema)) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = select Star (from (subquery (select Star (from (table #tab)) `as` #sub)))
 in printSQL query
 :}
@@ -181,7 +181,7 @@ limits and offsets:
 
 >>> :{
 let
-  query :: Query (DBof (Public Schema)) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = select Star (from (table #tab) & limit 100 & offset 2 & limit 50 & offset 2)
 in printSQL query
 :}
@@ -191,7 +191,7 @@ parameterized query:
 
 >>> :{
 let
-  query :: Query (DBof (Public Schema)) '[ 'NotNull 'PGint4] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] (Public Schema) '[ 'NotNull 'PGint4] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = select Star (from (table #tab) & where_ (#col1 .> param @1))
 in printSQL query
 :}
@@ -201,7 +201,7 @@ aggregation query:
 
 >>> :{
 let
-  query :: Query (DBof (Public Schema)) '[] '["sum" ::: 'NotNull 'PGint4, "col1" ::: 'NotNull 'PGint4 ]
+  query :: Query '[] (Public Schema) '[] '["sum" ::: 'NotNull 'PGint4, "col1" ::: 'NotNull 'PGint4 ]
   query =
     select_ (sum_ #col2 `as` #sum :* #col1)
     ( from (table (#tab `as` #table1))
@@ -215,7 +215,7 @@ sorted query:
 
 >>> :{
 let
-  query :: Query (DBof (Public Schema)) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = select Star (from (table #tab) & orderBy [#col1 & Asc])
 in printSQL query
 :}
@@ -252,7 +252,7 @@ type OrdersSchema =
 
 >>> :{
 let
-  query :: Query (DBof (Public OrdersSchema))
+  query :: Query '[] (Public OrdersSchema)
     '[]
     '[ "order_price" ::: 'NotNull 'PGfloat4
      , "customer_name" ::: 'NotNull 'PGtext
@@ -275,7 +275,7 @@ self-join:
 
 >>> :{
 let
-  query :: Query (DBof (Public Schema)) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = select (#t1 & DotStar) (from (table (#tab `as` #t1) & crossJoin (table (#tab `as` #t2))))
 in printSQL query
 :}
@@ -295,7 +295,7 @@ set operations:
 
 >>> :{
 let
-  query :: Query (DBof (Public Schema)) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = select Star (from (table #tab)) `unionAll` select Star (from (table #tab))
 in printSQL query
 :}
@@ -305,7 +305,7 @@ with queries:
 
 >>> :{
 let
-  query :: Query (DBof (Public Schema)) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = with (
     select Star (from (table #tab)) `as` #cte1 :>>
     select Star (from (common #cte1)) `as` #cte2

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -56,8 +56,6 @@ module Squeal.PostgreSQL.Schema
   , SchemaType
   , SchemasType
   , Public
-  , DBType
-  , DBof
     -- * Constraints
   , (:=>)
   , ColumnConstraint (..)
@@ -701,10 +699,6 @@ type SchemasType = [(Symbol,SchemaType)]
 
 type family Public (schema :: SchemaType) :: SchemasType
   where Public schema = '["public" ::: schema]
-
-type DBType = (FromType,SchemasType)
-
-type family DBof :: SchemasType -> DBType where DBof = '(,) '[]
 
 -- | `IsPGlabel` looks very much like the `IsLabel` class. Whereas
 -- the overloaded label, `fromLabel` is used for column references,

--- a/squeal-postgresql/test/Specs/ExceptionHandling.hs
+++ b/squeal-postgresql/test/Specs/ExceptionHandling.hs
@@ -48,8 +48,6 @@ type Schema =
 
 type Schemas = Public Schema
 
-type DB = DBof Schemas
-
 data User =
   User { userName  :: Text
        , userEmail :: Maybe Text
@@ -58,7 +56,7 @@ data User =
 instance SOP.Generic User
 instance SOP.HasDatatypeInfo User
 
-insertUser :: Manipulation DB '[ 'NotNull 'PGtext, 'NotNull ('PGvararray ('Null 'PGint2))]
+insertUser :: Manipulation '[] Schemas '[ 'NotNull 'PGtext, 'NotNull ('PGvararray ('Null 'PGint2))]
   '[ "fromOnly" ::: 'NotNull 'PGint4 ]
 insertUser = insertInto #users
   (Values_ (defaultAs #id :* param @1 `as` #name :* param @2 `as` #vec))


### PR DESCRIPTION
This PR removes the `DBType` kind in favor of being more explicit about common table expression scoping. It also adds common use case types `Query_` and `Manipulation_` with empty common table expression scope and Haskell types for parameters and return values:

```Haskell
type family Query_ (schemas :: SchemasType) (params :: Type) (row :: Type) where
  Query_ schemas params row = Query '[] schemas (TuplePG params) (RowPG row)

type family Manipulation_ (schemas :: SchemasType) (params :: Type) (row :: Type) where
  Manipulation_ schemas params row = Manipulation '[] schemas (TuplePG params) (RowPG row)
```