### PR TITLE
Array refactor

### DIFF
--- a/squeal-postgresql/exe/Example.hs
+++ b/squeal-postgresql/exe/Example.hs
@@ -82,16 +82,16 @@ getUsers = select_
     & innerJoin (table (#emails `as` #e))
       (#u ! #id .== #e ! #user_id)) )
 
-data User = User { userName :: Text, userEmail :: Maybe Text, userVec :: Vector (Maybe Int16) }
+data User = User { userName :: Text, userEmail :: Maybe Text, userVec :: VarArray (Vector (Maybe Int16)) }
   deriving (Show, GHC.Generic)
 instance SOP.Generic User
 instance SOP.HasDatatypeInfo User
 
 users :: [User]
 users = 
-  [ User "Alice" (Just "alice@gmail.com") [Nothing, Just 1]
-  , User "Bob" Nothing [Just 2, Nothing]
-  , User "Carole" (Just "carole@hotmail.com") [Just 3]
+  [ User "Alice" (Just "alice@gmail.com") (VarArray [Nothing, Just 1])
+  , User "Bob" Nothing (VarArray [Just 2, Nothing])
+  , User "Carole" (Just "carole@hotmail.com") (VarArray [Just 3])
   ]
 
 session :: (MonadBase IO pq, MonadPQ Schemas pq) => pq ()

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -59,9 +59,9 @@ create multi-dimensional fixed length arrays.
 
 >>> :{
 data Row = Row
-  { col1 :: Vector Int16
-  , col2 :: (Maybe Int16,Maybe Int16)
-  , col3 :: ((Int16,Int16),(Int16,Int16),(Int16,Int16))
+  { col1 :: VarArray (Vector Int16)
+  , col2 :: FixArray (Maybe Int16,Maybe Int16)
+  , col3 :: FixArray ((Int16,Int16),(Int16,Int16),(Int16,Int16))
   } deriving (Eq, GHC.Generic)
 :}
 
@@ -74,13 +74,13 @@ Once again, we define a simple round trip query.
 let
   roundTrip :: Query_ (Public '[]) Row Row
   roundTrip = values_ $
-    parameter @1 (int2 & vararray)                  `as` #col1 :*
-    parameter @2 (int2 & fixarray @2)               `as` #col2 :*
-    parameter @3 (int2 & fixarray @2 & fixarray @3) `as` #col3
+    parameter @1 (int2 & vararray) `as` #col1 :*
+    parameter @2 (int2 & fixarray @'[2]) `as` #col2 :*
+    parameter @3 (int2 & fixarray @'[3,2]) `as` #col3
 :}
 
 >>> :set -XOverloadedLists
->>> let input = Row [1,2] (Just 1,Nothing) ((1,2),(3,4),(5,6))
+>>> let input = Row (VarArray [1,2]) (FixArray (Just 1,Nothing)) (FixArray ((1,2),(3,4),(5,6)))
 >>> :{
 void . withConnection "host=localhost port=5432 dbname=exampledb" $ do
   result <- runQueryParams roundTrip input
@@ -322,19 +322,9 @@ instance (ToParam x pg, HasOid pg)
       . Encoding.nullableArray_vector (oid @pg) (unK . toParam @x @pg)
       . getVarArray
 instance (ToFixArray x dims ty, ty ~ nullity pg, HasOid pg)
-  => ToParam (FixArray x) ('PGfixarray_ dims ty) where
+  => ToParam (FixArray x) ('PGfixarray dims ty) where
     toParam = K . Encoding.array (oid @pg)
       . unK . unK . toFixArray @x @dims @ty . getFixArray
-instance ToArray x ('NotNull ('PGvararray ty))
-  => ToParam x ('PGvararray ty) where
-    toParam
-      = K . Encoding.array (baseOid @x @('NotNull ('PGvararray ty)))
-      . unK . toArray @x @('NotNull ('PGvararray ty))
-instance ToArray x ('NotNull ('PGfixarray n ty))
-  => ToParam x ('PGfixarray n ty) where
-    toParam
-      = K . Encoding.array (baseOid @x @('NotNull ('PGfixarray n ty)))
-      . unK . toArray @x @('NotNull ('PGfixarray n ty))
 instance
   ( IsEnumType x
   , HasDatatypeInfo x
@@ -429,47 +419,6 @@ instance
   => ToFixArray product (dim ': dims) ty where
     toFixArray = K . K . Encoding.dimensionArray foldlN
       (unK . unK . toFixArray @x @dims @ty) . unZ . unSOP . from
-
-class ToArray (x :: Type) (array :: NullityType) where
-  toArray :: x -> K Encoding.Array array
-  baseOid :: Word32
-  default baseOid :: HasOid (PGTypeOf array) => Word32
-  baseOid = oid @(PGTypeOf array)
-instance {-# OVERLAPPABLE #-} (HasOid pg, ToParam x pg)
-  => ToArray x ('NotNull pg) where
-    toArray = K . Encoding.encodingArray . unK . toParam @x @pg
-instance {-# OVERLAPPABLE #-} (HasOid pg, ToParam x pg)
-  => ToArray (Maybe x) ('Null pg) where
-    toArray = K . maybe Encoding.nullArray
-      (Encoding.encodingArray . unK . toParam @x @pg)
-instance {-# OVERLAPPING #-} ToArray x array
-  => ToArray (Vector x) ('NotNull ('PGvararray array)) where
-    toArray = K . Encoding.dimensionArray Vector.foldl'
-      (unK . toArray @x @array)
-    baseOid = baseOid @x @array
-instance {-# OVERLAPPING #-} ToArray x array
-  => ToArray (Maybe (Vector x)) ('Null ('PGvararray array)) where
-    toArray = K . maybe Encoding.nullArray
-      (Encoding.dimensionArray Vector.foldl' (unK . toArray @x @array))
-    baseOid = baseOid @x @array
-instance {-# OVERLAPPING #-}
-  ( IsProductType product xs
-  , Length xs ~ n
-  , All ((~) x) xs
-  , ToArray x array )
-  => ToArray product ('NotNull ('PGfixarray n array)) where
-    toArray = K . Encoding.dimensionArray foldlN
-      (unK . toArray @x @array) . unZ . unSOP . from
-    baseOid = baseOid @x @array
-instance {-# OVERLAPPING #-}
-  ( IsProductType product xs
-  , Length xs ~ n
-  , All ((~) x) xs
-  , ToArray x array )
-  => ToArray (Maybe product) ('Null ('PGfixarray n array)) where
-    toArray = K . maybe Encoding.nullArray
-      (Encoding.dimensionArray foldlN (unK . toArray @x @array) . unZ . unSOP . from)
-    baseOid = baseOid @x @array
 
 -- | A `ToParams` constraint generically sequences the encodings of `Type`s
 -- of the fields of a tuple or record to a row of `ColumnType`s. You should
@@ -567,14 +516,8 @@ instance FromValue pg y
         Decoding.array $ Decoding.dimensionArray rep
           (fromFixArray @'[] @('Null pg))
 instance FromFixArray dims ty y
-  => FromValue ('PGfixarray_ dims ty) (FixArray y) where
+  => FromValue ('PGfixarray dims ty) (FixArray y) where
     fromValue = FixArray <$> Decoding.array (fromFixArray @dims @ty @y)
-instance FromArray ('NotNull ('PGvararray ty)) y
-  => FromValue ('PGvararray ty) y where
-    fromValue = Decoding.array (fromArray @('NotNull ('PGvararray ty)) @y)
-instance FromArray ('NotNull ('PGfixarray n ty)) y
-  => FromValue ('PGfixarray n ty) y where
-    fromValue = Decoding.array (fromArray @('NotNull ('PGfixarray n ty)) @y)
 instance
   ( IsEnumType y
   , HasDatatypeInfo y
@@ -662,45 +605,6 @@ instance
         rep _ = fmap (to . SOP . Z) . replicateMN
       in
         Decoding.dimensionArray rep (fromFixArray @dims @ty @y)
-
-class FromArray (ty :: NullityType) (y :: Type) where
-  fromArray :: Decoding.Array y
-instance {-# OVERLAPPABLE #-} FromValue pg y
-  => FromArray ('NotNull pg) y where
-    fromArray = Decoding.valueArray (fromValue @pg @y)
-instance {-# OVERLAPPABLE #-} FromValue pg y
-  => FromArray ('Null pg) (Maybe y) where
-    fromArray = Decoding.nullableValueArray (fromValue @pg @y)
-instance {-# OVERLAPPING #-} FromArray array y
-  => FromArray ('NotNull ('PGvararray array)) (Vector y) where
-    fromArray =
-      Decoding.dimensionArray Vector.replicateM (fromArray @array @y)
-instance {-# OVERLAPPING #-} FromArray array y
-  => FromArray ('Null ('PGvararray array)) (Maybe (Vector y)) where
-    fromArray = Just <$> 
-      Decoding.dimensionArray Vector.replicateM (fromArray @array @y)
-instance {-# OVERLAPPING #-}
-  ( FromArray array y
-  , All ((~) y) ys
-  , SListI ys
-  , IsProductType product ys )
-  => FromArray ('NotNull ('PGfixarray n array)) product where
-    fromArray =
-      let
-        rep _ = fmap (to . SOP . Z) . replicateMN
-      in
-        Decoding.dimensionArray rep (fromArray @array @y)
-instance {-# OVERLAPPING #-}
-  ( FromArray array y
-  , All ((~) y) ys
-  , SListI ys
-  , IsProductType product ys )
-  => FromArray ('Null ('PGfixarray n array)) (Maybe product) where
-    fromArray =
-      let
-        rep _ = fmap (to . SOP . Z) . replicateMN
-      in
-        Just <$> Decoding.dimensionArray rep (fromArray @array @y)
 
 -- | A `FromRow` constraint generically sequences the parsings of the columns
 -- of a `RowType` into the fields of a record `Type` provided they have
@@ -796,7 +700,7 @@ type it's applied to should be stored as a `PGfixarray`.
 -}
 newtype FixArray arr = FixArray {getFixArray :: arr}
   deriving (Eq, Ord, Show, Read, GHC.Generic)
--- type instance PG (FixArray x) = 'PGfixarray (DimPG x) (FixPG x)
+type instance PG (FixArray x) = 'PGfixarray (DimPG x) (FixPG x)
 
 type family DimPG (hask :: Type) :: [Nat] where
   DimPG (x,x) = 2 ': DimPG x

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -95,6 +95,7 @@ import Prelude hiding ((.), id)
 import qualified Generics.SOP as SOP
 import qualified GHC.Generics as GHC
 
+import Squeal.PostgreSQL.Binary
 import Squeal.PostgreSQL.Expression
 import Squeal.PostgreSQL.Query
 import Squeal.PostgreSQL.Render

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
@@ -29,7 +29,6 @@ module Squeal.PostgreSQL.Render
   , renderCommaSeparated
   , renderCommaSeparatedMaybe
   , renderNat
-  , renderNats
   , renderSymbol
   , RenderSQL (..)
   , printSQL
@@ -98,10 +97,6 @@ renderCommaSeparatedMaybe render
 -- | Render a promoted `Nat`.
 renderNat :: forall n. KnownNat n => ByteString
 renderNat = fromString (show (natVal' (proxy# :: Proxy# n)))
-
--- | Render a promoted list of `Nat`s.
-renderNats :: forall ns. All KnownNat ns => ByteString
-renderNats = undefined
 
 -- | Render a promoted `Symbol`.
 renderSymbol :: forall s. KnownSymbol s => ByteString

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
@@ -29,6 +29,7 @@ module Squeal.PostgreSQL.Render
   , renderCommaSeparated
   , renderCommaSeparatedMaybe
   , renderNat
+  , renderNats
   , renderSymbol
   , RenderSQL (..)
   , printSQL
@@ -98,13 +99,16 @@ renderCommaSeparatedMaybe render
 renderNat :: forall n. KnownNat n => ByteString
 renderNat = fromString (show (natVal' (proxy# :: Proxy# n)))
 
+-- | Render a promoted list of `Nat`s.
+renderNats :: forall ns. All KnownNat ns => ByteString
+renderNats = undefined
+
 -- | Render a promoted `Symbol`.
 renderSymbol :: forall s. KnownSymbol s => ByteString
 renderSymbol = fromString (symbolVal' (proxy# :: Proxy# s))
 
 -- | A class for rendering SQL
-class RenderSQL sql where
-  renderSQL :: sql -> ByteString
+class RenderSQL sql where renderSQL :: sql -> ByteString
 
 -- | Print SQL.
 printSQL :: (RenderSQL sql, MonadBase IO io) => sql -> io ()

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -44,10 +44,6 @@ module Squeal.PostgreSQL.Schema
   , NullPG
   , TuplePG
   , RowPG
-  , Json (..)
-  , Jsonb (..)
-  , Composite (..)
-  , Enumerated (..)
     -- * Schema Types
   , ColumnType
   , ColumnsType
@@ -137,7 +133,6 @@ import Data.Time
 import Data.Word (Word16, Word32, Word64)
 import Data.Type.Bool
 import Data.UUID.Types (UUID)
-import Data.Vector (Vector)
 import Generics.SOP
 import Generics.SOP.Record
 import GHC.OverloadedLabels
@@ -755,49 +750,6 @@ type instance PG DiffTime = 'PGinterval
 type instance PG UUID = 'PGuuid
 type instance PG (NetAddr IP) = 'PGinet
 type instance PG Value = 'PGjson
-type instance PG (Json hask) = 'PGjson
-type instance PG (Jsonb hask) = 'PGjsonb
-type instance PG (Vector hask) = 'PGvararray (NullPG hask)
-type instance PG (hask, hask) = 'PGfixarray 2 (NullPG hask)
-type instance PG (hask, hask, hask) = 'PGfixarray 3 (NullPG hask)
-type instance PG (hask, hask, hask, hask) = 'PGfixarray 4 (NullPG hask)
-type instance PG (hask, hask, hask, hask, hask) = 'PGfixarray 5 (NullPG hask)
-type instance PG (hask, hask, hask, hask, hask, hask)
-  = 'PGfixarray 6 (NullPG hask)
-type instance PG (hask, hask, hask, hask, hask, hask, hask)
-  = 'PGfixarray 7 (NullPG hask)
-type instance PG (hask, hask, hask, hask, hask, hask, hask, hask)
-  = 'PGfixarray 8 (NullPG hask)
-type instance PG (hask, hask, hask, hask, hask, hask, hask, hask, hask)
-  = 'PGfixarray 9 (NullPG hask)
-type instance PG (hask, hask, hask, hask, hask, hask, hask, hask, hask, hask)
-  = 'PGfixarray 10 (NullPG hask)
-type instance PG (Composite hask) = 'PGcomposite (RowPG hask)
-type instance PG (Enumerated hask) = 'PGenum (LabelsPG hask)
-
-{- | The `Json` newtype is an indication that the Haskell
-type it's applied to should be stored as `PGjson`.
--}
-newtype Json hask = Json {getJson :: hask}
-  deriving (Eq, Ord, Show, Read, GHC.Generic)
-
-{- | The `Jsonb` newtype is an indication that the Haskell
-type it's applied to should be stored as `PGjsonb`.
--}
-newtype Jsonb hask = Jsonb {getJsonb :: hask}
-  deriving (Eq, Ord, Show, Read, GHC.Generic)
-
-{- | The `Composite` newtype is an indication that the Haskell
-type it's applied to should be stored as a `PGcomposite`.
--}
-newtype Composite record = Composite {getComposite :: record}
-  deriving (Eq, Ord, Show, Read, GHC.Generic)
-
-{- | The `Enumerated` newtype is an indication that the Haskell
-type it's applied to should be stored as `PGenum`.
--}
-newtype Enumerated enum = Enumerated {getEnumerated :: enum}
-  deriving (Eq, Ord, Show, Read, GHC.Generic)
 
 {-| The `LabelsPG` type family calculates the constructors of a
 Haskell enum type.

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -175,8 +175,7 @@ data PGType
   | PGjson -- ^	textual JSON data
   | PGjsonb -- ^ binary JSON data, decomposed
   | PGvararray NullityType -- ^ variable length array
-  | PGfixarray Nat NullityType -- ^ fixed length array
-  | PGfixarray_ [Nat] NullityType -- ^ fixed length array
+  | PGfixarray [Nat] NullityType -- ^ fixed length array
   | PGenum [Symbol] -- ^ enumerated (enum) types are data types that comprise a static, ordered set of values.
   | PGcomposite RowType -- ^ a composite type represents the structure of a row or record; it is essentially just a list of field names and their data types.
   | UnsafePGType Symbol -- ^ an escape hatch for unsupported PostgreSQL types

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -176,6 +176,7 @@ data PGType
   | PGjsonb -- ^ binary JSON data, decomposed
   | PGvararray NullityType -- ^ variable length array
   | PGfixarray Nat NullityType -- ^ fixed length array
+  | PGfixarray_ [Nat] NullityType -- ^ fixed length array
   | PGenum [Symbol] -- ^ enumerated (enum) types are data types that comprise a static, ordered set of values.
   | PGcomposite RowType -- ^ a composite type represents the structure of a row or record; it is essentially just a list of field names and their data types.
   | UnsafePGType Symbol -- ^ an escape hatch for unsupported PostgreSQL types

--- a/squeal-postgresql/test/Specs/ExceptionHandling.hs
+++ b/squeal-postgresql/test/Specs/ExceptionHandling.hs
@@ -51,7 +51,7 @@ type Schemas = Public Schema
 data User =
   User { userName  :: Text
        , userEmail :: Maybe Text
-       , userVec   :: Vector (Maybe Int16) }
+       , userVec   :: VarArray (Vector (Maybe Int16)) }
   deriving (Show, GHC.Generic)
 instance SOP.Generic User
 instance SOP.HasDatatypeInfo User
@@ -101,7 +101,7 @@ connectionString :: Char8.ByteString
 connectionString = "host=localhost port=5432 dbname=exampledb"
 
 testUser :: User
-testUser = User "TestUser" Nothing []
+testUser = User "TestUser" Nothing (VarArray [])
 
 newUser :: (MonadBase IO m, MonadPQ Schemas m) => User -> m ()
 newUser u = void $ manipulateParams insertUser (userName u, userVec u)


### PR DESCRIPTION
This PR should hopefully address #87 indirectly. It introduces `VarArray` and `FixArray` newtypes, removes the `ToArray` typeclass and adds a `ToFixArray` type class. Additionally, nesting behavior is treated differently so that `'PGfixarray` now takes a list of `Nat`s to express a multidimensional array, while variable length arrays should be unnested. 