### PR TITLE
Subqueries

### DIFF
--- a/squeal-postgresql/exe/Example.hs
+++ b/squeal-postgresql/exe/Example.hs
@@ -44,7 +44,7 @@ type Schema =
 type Schemas = Public Schema
 
 setup :: Definition (Public '[]) Schemas
-setup = 
+setup =
   createTable #users
     ( serial `as` #id :*
       (text & notNullable) `as` #name :*
@@ -62,20 +62,16 @@ setup =
 teardown :: Definition Schemas (Public '[])
 teardown = dropTable #emails >>> dropTable #users
 
-insertUser :: Manipulation '[] Schemas '[ 'NotNull 'PGtext, 'NotNull ('PGvararray ('Null 'PGint2))]
-  '[ "fromOnly" ::: 'NotNull 'PGint4 ]
+insertUser :: Manipulation_ Schemas (Text, VarArray (Vector (Maybe Int16))) (Only Int32)
 insertUser = insertInto #users
   (Values_ (defaultAs #id :* param @1 `as` #name :* param @2 `as` #vec))
   (OnConflict (OnConstraint #pk_users) DoNothing) (Returning_ (#id `as` #fromOnly))
 
-insertEmail :: Manipulation '[] Schemas '[ 'NotNull 'PGint4, 'Null 'PGtext] '[]
+insertEmail :: Manipulation_ Schemas (Int32, Maybe Text) ()
 insertEmail = insertInto_ #emails
   (Values_ (defaultAs #id :* param @1 `as` #user_id :* param @2 `as` #email))
 
-getUsers :: Query '[] Schemas '[]
-  '[ "userName" ::: 'NotNull 'PGtext
-   , "userEmail" ::: 'Null 'PGtext
-   , "userVec" ::: 'NotNull ('PGvararray ('Null 'PGint2))]
+getUsers :: Query_ Schemas () User
 getUsers = select_
   (#u ! #name `as` #userName :* #e ! #email `as` #userEmail :* #u ! #vec `as` #userVec)
   ( from (table (#users `as` #u)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition.hs
@@ -297,7 +297,7 @@ check
      , HasAll aliases (TableToRow table) subcolumns )
   => NP Alias aliases
   -- ^ specify the subcolumns which are getting checked
-  -> (forall t. Condition 'Ungrouped '[] schemas '[] '[t ::: subcolumns])
+  -> (forall t. Condition '[] 'Ungrouped '[] schemas '[] '[t ::: subcolumns])
   -- ^ a closed `Condition` on those subcolumns
   -> TableConstraintExpression sch tab schemas ('Check aliases)
 check _cols condition = UnsafeTableConstraintExpression $
@@ -772,7 +772,7 @@ newtype AlterColumn (schemas :: SchemasType) (ty0 :: ColumnType) (ty1 :: ColumnT
 -- :}
 -- ALTER TABLE "tab" ALTER COLUMN "col" SET DEFAULT 5;
 setDefault
-  :: Expression 'Ungrouped '[] schemas '[] '[] ty -- ^ default value to set
+  :: Expression '[] 'Ungrouped '[] schemas '[] '[] ty -- ^ default value to set
   -> AlterColumn schemas (constraint :=> ty) ('Def :=> ty)
 setDefault expression = UnsafeAlterColumn $
   "SET DEFAULT" <+> renderExpression expression
@@ -857,7 +857,7 @@ CREATE VIEW "bc" AS SELECT "b" AS "b", "c" AS "c" FROM "abc" AS "abc";
 createView
   :: (KnownSymbol sch, KnownSymbol vw, Has sch schemas schema)
   => QualifiedAlias sch vw -- ^ the name of the view to add
-  -> Query '[] schemas '[] view -- ^ query
+  -> Query '[] '[] schemas '[] view -- ^ query
   -> Definition schemas (Alter sch (Create vw ('View view) schema) schemas)
 createView alias query = UnsafeDefinition $
   "CREATE" <+> "VIEW" <+> renderSQL alias <+> "AS"
@@ -1023,7 +1023,7 @@ notNullable ty = UnsafeColumnTypeExpression $ renderSQL ty <+> "NOT NULL"
 
 -- | used in `createTable` commands as a column constraint to give a default
 default_
-  :: Expression 'Ungrouped '[] schemas '[] '[] ty
+  :: Expression '[] 'Ungrouped '[] schemas '[] '[] ty
   -> ColumnTypeExpression schemas ('NoDef :=> ty)
   -> ColumnTypeExpression schemas ('Def :=> ty)
 default_ x ty = UnsafeColumnTypeExpression $

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -1427,7 +1427,7 @@ class Aggregate expr1 expr2 aggr
   --
   -- >>> :{
   -- let
-  --   expression :: Expression (Grouped bys) commons schemas params from ('NotNull 'PGint8)
+  --   expression :: Expression outer ('Grouped bys) commons schemas params from ('NotNull 'PGint8)
   --   expression = countStar
   -- in printSQL expression
   -- :}
@@ -1436,7 +1436,7 @@ class Aggregate expr1 expr2 aggr
 
   -- | >>> :{
   -- let
-  --   expression :: Expression (Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity ty]] ('NotNull 'PGint8)
+  --   expression :: Expression outer ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity ty]] ('NotNull 'PGint8)
   --   expression = count (All #col)
   -- in printSQL expression
   -- :}
@@ -1462,6 +1462,16 @@ class Aggregate expr1 expr2 aggr
   arrayAgg
     :: expr1 ty
     -> aggr ('NotNull ('PGvararray ty))
+
+  -- | aggregates values as a JSON array
+  jsonAgg
+    :: expr1 ty
+    -> aggr ('NotNull 'PGjson)
+
+  -- | aggregates values as a JSON array
+  jsonbAgg
+    :: expr1 ty
+    -> aggr ('NotNull 'PGjsonb)
 
   -- | >>> :{
   -- let
@@ -1503,7 +1513,7 @@ class Aggregate expr1 expr2 aggr
 
   -- | >>> :{
   -- let
-  --   expression :: Expression (Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGbool]] (nullity 'PGbool)
+  --   expression :: Expression outer ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGbool]] (nullity 'PGbool)
   --   expression = boolOr (All #col)
   -- in printSQL expression
   -- :}
@@ -1548,7 +1558,7 @@ class Aggregate expr1 expr2 aggr
   {- | correlation coefficient
   >>> :{
   let
-    expression :: Expression ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
+    expression :: Expression o ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
     expression = corr (All (#y :*: #x))
   in printSQL expression
   :}
@@ -1561,7 +1571,7 @@ class Aggregate expr1 expr2 aggr
   {- | population covariance
   >>> :{
   let
-    expression :: Expression ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
+    expression :: Expression o ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
     expression = covarPop (All (#y :*: #x))
   in printSQL expression
   :}
@@ -1587,7 +1597,7 @@ class Aggregate expr1 expr2 aggr
   {- | average of the independent variable (sum(X)/N)
   >>> :{
   let
-    expression :: Expression ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
+    expression :: Expression o ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
     expression = regrAvgX (All (#y :*: #x))
   in printSQL expression
   :}
@@ -1626,7 +1636,7 @@ class Aggregate expr1 expr2 aggr
   {- | y-intercept of the least-squares-fit linear equation determined by the (X, Y) pairs
   >>> :{
   let
-    expression :: Expression ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
+    expression :: Expression o ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
     expression = regrIntercept (All (#y :*: #x))
   in printSQL expression
   :}
@@ -1725,6 +1735,8 @@ instance Aggregate
     count = unsafeAggregate1 "count"
     sum_ = unsafeAggregate1 "sum"
     arrayAgg = unsafeAggregate1 "array_agg"
+    jsonAgg = unsafeAggregate1 "json_agg"
+    jsonbAgg = unsafeAggregate1 "jsonb_agg"
     bitAnd = unsafeAggregate1 "bit_and"
     bitOr = unsafeAggregate1 "bit_or"
     boolAnd = unsafeAggregate1 "bool_and"
@@ -1759,6 +1771,8 @@ instance Aggregate
     count = unsafeWindowFunction1 "count"
     sum_ = unsafeWindowFunction1 "sum"
     arrayAgg = unsafeWindowFunction1 "array_agg"
+    jsonAgg = unsafeWindowFunction1 "json_agg"
+    jsonbAgg = unsafeWindowFunction1 "jsonb_agg"
     bitAnd = unsafeWindowFunction1 "bit_and"
     bitOr = unsafeWindowFunction1 "bit_or"
     boolAnd = unsafeWindowFunction1 "bool_and"

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -1427,7 +1427,7 @@ class Aggregate expr1 expr2 aggr
   --
   -- >>> :{
   -- let
-  --   expression :: Expression outer ('Grouped bys) commons schemas params from ('NotNull 'PGint8)
+  --   expression :: Expression '[] ('Grouped bys) commons schemas params from ('NotNull 'PGint8)
   --   expression = countStar
   -- in printSQL expression
   -- :}
@@ -1436,7 +1436,7 @@ class Aggregate expr1 expr2 aggr
 
   -- | >>> :{
   -- let
-  --   expression :: Expression outer ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity ty]] ('NotNull 'PGint8)
+  --   expression :: Expression '[] ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity ty]] ('NotNull 'PGint8)
   --   expression = count (All #col)
   -- in printSQL expression
   -- :}
@@ -1448,7 +1448,7 @@ class Aggregate expr1 expr2 aggr
 
   -- | >>> :{
   -- let
-  --   expression :: Expression outer ('Grouped bys) commons schemas params '[tab ::: '["col" ::: 'Null 'PGnumeric]] ('Null 'PGnumeric)
+  --   expression :: Expression '[] ('Grouped bys) commons schemas params '[tab ::: '["col" ::: 'Null 'PGnumeric]] ('Null 'PGnumeric)
   --   expression = sum_ (Distinct #col)
   -- in printSQL expression
   -- :}
@@ -1475,7 +1475,7 @@ class Aggregate expr1 expr2 aggr
 
   -- | >>> :{
   -- let
-  --   expression :: Expression outer ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGint4]] (nullity 'PGint4)
+  --   expression :: Expression '[] ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGint4]] (nullity 'PGint4)
   --   expression = bitAnd (Distinct #col)
   -- in printSQL expression
   -- :}
@@ -1488,7 +1488,7 @@ class Aggregate expr1 expr2 aggr
 
   -- | >>> :{
   -- let
-  --   expression :: Expression outer ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGint4]] (nullity 'PGint4)
+  --   expression :: Expression '[] ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGint4]] (nullity 'PGint4)
   --   expression = bitOr (All #col)
   -- in printSQL expression
   -- :}
@@ -1501,7 +1501,7 @@ class Aggregate expr1 expr2 aggr
 
   -- | >>> :{
   -- let
-  --   winFun :: WindowFunction 'Ungrouped commons schemas params '[tab ::: '["col" ::: nullity 'PGbool]] (nullity 'PGbool)
+  --   winFun :: WindowFunction '[] 'Ungrouped commons schemas params '[tab ::: '["col" ::: nullity 'PGbool]] (nullity 'PGbool)
   --   winFun = boolAnd #col
   -- in printSQL winFun
   -- :}
@@ -1513,7 +1513,7 @@ class Aggregate expr1 expr2 aggr
 
   -- | >>> :{
   -- let
-  --   expression :: Expression outer ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGbool]] (nullity 'PGbool)
+  --   expression :: Expression '[] ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGbool]] (nullity 'PGbool)
   --   expression = boolOr (All #col)
   -- in printSQL expression
   -- :}
@@ -1527,7 +1527,7 @@ class Aggregate expr1 expr2 aggr
   --
   -- >>> :{
   -- let
-  --   expression :: Expression outer ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGbool]] (nullity 'PGbool)
+  --   expression :: Expression '[] ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGbool]] (nullity 'PGbool)
   --   expression = every (Distinct #col)
   -- in printSQL expression
   -- :}
@@ -1548,7 +1548,7 @@ class Aggregate expr1 expr2 aggr
     :: expr1 (nullity ty)
     -- ^ what to minimize
     -> aggr (nullity ty)
-  
+
   -- | average aggregation
   avg
     :: expr1 (nullity ty)
@@ -1558,7 +1558,7 @@ class Aggregate expr1 expr2 aggr
   {- | correlation coefficient
   >>> :{
   let
-    expression :: Expression o ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
+    expression :: Expression '[] ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
     expression = corr (All (#y :*: #x))
   in printSQL expression
   :}
@@ -1571,7 +1571,7 @@ class Aggregate expr1 expr2 aggr
   {- | population covariance
   >>> :{
   let
-    expression :: Expression o ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
+    expression :: Expression '[] ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
     expression = covarPop (All (#y :*: #x))
   in printSQL expression
   :}
@@ -1584,7 +1584,7 @@ class Aggregate expr1 expr2 aggr
   {- | sample covariance
   >>> :{
   let
-    winFun :: WindowFunction 'Ungrouped c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
+    winFun :: WindowFunction '[] 'Ungrouped c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
     winFun = covarSamp (#y :*: #x)
   in printSQL winFun
   :}
@@ -1597,7 +1597,7 @@ class Aggregate expr1 expr2 aggr
   {- | average of the independent variable (sum(X)/N)
   >>> :{
   let
-    expression :: Expression o ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
+    expression :: Expression '[] ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
     expression = regrAvgX (All (#y :*: #x))
   in printSQL expression
   :}
@@ -1610,7 +1610,7 @@ class Aggregate expr1 expr2 aggr
   {- | average of the dependent variable (sum(Y)/N)
   >>> :{
   let
-    winFun :: WindowFunction 'Ungrouped c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
+    winFun :: WindowFunction '[] 'Ungrouped c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
     winFun = regrAvgY (#y :*: #x)
   in printSQL winFun
   :}
@@ -1623,7 +1623,7 @@ class Aggregate expr1 expr2 aggr
   {- | number of input rows in which both expressions are nonnull
   >>> :{
   let
-    winFun :: WindowFunction 'Ungrouped c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGint8)
+    winFun :: WindowFunction '[] 'Ungrouped c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGint8)
     winFun = regrCount (#y :*: #x)
   in printSQL winFun
   :}
@@ -1636,7 +1636,7 @@ class Aggregate expr1 expr2 aggr
   {- | y-intercept of the least-squares-fit linear equation determined by the (X, Y) pairs
   >>> :{
   let
-    expression :: Expression o ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
+    expression :: Expression '[] ('Grouped g) c s p '[t ::: '["x" ::: 'NotNull 'PGfloat8, "y" ::: 'NotNull 'PGfloat8]] ('NotNull 'PGfloat8)
     expression = regrIntercept (All (#y :*: #x))
   in printSQL expression
   :}
@@ -1674,27 +1674,27 @@ class Aggregate expr1 expr2 aggr
   regrSyy
     :: expr2 (nullity 'PGfloat8)
     -> aggr (nullity 'PGfloat8)
-  
+
   -- | historical alias for `stddevSamp`
   stddev
     :: expr1 (nullity ty)
     -> aggr (nullity (PGAvg ty))
-  
+
   -- | population standard deviation of the input values
   stddevPop
     :: expr1 (nullity ty)
     -> aggr (nullity (PGAvg ty))
-  
+
   -- | sample standard deviation of the input values
   stddevSamp
     :: expr1 (nullity ty)
     -> aggr (nullity (PGAvg ty))
-  
+
   -- | historical alias for `varSamp`
   variance
     :: expr1 (nullity ty)
     -> aggr (nullity (PGAvg ty))
-  
+
   -- | population variance of the input values
   -- (square of the population standard deviation)
   varPop

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -237,6 +237,7 @@ values from primitive expression using arithmetic, logical,
 and other operations.
 -}
 newtype Expression
+  (outer :: FromType)
   (grp :: Grouping)
   (commons :: FromType)
   (schemas :: SchemasType)
@@ -246,7 +247,7 @@ newtype Expression
     = UnsafeExpression { renderExpression :: ByteString }
     deriving (GHC.Generic,Show,Eq,Ord,NFData)
 
-instance RenderSQL (Expression grp commons schemas params from ty) where
+instance RenderSQL (Expression outer grp commons schemas params from ty) where
   renderSQL = renderExpression
 
 {- | A `HasParameter` constraint is used to indicate a value that is
@@ -264,12 +265,12 @@ class KnownNat n => HasParameter
   | n params -> ty where
     -- | `parameter` takes a `Nat` using type application and a `TypeExpression`.
     --
-    -- >>> let expr = parameter @1 int4 :: Expression grp '[] schemas '[ 'Null 'PGint4] from ('Null 'PGint4)
+    -- >>> let expr = parameter @1 int4 :: Expression outer grp '[] schemas '[ 'Null 'PGint4] from ('Null 'PGint4)
     -- >>> printSQL expr
     -- ($1 :: int4)
     parameter
       :: TypeExpression schemas ty
-      -> Expression grp commons schemas params from ty
+      -> Expression outer grp commons schemas params from ty
     parameter ty = UnsafeExpression $ parenthesized $
       "$" <> renderNat @n <+> "::"
         <+> renderSQL ty
@@ -280,116 +281,116 @@ instance {-# OVERLAPPABLE #-} (KnownNat n, HasParameter (n-1) params ty)
 -- | `param` takes a `Nat` using type application and for basic types,
 -- infers a `TypeExpression`.
 --
--- >>> let expr = param @1 :: Expression grp commons schemas '[ 'Null 'PGint4] from ('Null 'PGint4)
+-- >>> let expr = param @1 :: Expression outer grp commons schemas '[ 'Null 'PGint4] from ('Null 'PGint4)
 -- >>> printSQL expr
 -- ($1 :: int4)
 param
-  :: forall n commons schemas params from grp ty
+  :: forall n outer commons schemas params from grp ty
    . (PGTyped schemas ty, HasParameter n params ty)
-  => Expression grp commons schemas params from ty -- ^ param
+  => Expression outer grp commons schemas params from ty -- ^ param
 param = parameter @n (pgtype @schemas)
 
-instance (HasUnique tab from row, Has col row ty)
-  => IsLabel col (Expression 'Ungrouped commons schemas params from ty) where
+instance (HasUnique tab (Join outer from) row, Has col row ty)
+  => IsLabel col (Expression outer 'Ungrouped commons schemas params from ty) where
     fromLabel = UnsafeExpression $ renderSQL (Alias @col)
-instance (HasUnique tab from row, Has col row ty, tys ~ '[ty])
-  => IsLabel col (NP (Expression 'Ungrouped commons schemas params from) tys) where
+instance (HasUnique tab (Join outer from) row, Has col row ty, tys ~ '[ty])
+  => IsLabel col (NP (Expression outer 'Ungrouped commons schemas params from) tys) where
     fromLabel = fromLabel @col :* Nil
-instance (HasUnique tab from row, Has col row ty, column ~ (col ::: ty))
+instance (HasUnique tab (Join outer from) row, Has col row ty, column ~ (col ::: ty))
   => IsLabel col
-    (Aliased (Expression 'Ungrouped commons schemas params from) column) where
+    (Aliased (Expression outer 'Ungrouped commons schemas params from) column) where
     fromLabel = fromLabel @col `As` Alias
-instance (HasUnique tab from row, Has col row ty, columns ~ '[col ::: ty])
+instance (HasUnique tab (Join outer from) row, Has col row ty, columns ~ '[col ::: ty])
   => IsLabel col
-    (NP (Aliased (Expression 'Ungrouped commons schemas params from)) columns) where
+    (NP (Aliased (Expression outer 'Ungrouped commons schemas params from)) columns) where
     fromLabel = fromLabel @col :* Nil
 
-instance (Has tab from row, Has col row ty)
-  => IsQualified tab col (Expression 'Ungrouped commons schemas params from ty) where
+instance (Has tab (Join outer from) row, Has col row ty)
+  => IsQualified tab col (Expression outer 'Ungrouped commons schemas params from ty) where
     tab ! col = UnsafeExpression $
       renderSQL tab <> "." <> renderSQL col
-instance (Has tab from row, Has col row ty, tys ~ '[ty])
-  => IsQualified tab col (NP (Expression 'Ungrouped commons schemas params from) tys) where
+instance (Has tab (Join outer from) row, Has col row ty, tys ~ '[ty])
+  => IsQualified tab col (NP (Expression outer 'Ungrouped commons schemas params from) tys) where
     tab ! col = tab ! col :* Nil
-instance (Has tab from row, Has col row ty, column ~ (col ::: ty))
+instance (Has tab (Join outer from) row, Has col row ty, column ~ (col ::: ty))
   => IsQualified tab col
-    (Aliased (Expression 'Ungrouped commons schemas params from) column) where
+    (Aliased (Expression outer 'Ungrouped commons schemas params from) column) where
     tab ! col = tab ! col `As` col
-instance (Has tab from row, Has col row ty, columns ~ '[col ::: ty])
+instance (Has tab (Join outer from) row, Has col row ty, columns ~ '[col ::: ty])
   => IsQualified tab col
-    (NP (Aliased (Expression 'Ungrouped commons schemas params from)) columns) where
+    (NP (Aliased (Expression outer 'Ungrouped commons schemas params from)) columns) where
     tab ! col = tab ! col :* Nil
 
 instance
-  ( HasUnique tab from row
+  ( HasUnique tab (Join outer from) row
   , Has col row ty
   , GroupedBy tab col bys
   ) => IsLabel col
-    (Expression ('Grouped bys) commons schemas params from ty) where
+    (Expression outer ('Grouped bys) commons schemas params from ty) where
       fromLabel = UnsafeExpression $ renderSQL (Alias @col)
 instance
-  ( HasUnique tab from row
+  ( HasUnique tab (Join outer from) row
   , Has col row ty
   , GroupedBy tab col bys
   , tys ~ '[ty]
   ) => IsLabel col
-    (NP (Expression ('Grouped bys) commons schemas params from) tys) where
+    (NP (Expression outer ('Grouped bys) commons schemas params from) tys) where
       fromLabel = fromLabel @col :* Nil
 instance
-  ( HasUnique tab from row
+  ( HasUnique tab (Join outer from) row
   , Has col row ty
   , GroupedBy tab col bys
   , column ~ (col ::: ty)
   ) => IsLabel col
-    (Aliased (Expression ('Grouped bys) commons schemas params from) column) where
+    (Aliased (Expression outer ('Grouped bys) commons schemas params from) column) where
       fromLabel = fromLabel @col `As` Alias
 instance
-  ( HasUnique tab from row
+  ( HasUnique tab (Join outer from) row
   , Has col row ty
   , GroupedBy tab col bys
   , columns ~ '[col ::: ty]
   ) => IsLabel col
-    (NP (Aliased (Expression ('Grouped bys) commons schemas params from)) columns) where
+    (NP (Aliased (Expression outer ('Grouped bys) commons schemas params from)) columns) where
       fromLabel = fromLabel @col :* Nil
 
 instance
-  ( Has tab from row
+  ( Has tab (Join outer from) row
   , Has col row ty
   , GroupedBy tab col bys
   ) => IsQualified tab col
-    (Expression ('Grouped bys) commons schemas params from ty) where
+    (Expression outer ('Grouped bys) commons schemas params from ty) where
       tab ! col = UnsafeExpression $
         renderSQL tab <> "." <> renderSQL col
 instance
-  ( Has tab from row
+  ( Has tab (Join outer from) row
   , Has col row ty
   , GroupedBy tab col bys
   , tys ~ '[ty]
   ) => IsQualified tab col
-    (NP (Expression ('Grouped bys) commons schemas params from) tys) where
+    (NP (Expression outer ('Grouped bys) commons schemas params from) tys) where
       tab ! col = tab ! col :* Nil
 instance
-  ( Has tab from row
+  ( Has tab (Join outer from) row
   , Has col row ty
   , GroupedBy tab col bys
   , column ~ (col ::: ty)
   ) => IsQualified tab col
-    (Aliased (Expression ('Grouped bys) commons schemas params from) column) where
+    (Aliased (Expression outer ('Grouped bys) commons schemas params from) column) where
       tab ! col = tab ! col `As` col
 instance
-  ( Has tab from row
+  ( Has tab (Join outer from) row
   , Has col row ty
   , GroupedBy tab col bys
   , columns ~ '[col ::: ty]
   ) => IsQualified tab col
-    (NP (Aliased (Expression ('Grouped bys) commons schemas params from)) columns) where
+    (NP (Aliased (Expression outer ('Grouped bys) commons schemas params from)) columns) where
       tab ! col = tab ! col :* Nil
 
 -- | analagous to `Nothing`
 --
 -- >>> printSQL null_
 -- NULL
-null_ :: Expression commons schemas rels grouping params ('Null ty)
+null_ :: Expression outer grp commons schemas params from ('Null ty)
 null_ = UnsafeExpression "NULL"
 
 -- | analagous to `Just`
@@ -397,8 +398,8 @@ null_ = UnsafeExpression "NULL"
 -- >>> printSQL $ notNull true
 -- TRUE
 notNull
-  :: Expression commons schemas rels grouping params ('NotNull ty)
-  -> Expression commons schemas rels grouping params ('Null ty)
+  :: Expression outer grp commons schemas params from ('NotNull ty)
+  -> Expression outer grp commons schemas params from ('Null ty)
 notNull = UnsafeExpression . renderSQL
 
 -- | return the leftmost value which is not NULL
@@ -406,11 +407,11 @@ notNull = UnsafeExpression . renderSQL
 -- >>> printSQL $ coalesce [null_, true] false
 -- COALESCE(NULL, TRUE, FALSE)
 coalesce
-  :: [Expression grp commons schemas params from ('Null ty)]
+  :: [Expression outer grp commons schemas params from ('Null ty)]
   -- ^ @NULL@s may be present
-  -> Expression grp commons schemas params from ('NotNull ty)
+  -> Expression outer grp commons schemas params from ('NotNull ty)
   -- ^ @NULL@ is absent
-  -> Expression grp commons schemas params from ('NotNull ty)
+  -> Expression outer grp commons schemas params from ('NotNull ty)
 coalesce nullxs notNullx = UnsafeExpression $
   "COALESCE" <> parenthesized (commaSeparated
     ((renderSQL <$> nullxs) <> [renderSQL notNullx]))
@@ -420,26 +421,26 @@ coalesce nullxs notNullx = UnsafeExpression $
 -- >>> printSQL $ fromNull true null_
 -- COALESCE(NULL, TRUE)
 fromNull
-  :: Expression grp commons schemas params from ('NotNull ty)
+  :: Expression outer grp commons schemas params from ('NotNull ty)
   -- ^ what to convert @NULL@ to
-  -> Expression grp commons schemas params from ('Null ty)
-  -> Expression grp commons schemas params from ('NotNull ty)
+  -> Expression outer grp commons schemas params from ('Null ty)
+  -> Expression outer grp commons schemas params from ('NotNull ty)
 fromNull notNullx nullx = coalesce [nullx] notNullx
 
 -- | >>> printSQL $ null_ & isNull
 -- NULL IS NULL
 isNull
-  :: Expression grp commons schemas params from ('Null ty)
+  :: Expression outer grp commons schemas params from ('Null ty)
   -- ^ possibly @NULL@
-  -> Condition grp commons schemas params from
+  -> Condition outer grp commons schemas params from
 isNull x = UnsafeExpression $ renderSQL x <+> "IS NULL"
 
 -- | >>> printSQL $ null_ & isNotNull
 -- NULL IS NOT NULL
 isNotNull
-  :: Expression grp commons schemas params from ('Null ty)
+  :: Expression outer grp commons schemas params from ('Null ty)
   -- ^ possibly @NULL@
-  -> Condition grp commons schemas params from
+  -> Condition outer grp commons schemas params from
 isNotNull x = UnsafeExpression $ renderSQL x <+> "IS NOT NULL"
 
 -- | analagous to `maybe` using @IS NULL@
@@ -447,13 +448,13 @@ isNotNull x = UnsafeExpression $ renderSQL x <+> "IS NOT NULL"
 -- >>> printSQL $ matchNull true not_ null_
 -- CASE WHEN NULL IS NULL THEN TRUE ELSE (NOT NULL) END
 matchNull
-  :: Expression grp commons schemas params from (nullty)
+  :: Expression outer grp commons schemas params from (nullty)
   -- ^ what to convert @NULL@ to
-  -> ( Expression grp commons schemas params from ('NotNull ty)
-       -> Expression grp commons schemas params from (nullty) )
+  -> ( Expression outer grp commons schemas params from ('NotNull ty)
+       -> Expression outer grp commons schemas params from (nullty) )
   -- ^ function to perform when @NULL@ is absent
-  -> Expression grp commons schemas params from ('Null ty)
-  -> Expression grp commons schemas params from (nullty)
+  -> Expression outer grp commons schemas params from ('Null ty)
+  -> Expression outer grp commons schemas params from (nullty)
 matchNull y f x = ifThenElse (isNull x) y
   (f (UnsafeExpression (renderSQL x)))
 
@@ -461,25 +462,25 @@ matchNull y f x = ifThenElse (isNull x) y
 `nullIf` gives @NULL@.
 
 >>> :set -XTypeApplications -XDataKinds
->>> let expr = nullIf false (param @1) :: Expression grp commons schemas '[ 'NotNull 'PGbool] from ('Null 'PGbool)
+>>> let expr = nullIf false (param @1) :: Expression outer grp commons schemas '[ 'NotNull 'PGbool] from ('Null 'PGbool)
 >>> printSQL expr
 NULL IF (FALSE, ($1 :: bool))
 -}
 nullIf
-  :: Expression grp commons schemas params from ('NotNull ty)
+  :: Expression outer grp commons schemas params from ('NotNull ty)
   -- ^ @NULL@ is absent
-  -> Expression grp commons schemas params from ('NotNull ty)
+  -> Expression outer grp commons schemas params from ('NotNull ty)
   -- ^ @NULL@ is absent
-  -> Expression grp commons schemas params from ('Null ty)
+  -> Expression outer grp commons schemas params from ('Null ty)
 nullIf x y = UnsafeExpression $ "NULL IF" <+> parenthesized
   (renderSQL x <> ", " <> renderSQL y)
 
 -- | >>> printSQL $ array [null_, false, true]
 -- ARRAY[NULL, FALSE, TRUE]
 array
-  :: [Expression grp commons schemas params from ty]
+  :: [Expression outer grp commons schemas params from ty]
   -- ^ array elements
-  -> Expression grp commons schemas params from (nullity ('PGvararray ty))
+  -> Expression outer grp commons schemas params from (nullity ('PGvararray ty))
 array xs = UnsafeExpression $
   "ARRAY[" <> commaSeparated (renderSQL <$> xs) <> "]"
 
@@ -487,13 +488,13 @@ array xs = UnsafeExpression $
 -- (ARRAY[NULL, FALSE, TRUE])[2]
 index
   :: Word64 -- ^ index
-  -> Expression grp commons schemas params from (nullity ('PGvararray ty)) -- ^ array
-  -> Expression grp commons schemas params from (NullifyType ty)
+  -> Expression outer grp commons schemas params from (nullity ('PGvararray ty)) -- ^ array
+  -> Expression outer grp commons schemas params from (NullifyType ty)
 index n expr = UnsafeExpression $
   parenthesized (renderSQL expr) <> "[" <> fromString (show n) <> "]"
 
 instance (KnownSymbol label, label `In` labels) => IsPGlabel label
-  (Expression grp commons schemas params from (nullity ('PGenum labels))) where
+  (Expression outer grp commons schemas params from (nullity ('PGenum labels))) where
   label = UnsafeExpression $ renderSQL (PGlabel @label)
 
 -- | A row constructor is an expression that builds a row value
@@ -505,14 +506,14 @@ instance (KnownSymbol label, label `In` labels) => IsPGlabel label
 --    , "imaginary" ::: 'NotNull 'PGfloat8 ]
 -- :}
 --
--- >>> let i = row (0 `as` #real :* 1 `as` #imaginary) :: Expression grp commons schemas params from ('NotNull Complex)
+-- >>> let i = row (0 `as` #real :* 1 `as` #imaginary) :: Expression outer grp commons schemas params from ('NotNull Complex)
 -- >>> printSQL i
 -- ROW(0, 1)
 row
   :: SListI row
-  => NP (Aliased (Expression grp commons schemas params from)) row
+  => NP (Aliased (Expression outer grp commons schemas params from)) row
   -- ^ zero or more expressions for the row field values
-  -> Expression grp commons schemas params from (nullity ('PGcomposite row))
+  -> Expression outer grp commons schemas params from (nullity ('PGcomposite row))
 row exprs = UnsafeExpression $ "ROW" <> parenthesized
   (renderCommaSeparated (\ (expr `As` _) -> renderSQL expr) exprs)
 
@@ -523,7 +524,7 @@ row exprs = UnsafeExpression $ "ROW" <> parenthesized
 -- type Schema = '["complex" ::: 'Typedef Complex]
 -- :}
 --
--- >>> let i = row (0 `as` #real :* 1 `as` #imaginary) :: Expression grp '[] (Public Schema) from params ('NotNull Complex)
+-- >>> let i = row (0 `as` #real :* 1 `as` #imaginary) :: Expression outer grp '[] (Public Schema) from params ('NotNull Complex)
 -- >>> printSQL $ i & field #complex #imaginary
 -- (ROW(0, 1)::"complex")."imaginary"
 field
@@ -532,41 +533,41 @@ field
      , Has field row ty)
   => QualifiedAlias sch tydef -- ^ row type
   -> Alias field -- ^ field name
-  -> Expression grp commons schemas params from ('NotNull ('PGcomposite row))
-  -> Expression grp commons schemas params from ty
+  -> Expression outer grp commons schemas params from ('NotNull ('PGcomposite row))
+  -> Expression outer grp commons schemas params from ty
 field td fld expr = UnsafeExpression $
   parenthesized (renderSQL expr <> "::" <> renderSQL td)
     <> "." <> renderSQL fld
 
 instance Semigroup
-  (Expression grp commons schemas params from (nullity ('PGvararray ty))) where
+  (Expression outer grp commons schemas params from (nullity ('PGvararray ty))) where
     (<>) = unsafeBinaryOp "||"
 
 instance Monoid
-  (Expression grp commons schemas params from (nullity ('PGvararray ty))) where
+  (Expression outer grp commons schemas params from (nullity ('PGvararray ty))) where
     mempty = array []
     mappend = (<>)
 
--- | >>> let expr = greatest currentTimestamp [param @1] :: Expression grp commons schemas '[ 'NotNull 'PGtimestamptz] from ('NotNull 'PGtimestamptz)
+-- | >>> let expr = greatest currentTimestamp [param @1] :: Expression outer grp commons schemas '[ 'NotNull 'PGtimestamptz] from ('NotNull 'PGtimestamptz)
 -- >>> printSQL expr
 -- GREATEST(CURRENT_TIMESTAMP, ($1 :: timestamp with time zone))
 greatest
-  :: Expression grp commons schemas params from (nullty)
+  :: Expression outer grp commons schemas params from (nullty)
   -- ^ needs at least 1 argument
-  -> [Expression grp commons schemas params from (nullty)]
+  -> [Expression outer grp commons schemas params from (nullty)]
   -- ^ or more
-  -> Expression grp commons schemas params from (nullty)
+  -> Expression outer grp commons schemas params from (nullty)
 greatest x xs = UnsafeExpression $ "GREATEST("
   <> commaSeparated (renderSQL <$> (x:xs)) <> ")"
 
 -- | >>> printSQL $ least currentTimestamp [null_]
 -- LEAST(CURRENT_TIMESTAMP, NULL)
 least
-  :: Expression grp commons schemas params from (nullty)
+  :: Expression outer grp commons schemas params from (nullty)
   -- ^ needs at least 1 argument
-  -> [Expression grp commons schemas params from (nullty)]
+  -> [Expression outer grp commons schemas params from (nullty)]
   -- ^ or more
-  -> Expression grp commons schemas params from (nullty)
+  -> Expression outer grp commons schemas params from (nullty)
 least x xs = UnsafeExpression $ "LEAST("
   <> commaSeparated (renderSQL <$> (x:xs)) <> ")"
 
@@ -575,9 +576,9 @@ least x xs = UnsafeExpression $ "LEAST("
 unsafeBinaryOp
   :: ByteString
   -- ^ operator
-  -> Expression grp commons schemas params from (ty0)
-  -> Expression grp commons schemas params from (ty1)
-  -> Expression grp commons schemas params from (ty2)
+  -> Expression outer grp commons schemas params from (ty0)
+  -> Expression outer grp commons schemas params from (ty1)
+  -> Expression outer grp commons schemas params from (ty2)
 unsafeBinaryOp op x y = UnsafeExpression $ parenthesized $
   renderSQL x <+> op <+> renderSQL y
 
@@ -586,8 +587,8 @@ unsafeBinaryOp op x y = UnsafeExpression $ parenthesized $
 unsafeUnaryOp
   :: ByteString
   -- ^ operator
-  -> Expression grp commons schemas params from (ty0)
-  -> Expression grp commons schemas params from (ty1)
+  -> Expression outer grp commons schemas params from (ty0)
+  -> Expression outer grp commons schemas params from (ty1)
 unsafeUnaryOp op x = UnsafeExpression $ parenthesized $
   op <+> renderSQL x
 
@@ -596,8 +597,8 @@ unsafeUnaryOp op x = UnsafeExpression $ parenthesized $
 unsafeFunction
   :: ByteString
   -- ^ function
-  -> Expression grp commons schemas params from (xty)
-  -> Expression grp commons schemas params from (yty)
+  -> Expression outer grp commons schemas params from (xty)
+  -> Expression outer grp commons schemas params from (yty)
 unsafeFunction fun x = UnsafeExpression $
   fun <> parenthesized (renderSQL x)
 
@@ -606,13 +607,13 @@ unsafeVariadicFunction
   :: SListI elems
   => ByteString
   -- ^ function
-  -> NP (Expression grp commons schemas params from) elems
-  -> Expression grp commons schemas params from ret
+  -> NP (Expression outer grp commons schemas params from) elems
+  -> Expression outer grp commons schemas params from ret
 unsafeVariadicFunction fun x = UnsafeExpression $
   fun <> parenthesized (commaSeparated (hcollapse (hmap (K . renderSQL) x)))
 
 instance ty `In` PGNum
-  => Num (Expression grp commons schemas params from (nullity ty)) where
+  => Num (Expression outer grp commons schemas params from (nullity ty)) where
     (+) = unsafeBinaryOp "+"
     (-) = unsafeBinaryOp "-"
     (*) = unsafeBinaryOp "*"
@@ -624,12 +625,12 @@ instance ty `In` PGNum
       . show
 
 instance (ty `In` PGNum, ty `In` PGFloating) => Fractional
-  (Expression grp commons schemas params from (nullity ty)) where
+  (Expression outer grp commons schemas params from (nullity ty)) where
     (/) = unsafeBinaryOp "/"
     fromRational x = fromInteger (numerator x) / fromInteger (denominator x)
 
 instance (ty `In` PGNum, ty `In` PGFloating) => Floating
-  (Expression grp commons schemas params from (nullity ty)) where
+  (Expression outer grp commons schemas params from (nullity ty)) where
     pi = UnsafeExpression "pi()"
     exp = unsafeFunction "exp"
     log = unsafeFunction "ln"
@@ -652,18 +653,18 @@ instance (ty `In` PGNum, ty `In` PGFloating) => Floating
 
 -- | >>> :{
 -- let
---   expression :: Expression grp commons schemas params from (nullity 'PGfloat4)
+--   expression :: Expression outer grp commons schemas params from (nullity 'PGfloat4)
 --   expression = atan2_ pi 2
 -- in printSQL expression
 -- :}
 -- atan2(pi(), 2)
 atan2_
   :: float `In` PGFloating
-  => Expression grp commons schemas params from (nullity float)
+  => Expression outer grp commons schemas params from (nullity float)
   -- ^ numerator
-  -> Expression grp commons schemas params from (nullity float)
+  -> Expression outer grp commons schemas params from (nullity float)
   -- ^ denominator
-  -> Expression grp commons schemas params from (nullity float)
+  -> Expression outer grp commons schemas params from (nullity float)
 atan2_ y x = UnsafeExpression $
   "atan2(" <> renderSQL y <> ", " <> renderSQL x <> ")"
 
@@ -676,9 +677,9 @@ atan2_ y x = UnsafeExpression $
 cast
   :: TypeExpression schemas ty1
   -- ^ type to cast as
-  -> Expression grp commons schemas params from ty0
+  -> Expression outer grp commons schemas params from ty0
   -- ^ value to convert
-  -> Expression grp commons schemas params from ty1
+  -> Expression outer grp commons schemas params from ty1
 cast ty x = UnsafeExpression $ parenthesized $
   renderSQL x <+> "::" <+> renderSQL ty
 
@@ -686,136 +687,136 @@ cast ty x = UnsafeExpression $ parenthesized $
 --
 -- >>> :{
 -- let
---   expression :: Expression grp commons schemas params from (nullity 'PGint2)
+--   expression :: Expression outer grp commons schemas params from (nullity 'PGint2)
 --   expression = 5 `quot_` 2
 -- in printSQL expression
 -- :}
 -- (5 / 2)
 quot_
   :: int `In` PGIntegral
-  => Expression grp commons schemas params from (nullity int)
+  => Expression outer grp commons schemas params from (nullity int)
   -- ^ numerator
-  -> Expression grp commons schemas params from (nullity int)
+  -> Expression outer grp commons schemas params from (nullity int)
   -- ^ denominator
-  -> Expression grp commons schemas params from (nullity int)
+  -> Expression outer grp commons schemas params from (nullity int)
 quot_ = unsafeBinaryOp "/"
 
 -- | remainder upon integer division
 --
 -- >>> :{
 -- let
---   expression :: Expression grp commons schemas params from (nullity 'PGint2)
+--   expression :: Expression outer grp commons schemas params from (nullity 'PGint2)
 --   expression = 5 `rem_` 2
 -- in printSQL expression
 -- :}
 -- (5 % 2)
 rem_
   :: int `In` PGIntegral
-  => Expression grp commons schemas params from (nullity int)
+  => Expression outer grp commons schemas params from (nullity int)
   -- ^ numerator
-  -> Expression grp commons schemas params from (nullity int)
+  -> Expression outer grp commons schemas params from (nullity int)
   -- ^ denominator
-  -> Expression grp commons schemas params from (nullity int)
+  -> Expression outer grp commons schemas params from (nullity int)
 rem_ = unsafeBinaryOp "%"
 
 -- | >>> :{
 -- let
---   expression :: Expression grp commons schemas params from (nullity 'PGfloat4)
+--   expression :: Expression outer grp commons schemas params from (nullity 'PGfloat4)
 --   expression = trunc pi
 -- in printSQL expression
 -- :}
 -- trunc(pi())
 trunc
   :: frac `In` PGFloating
-  => Expression grp commons schemas params from (nullity frac)
+  => Expression outer grp commons schemas params from (nullity frac)
   -- ^ fractional number
-  -> Expression grp commons schemas params from (nullity frac)
+  -> Expression outer grp commons schemas params from (nullity frac)
 trunc = unsafeFunction "trunc"
 
 -- | >>> :{
 -- let
---   expression :: Expression grp commons schemas params from (nullity 'PGfloat4)
+--   expression :: Expression outer grp commons schemas params from (nullity 'PGfloat4)
 --   expression = round_ pi
 -- in printSQL expression
 -- :}
 -- round(pi())
 round_
   :: frac `In` PGFloating
-  => Expression grp commons schemas params from (nullity frac)
+  => Expression outer grp commons schemas params from (nullity frac)
   -- ^ fractional number
-  -> Expression grp commons schemas params from (nullity frac)
+  -> Expression outer grp commons schemas params from (nullity frac)
 round_ = unsafeFunction "round"
 
 -- | >>> :{
 -- let
---   expression :: Expression grp commons schemas params from (nullity 'PGfloat4)
+--   expression :: Expression outer grp commons schemas params from (nullity 'PGfloat4)
 --   expression = ceiling_ pi
 -- in printSQL expression
 -- :}
 -- ceiling(pi())
 ceiling_
   :: frac `In` PGFloating
-  => Expression grp commons schemas params from (nullity frac)
+  => Expression outer grp commons schemas params from (nullity frac)
   -- ^ fractional number
-  -> Expression grp commons schemas params from (nullity frac)
+  -> Expression outer grp commons schemas params from (nullity frac)
 ceiling_ = unsafeFunction "ceiling"
 
 -- | A `Condition` is an `Expression`, which can evaluate
 -- to `true`, `false` or `null_`. This is because SQL uses
 -- a three valued logic.
-type Condition grp commons schemas params from =
-  Expression grp commons schemas params from ('Null 'PGbool)
+type Condition outer grp commons schemas params from =
+  Expression outer grp commons schemas params from ('Null 'PGbool)
 
 -- | >>> printSQL true
 -- TRUE
-true :: Expression grp commons schemas params from (nullity 'PGbool)
+true :: Expression outer grp commons schemas params from (nullity 'PGbool)
 true = UnsafeExpression "TRUE"
 
 -- | >>> printSQL false
 -- FALSE
-false :: Expression grp commons schemas params from (nullity 'PGbool)
+false :: Expression outer grp commons schemas params from (nullity 'PGbool)
 false = UnsafeExpression "FALSE"
 
 -- | >>> printSQL $ not_ true
 -- (NOT TRUE)
 not_
-  :: Expression grp commons schemas params from (nullity 'PGbool)
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from (nullity 'PGbool)
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 not_ = unsafeUnaryOp "NOT"
 
 -- | >>> printSQL $ true .&& false
 -- (TRUE AND FALSE)
 (.&&)
-  :: Expression grp commons schemas params from (nullity 'PGbool)
-  -> Expression grp commons schemas params from (nullity 'PGbool)
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from (nullity 'PGbool)
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 infixr 3 .&&
 (.&&) = unsafeBinaryOp "AND"
 
 -- | >>> printSQL $ true .|| false
 -- (TRUE OR FALSE)
 (.||)
-  :: Expression grp commons schemas params from (nullity 'PGbool)
-  -> Expression grp commons schemas params from (nullity 'PGbool)
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from (nullity 'PGbool)
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 infixr 2 .||
 (.||) = unsafeBinaryOp "OR"
 
 -- | >>> :{
 -- let
---   expression :: Expression grp commons schemas params from (nullity 'PGint2)
+--   expression :: Expression outer grp commons schemas params from (nullity 'PGint2)
 --   expression = caseWhenThenElse [(true, 1), (false, 2)] 3
 -- in printSQL expression
 -- :}
 -- CASE WHEN TRUE THEN 1 WHEN FALSE THEN 2 ELSE 3 END
 caseWhenThenElse
-  :: [ ( Condition grp commons schemas params from
-       , Expression grp commons schemas params from ty
+  :: [ ( Condition outer grp commons schemas params from
+       , Expression outer grp commons schemas params from ty
      ) ]
   -- ^ whens and thens
-  -> Expression grp commons schemas params from ty
+  -> Expression outer grp commons schemas params from ty
   -- ^ else
-  -> Expression grp commons schemas params from ty
+  -> Expression outer grp commons schemas params from ty
 caseWhenThenElse whenThens else_ = UnsafeExpression $ mconcat
   [ "CASE"
   , mconcat
@@ -831,16 +832,16 @@ caseWhenThenElse whenThens else_ = UnsafeExpression $ mconcat
 
 -- | >>> :{
 -- let
---   expression :: Expression grp commons schemas params from (nullity 'PGint2)
+--   expression :: Expression outer grp commons schemas params from (nullity 'PGint2)
 --   expression = ifThenElse true 1 0
 -- in printSQL expression
 -- :}
 -- CASE WHEN TRUE THEN 1 ELSE 0 END
 ifThenElse
-  :: Condition grp commons schemas params from
-  -> Expression grp commons schemas params from ty -- ^ then
-  -> Expression grp commons schemas params from ty -- ^ else
-  -> Expression grp commons schemas params from ty
+  :: Condition outer grp commons schemas params from
+  -> Expression outer grp commons schemas params from ty -- ^ then
+  -> Expression outer grp commons schemas params from ty -- ^ else
+  -> Expression outer grp commons schemas params from ty
 ifThenElse if_ then_ else_ = caseWhenThenElse [(if_,then_)] else_
 
 -- | Comparison operations like `.==`, `./=`, `.>`, `.>=`, `.<` and `.<=`
@@ -849,85 +850,85 @@ ifThenElse if_ then_ else_ = caseWhenThenElse [(if_,then_)] else_
 -- >>> printSQL $ true .== null_
 -- (TRUE = NULL)
 (.==)
-  :: Expression grp commons schemas params from (nullity0 ty) -- ^ lhs
-  -> Expression grp commons schemas params from (nullity1 ty) -- ^ rhs
-  -> Condition grp commons schemas params from
+  :: Expression outer grp commons schemas params from (nullity0 ty) -- ^ lhs
+  -> Expression outer grp commons schemas params from (nullity1 ty) -- ^ rhs
+  -> Condition outer grp commons schemas params from
 (.==) = unsafeBinaryOp "="
 infix 4 .==
 
 -- | >>> printSQL $ true ./= null_
 -- (TRUE <> NULL)
 (./=)
-  :: Expression grp commons schemas params from (nullity0 ty) -- ^ lhs
-  -> Expression grp commons schemas params from (nullity1 ty) -- ^ rhs
-  -> Condition grp commons schemas params from
+  :: Expression outer grp commons schemas params from (nullity0 ty) -- ^ lhs
+  -> Expression outer grp commons schemas params from (nullity1 ty) -- ^ rhs
+  -> Condition outer grp commons schemas params from
 (./=) = unsafeBinaryOp "<>"
 infix 4 ./=
 
 -- | >>> printSQL $ true .>= null_
 -- (TRUE >= NULL)
 (.>=)
-  :: Expression grp commons schemas params from (nullity0 ty) -- ^ lhs
-  -> Expression grp commons schemas params from (nullity1 ty) -- ^ rhs
-  -> Condition grp commons schemas params from
+  :: Expression outer grp commons schemas params from (nullity0 ty) -- ^ lhs
+  -> Expression outer grp commons schemas params from (nullity1 ty) -- ^ rhs
+  -> Condition outer grp commons schemas params from
 (.>=) = unsafeBinaryOp ">="
 infix 4 .>=
 
 -- | >>> printSQL $ true .< null_
 -- (TRUE < NULL)
 (.<)
-  :: Expression grp commons schemas params from (nullity0 ty) -- ^ lhs
-  -> Expression grp commons schemas params from (nullity1 ty) -- ^ rhs
-  -> Condition grp commons schemas params from
+  :: Expression outer grp commons schemas params from (nullity0 ty) -- ^ lhs
+  -> Expression outer grp commons schemas params from (nullity1 ty) -- ^ rhs
+  -> Condition outer grp commons schemas params from
 (.<) = unsafeBinaryOp "<"
 infix 4 .<
 
 -- | >>> printSQL $ true .<= null_
 -- (TRUE <= NULL)
 (.<=)
-  :: Expression grp commons schemas params from (nullity0 ty) -- ^ lhs
-  -> Expression grp commons schemas params from (nullity1 ty) -- ^ rhs
-  -> Condition grp commons schemas params from
+  :: Expression outer grp commons schemas params from (nullity0 ty) -- ^ lhs
+  -> Expression outer grp commons schemas params from (nullity1 ty) -- ^ rhs
+  -> Condition outer grp commons schemas params from
 (.<=) = unsafeBinaryOp "<="
 infix 4 .<=
 
 -- | >>> printSQL $ true .> null_
 -- (TRUE > NULL)
 (.>)
-  :: Expression grp commons schemas params from (nullity0 ty) -- ^ lhs
-  -> Expression grp commons schemas params from (nullity1 ty) -- ^ rhs
-  -> Condition grp commons schemas params from
+  :: Expression outer grp commons schemas params from (nullity0 ty) -- ^ lhs
+  -> Expression outer grp commons schemas params from (nullity1 ty) -- ^ rhs
+  -> Condition outer grp commons schemas params from
 (.>) = unsafeBinaryOp ">"
 infix 4 .>
 
 -- | >>> printSQL currentDate
 -- CURRENT_DATE
 currentDate
-  :: Expression grp commons schemas params from (nullity 'PGdate)
+  :: Expression outer grp commons schemas params from (nullity 'PGdate)
 currentDate = UnsafeExpression "CURRENT_DATE"
 
 -- | >>> printSQL currentTime
 -- CURRENT_TIME
 currentTime
-  :: Expression grp commons schemas params from (nullity 'PGtimetz)
+  :: Expression outer grp commons schemas params from (nullity 'PGtimetz)
 currentTime = UnsafeExpression "CURRENT_TIME"
 
 -- | >>> printSQL currentTimestamp
 -- CURRENT_TIMESTAMP
 currentTimestamp
-  :: Expression grp commons schemas params from (nullity 'PGtimestamptz)
+  :: Expression outer grp commons schemas params from (nullity 'PGtimestamptz)
 currentTimestamp = UnsafeExpression "CURRENT_TIMESTAMP"
 
 -- | >>> printSQL localTime
 -- LOCALTIME
 localTime
-  :: Expression grp commons schemas params from (nullity 'PGtime)
+  :: Expression outer grp commons schemas params from (nullity 'PGtime)
 localTime = UnsafeExpression "LOCALTIME"
 
 -- | >>> printSQL localTimestamp
 -- LOCALTIMESTAMP
 localTimestamp
-  :: Expression grp commons schemas params from (nullity 'PGtimestamp)
+  :: Expression outer grp commons schemas params from (nullity 'PGtimestamp)
 localTimestamp = UnsafeExpression "LOCALTIMESTAMP"
 
 {-----------------------------------------
@@ -935,7 +936,7 @@ text
 -----------------------------------------}
 
 instance IsString
-  (Expression grp commons schemas params from (nullity 'PGtext)) where
+  (Expression outer grp commons schemas params from (nullity 'PGtext)) where
     fromString str = UnsafeExpression $
       "E\'" <> fromString (escape =<< str) <> "\'"
       where
@@ -951,36 +952,36 @@ instance IsString
           c -> [c]
 
 instance Semigroup
-  (Expression grp commons schemas params from (nullity 'PGtext)) where
+  (Expression outer grp commons schemas params from (nullity 'PGtext)) where
     (<>) = unsafeBinaryOp "||"
 
 instance Monoid
-  (Expression grp commons schemas params from (nullity 'PGtext)) where
+  (Expression outer grp commons schemas params from (nullity 'PGtext)) where
     mempty = fromString ""
     mappend = (<>)
 
 -- | >>> printSQL $ lower "ARRRGGG"
 -- lower(E'ARRRGGG')
 lower
-  :: Expression grp commons schemas params from (nullity 'PGtext)
+  :: Expression outer grp commons schemas params from (nullity 'PGtext)
   -- ^ string to lower case
-  -> Expression grp commons schemas params from (nullity 'PGtext)
+  -> Expression outer grp commons schemas params from (nullity 'PGtext)
 lower = unsafeFunction "lower"
 
 -- | >>> printSQL $ upper "eeee"
 -- upper(E'eeee')
 upper
-  :: Expression grp commons schemas params from (nullity 'PGtext)
+  :: Expression outer grp commons schemas params from (nullity 'PGtext)
   -- ^ string to upper case
-  -> Expression grp commons schemas params from (nullity 'PGtext)
+  -> Expression outer grp commons schemas params from (nullity 'PGtext)
 upper = unsafeFunction "upper"
 
 -- | >>> printSQL $ charLength "four"
 -- char_length(E'four')
 charLength
-  :: Expression grp commons schemas params from (nullity 'PGtext)
+  :: Expression outer grp commons schemas params from (nullity 'PGtext)
   -- ^ string to measure
-  -> Expression grp commons schemas params from (nullity 'PGint4)
+  -> Expression outer grp commons schemas params from (nullity 'PGint4)
 charLength = unsafeFunction "char_length"
 
 -- | The `like` expression returns true if the @string@ matches
@@ -993,11 +994,11 @@ charLength = unsafeFunction "char_length"
 -- >>> printSQL $ "abc" `like` "a%"
 -- (E'abc' LIKE E'a%')
 like
-  :: Expression grp commons schemas params from (nullity 'PGtext)
+  :: Expression outer grp commons schemas params from (nullity 'PGtext)
   -- ^ string
-  -> Expression grp commons schemas params from (nullity 'PGtext)
+  -> Expression outer grp commons schemas params from (nullity 'PGtext)
   -- ^ pattern
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 like = unsafeBinaryOp "LIKE"
 
 -- | The key word ILIKE can be used instead of LIKE to make the
@@ -1006,11 +1007,11 @@ like = unsafeBinaryOp "LIKE"
 -- >>> printSQL $ "abc" `ilike` "a%"
 -- (E'abc' ILIKE E'a%')
 ilike
-  :: Expression grp commons schemas params from (nullity 'PGtext)
+  :: Expression outer grp commons schemas params from (nullity 'PGtext)
   -- ^ string
-  -> Expression grp commons schemas params from (nullity 'PGtext)
+  -> Expression outer grp commons schemas params from (nullity 'PGtext)
   -- ^ pattern
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 ilike = unsafeBinaryOp "ILIKE"
 
 {-----------------------------------------
@@ -1025,36 +1026,36 @@ Table 9.44: json and jsonb operators
 -- | Get JSON value (object field or array element) at a key.
 (.->)
   :: (json `In` PGJsonType, key `In` PGJsonKey)
-  => Expression grp commons schemas params from (nullity json)
-  -> Expression grp commons schemas params from (nullity key)
-  -> Expression grp commons schemas params from ('Null json)
+  => Expression outer grp commons schemas params from (nullity json)
+  -> Expression outer grp commons schemas params from (nullity key)
+  -> Expression outer grp commons schemas params from ('Null json)
 infixl 8 .->
 (.->) = unsafeBinaryOp "->"
 
 -- | Get JSON value (object field or array element) at a key, as text.
 (.->>)
   :: (json `In` PGJsonType, key `In` PGJsonKey)
-  => Expression grp commons schemas params from (nullity json)
-  -> Expression grp commons schemas params from (nullity key)
-  -> Expression grp commons schemas params from ('Null 'PGtext)
+  => Expression outer grp commons schemas params from (nullity json)
+  -> Expression outer grp commons schemas params from (nullity key)
+  -> Expression outer grp commons schemas params from ('Null 'PGtext)
 infixl 8 .->>
 (.->>) = unsafeBinaryOp "->>"
 
 -- | Get JSON value at a specified path.
 (.#>)
   :: (json `In` PGJsonType, PGTextArray "(.#>)" path)
-  => Expression grp commons schemas params from (nullity json)
-  -> Expression grp commons schemas params from (nullity path)
-  -> Expression grp commons schemas params from ('Null json)
+  => Expression outer grp commons schemas params from (nullity json)
+  -> Expression outer grp commons schemas params from (nullity path)
+  -> Expression outer grp commons schemas params from ('Null json)
 infixl 8 .#>
 (.#>) = unsafeBinaryOp "#>"
 
 -- | Get JSON value at a specified path as text.
 (.#>>)
   :: (json `In` PGJsonType, PGTextArray "(.#>>)" path)
-  => Expression grp commons schemas params from (nullity json)
-  -> Expression grp commons schemas params from (nullity path)
-  -> Expression grp commons schemas params from ('Null 'PGtext)
+  => Expression outer grp commons schemas params from (nullity json)
+  -> Expression outer grp commons schemas params from (nullity path)
+  -> Expression outer grp commons schemas params from ('Null 'PGtext)
 infixl 8 .#>>
 (.#>>) = unsafeBinaryOp "#>>"
 
@@ -1063,49 +1064,49 @@ infixl 8 .#>>
 -- | Does the left JSON value contain the right JSON path/value entries at the
 -- top level?
 (.@>)
-  :: Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Condition grp commons schemas params from
+  :: Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Condition outer grp commons schemas params from
 infixl 9 .@>
 (.@>) = unsafeBinaryOp "@>"
 
 -- | Are the left JSON path/value entries contained at the top level within the
 -- right JSON value?
 (.<@)
-  :: Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Condition grp commons schemas params from
+  :: Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Condition outer grp commons schemas params from
 infixl 9 .<@
 (.<@) = unsafeBinaryOp "<@"
 
 -- | Does the string exist as a top-level key within the JSON value?
 (.?)
-  :: Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Expression grp commons schemas params from (nullity 'PGtext)
-  -> Condition grp commons schemas params from
+  :: Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Expression outer grp commons schemas params from (nullity 'PGtext)
+  -> Condition outer grp commons schemas params from
 infixl 9 .?
 (.?) = unsafeBinaryOp "?"
 
 -- | Do any of these array strings exist as top-level keys?
 (.?|)
-  :: Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Expression grp commons schemas params from (nullity ('PGvararray ('NotNull 'PGtext)))
-  -> Condition grp commons schemas params from
+  :: Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Expression outer grp commons schemas params from (nullity ('PGvararray ('NotNull 'PGtext)))
+  -> Condition outer grp commons schemas params from
 infixl 9 .?|
 (.?|) = unsafeBinaryOp "?|"
 
 -- | Do all of these array strings exist as top-level keys?
 (.?&)
-  :: Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Expression grp commons schemas params from (nullity ('PGvararray ('NotNull 'PGtext)))
-  -> Condition grp commons schemas params from
+  :: Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Expression outer grp commons schemas params from (nullity ('PGvararray ('NotNull 'PGtext)))
+  -> Condition outer grp commons schemas params from
 infixl 9 .?&
 (.?&) = unsafeBinaryOp "?&"
 
 -- | Concatenate two jsonb values into a new jsonb value.
-instance
-  Semigroup (Expression commons schemas from grouping param (nullity 'PGjsonb)) where
-  (<>) = unsafeBinaryOp "||"
+instance Semigroup
+  (Expression outer grp commons schemas params from (nullity 'PGjsonb)) where
+    (<>) = unsafeBinaryOp "||"
 
 -- | Delete a key or keys from a JSON object, or remove an array element.
 --
@@ -1121,9 +1122,9 @@ instance
 -- count from the end). Throws an error if top level container is not an array.
 (.-.)
   :: (key `In` '[ 'PGtext, 'PGvararray ('NotNull 'PGtext), 'PGint4, 'PGint2 ]) -- hlint error without parens here
-  => Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Expression grp commons schemas params from (nullity key)
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
+  => Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Expression outer grp commons schemas params from (nullity key)
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
 infixl 6 .-.
 (.-.) = unsafeBinaryOp "-"
 
@@ -1131,9 +1132,9 @@ infixl 6 .-.
 -- integers count from the end)
 (#-.)
   :: PGTextArray "(#-.)" arrayty
-  => Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Expression grp commons schemas params from (nullity arrayty)
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
+  => Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Expression outer grp commons schemas params from (nullity arrayty)
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
 infixl 6 #-.
 (#-.) = unsafeBinaryOp "#-"
 
@@ -1144,14 +1145,14 @@ Table 9.45: JSON creation functions
 -- | Literal binary JSON
 jsonbLit
   :: JSON.ToJSON x
-  => x -> Expression grp commons schemas params from (nullity 'PGjsonb)
+  => x -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
 jsonbLit = cast jsonb . UnsafeExpression
   . singleQuotedUtf8 . toStrict . JSON.encode
 
 -- | Literal JSON
 jsonLit
   :: JSON.ToJSON x
-  => x -> Expression grp commons schemas params from (nullity 'PGjson)
+  => x -> Expression outer grp commons schemas params from (nullity 'PGjson)
 jsonLit = cast json . UnsafeExpression
   . singleQuotedUtf8 . toStrict . JSON.encode
 
@@ -1162,8 +1163,8 @@ jsonLit = cast json . UnsafeExpression
 -- number, a Boolean, or a null value, the text representation will be used, in
 -- such a fashion that it is a valid json value.
 toJson
-  :: Expression grp commons schemas params from (nullity ty)
-  -> Expression grp commons schemas params from (nullity 'PGjson)
+  :: Expression outer grp commons schemas params from (nullity ty)
+  -> Expression outer grp commons schemas params from (nullity 'PGjson)
 toJson = unsafeFunction "to_json"
 
 -- | Returns the value as jsonb. Arrays and composites are converted
@@ -1173,43 +1174,43 @@ toJson = unsafeFunction "to_json"
 -- number, a Boolean, or a null value, the text representation will be used, in
 -- such a fashion that it is a valid jsonb value.
 toJsonb
-  :: Expression grp commons schemas params from (nullity ty)
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
+  :: Expression outer grp commons schemas params from (nullity ty)
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
 toJsonb = unsafeFunction "to_jsonb"
 
 -- | Returns the array as a JSON array. A PostgreSQL multidimensional array
 -- becomes a JSON array of arrays.
 arrayToJson
   :: PGArray "arrayToJson" arr
-  => Expression grp commons schemas params from (nullity arr)
-  -> Expression grp commons schemas params from (nullity 'PGjson)
+  => Expression outer grp commons schemas params from (nullity arr)
+  -> Expression outer grp commons schemas params from (nullity 'PGjson)
 arrayToJson = unsafeFunction "array_to_json"
 
 -- | Returns the row as a JSON object.
 rowToJson
-  :: Expression grp commons schemas params from (nullity ('PGcomposite ty))
-  -> Expression grp commons schemas params from (nullity 'PGjson)
+  :: Expression outer grp commons schemas params from (nullity ('PGcomposite ty))
+  -> Expression outer grp commons schemas params from (nullity 'PGjson)
 rowToJson = unsafeFunction "row_to_json"
 
 -- | Builds a possibly-heterogeneously-typed JSON array out of a variadic
 -- argument list.
 jsonBuildArray
   :: SListI elems
-  => NP (Expression grp commons schemas params from) elems
-  -> Expression grp commons schemas params from (nullity 'PGjson)
+  => NP (Expression outer grp commons schemas params from) elems
+  -> Expression outer grp commons schemas params from (nullity 'PGjson)
 jsonBuildArray = unsafeVariadicFunction "json_build_array"
 
 -- | Builds a possibly-heterogeneously-typed (binary) JSON array out of a
 -- variadic argument list.
 jsonbBuildArray
   :: SListI elems
-  => NP (Expression grp commons schemas params from) elems
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
+  => NP (Expression outer grp commons schemas params from) elems
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
 jsonbBuildArray = unsafeVariadicFunction "jsonb_build_array"
 
 unsafeRowFunction
   :: All Top elems
-  => NP (Aliased (Expression grp commons schemas params from)) elems
+  => NP (Aliased (Expression outer grp commons schemas params from)) elems
   -> [ByteString]
 unsafeRowFunction =
   (`appEndo` []) . hcfoldMap (Proxy :: Proxy Top)
@@ -1224,8 +1225,8 @@ unsafeRowFunction =
 -- and values.
 jsonBuildObject
   :: All Top elems
-  => NP (Aliased (Expression grp commons schemas params from)) elems
-  -> Expression grp commons schemas params from (nullity 'PGjson)
+  => NP (Aliased (Expression outer grp commons schemas params from)) elems
+  -> Expression outer grp commons schemas params from (nullity 'PGjson)
 jsonBuildObject
   = unsafeFunction "json_build_object"
   . UnsafeExpression
@@ -1237,8 +1238,8 @@ jsonBuildObject
 -- between text and values.
 jsonbBuildObject
   :: All Top elems
-  => NP (Aliased (Expression grp commons schemas params from)) elems
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
+  => NP (Aliased (Expression outer grp commons schemas params from)) elems
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
 jsonbBuildObject
   = unsafeFunction "jsonb_build_object"
   . UnsafeExpression
@@ -1251,8 +1252,8 @@ jsonbBuildObject
 -- array has exactly two elements, which are taken as a key/value pair.
 jsonObject
   :: PGArrayOf "jsonObject" arr ('NotNull 'PGtext)
-  => Expression grp commons schemas params from (nullity arr)
-  -> Expression grp commons schemas params from (nullity 'PGjson)
+  => Expression outer grp commons schemas params from (nullity arr)
+  -> Expression outer grp commons schemas params from (nullity 'PGjson)
 jsonObject = unsafeFunction "json_object"
 
 -- | Builds a binary JSON object out of a text array. The array must have either
@@ -1261,8 +1262,8 @@ jsonObject = unsafeFunction "json_object"
 -- array has exactly two elements, which are taken as a key/value pair.
 jsonbObject
   :: PGArrayOf "jsonbObject" arr ('NotNull 'PGtext)
-  => Expression grp commons schemas params from (nullity arr)
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
+  => Expression outer grp commons schemas params from (nullity arr)
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
 jsonbObject = unsafeFunction "jsonb_object"
 
 -- | This is an alternate form of 'jsonObject' that takes two arrays; one for
@@ -1270,9 +1271,9 @@ jsonbObject = unsafeFunction "jsonb_object"
 jsonZipObject
   :: ( PGArrayOf "jsonZipObject" keysArray ('NotNull 'PGtext)
      , PGArrayOf "jsonZipObject" valuesArray ('NotNull 'PGtext))
-  => Expression grp commons schemas params from (nullity keysArray)
-  -> Expression grp commons schemas params from (nullity valuesArray)
-  -> Expression grp commons schemas params from (nullity 'PGjson)
+  => Expression outer grp commons schemas params from (nullity keysArray)
+  -> Expression outer grp commons schemas params from (nullity valuesArray)
+  -> Expression outer grp commons schemas params from (nullity 'PGjson)
 jsonZipObject ks vs =
   unsafeVariadicFunction "json_object" (ks :* vs :* Nil)
 
@@ -1282,9 +1283,9 @@ jsonZipObject ks vs =
 jsonbZipObject
   :: ( PGArrayOf "jsonbZipObject" keysArray ('NotNull 'PGtext)
      , PGArrayOf "jsonbZipObject" valuesArray ('NotNull 'PGtext))
-  => Expression grp commons schemas params from (nullity keysArray)
-  -> Expression grp commons schemas params from (nullity valuesArray)
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
+  => Expression outer grp commons schemas params from (nullity keysArray)
+  -> Expression outer grp commons schemas params from (nullity valuesArray)
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
 jsonbZipObject ks vs =
   unsafeVariadicFunction "jsonb_object" (ks :* vs :* Nil)
 
@@ -1294,23 +1295,23 @@ Table 9.46: JSON processing functions
 
 -- | Returns the number of elements in the outermost JSON array.
 jsonArrayLength
-  :: Expression grp commons schemas params from (nullity 'PGjson)
-  -> Expression grp commons schemas params from (nullity 'PGint4)
+  :: Expression outer grp commons schemas params from (nullity 'PGjson)
+  -> Expression outer grp commons schemas params from (nullity 'PGint4)
 jsonArrayLength = unsafeFunction "json_array_length"
 
 -- | Returns the number of elements in the outermost binary JSON array.
 jsonbArrayLength
-  :: Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Expression grp commons schemas params from (nullity 'PGint4)
+  :: Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Expression outer grp commons schemas params from (nullity 'PGint4)
 jsonbArrayLength = unsafeFunction "jsonb_array_length"
 
 -- | Returns JSON value pointed to by the given path (equivalent to #>
 -- operator).
 jsonExtractPath
   :: SListI elems
-  => Expression grp commons schemas params from (nullity 'PGjson)
-  -> NP (Expression grp commons schemas params from) elems
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
+  => Expression outer grp commons schemas params from (nullity 'PGjson)
+  -> NP (Expression outer grp commons schemas params from) elems
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
 jsonExtractPath x xs =
   unsafeVariadicFunction "json_extract_path" (x :* xs)
 
@@ -1318,9 +1319,9 @@ jsonExtractPath x xs =
 -- operator).
 jsonbExtractPath
   :: SListI elems
-  => Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> NP (Expression grp commons schemas params from) elems
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
+  => Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> NP (Expression outer grp commons schemas params from) elems
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
 jsonbExtractPath x xs =
   unsafeVariadicFunction "jsonb_extract_path" (x :* xs)
 
@@ -1328,9 +1329,9 @@ jsonbExtractPath x xs =
 -- operator), as text.
 jsonExtractPathAsText
   :: SListI elems
-  => Expression grp commons schemas params from (nullity 'PGjson)
-  -> NP (Expression grp commons schemas params from) elems
-  -> Expression grp commons schemas params from (nullity 'PGjson)
+  => Expression outer grp commons schemas params from (nullity 'PGjson)
+  -> NP (Expression outer grp commons schemas params from) elems
+  -> Expression outer grp commons schemas params from (nullity 'PGjson)
 jsonExtractPathAsText x xs =
   unsafeVariadicFunction "json_extract_path_text" (x :* xs)
 
@@ -1338,38 +1339,38 @@ jsonExtractPathAsText x xs =
 -- operator), as text.
 jsonbExtractPathAsText
   :: SListI elems
-  => Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> NP (Expression grp commons schemas params from) elems
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
+  => Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> NP (Expression outer grp commons schemas params from) elems
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
 jsonbExtractPathAsText x xs =
   unsafeVariadicFunction "jsonb_extract_path_text" (x :* xs)
 
 -- | Returns the type of the outermost JSON value as a text string. Possible
 -- types are object, array, string, number, boolean, and null.
 jsonTypeof
-  :: Expression grp commons schemas params from (nullity 'PGjson)
-  -> Expression grp commons schemas params from (nullity 'PGtext)
+  :: Expression outer grp commons schemas params from (nullity 'PGjson)
+  -> Expression outer grp commons schemas params from (nullity 'PGtext)
 jsonTypeof = unsafeFunction "json_typeof"
 
 -- | Returns the type of the outermost binary JSON value as a text string.
 -- Possible types are object, array, string, number, boolean, and null.
 jsonbTypeof
-  :: Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Expression grp commons schemas params from (nullity 'PGtext)
+  :: Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Expression outer grp commons schemas params from (nullity 'PGtext)
 jsonbTypeof = unsafeFunction "jsonb_typeof"
 
 -- | Returns its argument with all object fields that have null values omitted.
 -- Other null values are untouched.
 jsonStripNulls
-  :: Expression grp commons schemas params from (nullity 'PGjson)
-  -> Expression grp commons schemas params from (nullity 'PGjson)
+  :: Expression outer grp commons schemas params from (nullity 'PGjson)
+  -> Expression outer grp commons schemas params from (nullity 'PGjson)
 jsonStripNulls = unsafeFunction "json_strip_nulls"
 
 -- | Returns its argument with all object fields that have null values omitted.
 -- Other null values are untouched.
 jsonbStripNulls
-  :: Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
+  :: Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
 jsonbStripNulls = unsafeFunction "jsonb_strip_nulls"
 
 -- | @ jsonbSet target path new_value create_missing @
@@ -1381,11 +1382,11 @@ jsonbStripNulls = unsafeFunction "jsonb_strip_nulls"
 -- arrays.
 jsonbSet
   :: PGTextArray "jsonbSet" arr
-  => Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Expression grp commons schemas params from (nullity arr)
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Maybe (Expression grp commons schemas params from (nullity 'PGbool))
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
+  => Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Expression outer grp commons schemas params from (nullity arr)
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Maybe (Expression outer grp commons schemas params from (nullity 'PGbool))
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
 jsonbSet tgt path val createMissing = case createMissing of
   Just m -> unsafeVariadicFunction "jsonb_set" (tgt :* path :* val :* m :* Nil)
   Nothing -> unsafeVariadicFunction "jsonb_set" (tgt :* path :* val :* Nil)
@@ -1400,19 +1401,19 @@ jsonbSet tgt path val createMissing = case createMissing of
 -- in path count from the end of JSON arrays.
 jsonbInsert
   :: PGTextArray "jsonbInsert" arr
-  => Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Expression grp commons schemas params from (nullity arr)
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Maybe (Expression grp commons schemas params from (nullity 'PGbool))
-  -> Expression grp commons schemas params from (nullity 'PGjsonb)
+  => Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Expression outer grp commons schemas params from (nullity arr)
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Maybe (Expression outer grp commons schemas params from (nullity 'PGbool))
+  -> Expression outer grp commons schemas params from (nullity 'PGjsonb)
 jsonbInsert tgt path val insertAfter = case insertAfter of
   Just i -> unsafeVariadicFunction "jsonb_insert" (tgt :* path :* val :* i :* Nil)
   Nothing -> unsafeVariadicFunction "jsonb_insert" (tgt :* path :* val :* Nil)
 
 -- | Returns its argument as indented JSON text.
 jsonbPretty
-  :: Expression grp commons schemas params from (nullity 'PGjsonb)
-  -> Expression grp commons schemas params from (nullity 'PGtext)
+  :: Expression outer grp commons schemas params from (nullity 'PGjsonb)
+  -> Expression outer grp commons schemas params from (nullity 'PGtext)
 jsonbPretty = unsafeFunction "jsonb_pretty"
 
 {-----------------------------------------
@@ -1447,7 +1448,7 @@ class Aggregate expr1 expr2 aggr
 
   -- | >>> :{
   -- let
-  --   expression :: Expression ('Grouped bys) commons schemas params '[tab ::: '["col" ::: 'Null 'PGnumeric]] ('Null 'PGnumeric)
+  --   expression :: Expression outer ('Grouped bys) commons schemas params '[tab ::: '["col" ::: 'Null 'PGnumeric]] ('Null 'PGnumeric)
   --   expression = sum_ (Distinct #col)
   -- in printSQL expression
   -- :}
@@ -1464,7 +1465,7 @@ class Aggregate expr1 expr2 aggr
 
   -- | >>> :{
   -- let
-  --   expression :: Expression ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGint4]] (nullity 'PGint4)
+  --   expression :: Expression outer ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGint4]] (nullity 'PGint4)
   --   expression = bitAnd (Distinct #col)
   -- in printSQL expression
   -- :}
@@ -1477,7 +1478,7 @@ class Aggregate expr1 expr2 aggr
 
   -- | >>> :{
   -- let
-  --   expression :: Expression ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGint4]] (nullity 'PGint4)
+  --   expression :: Expression outer ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGint4]] (nullity 'PGint4)
   --   expression = bitOr (All #col)
   -- in printSQL expression
   -- :}
@@ -1516,7 +1517,7 @@ class Aggregate expr1 expr2 aggr
   --
   -- >>> :{
   -- let
-  --   expression :: Expression ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGbool]] (nullity 'PGbool)
+  --   expression :: Expression outer ('Grouped bys) commons schemas params '[tab ::: '["col" ::: nullity 'PGbool]] (nullity 'PGbool)
   --   expression = every (Distinct #col)
   -- in printSQL expression
   -- :}
@@ -1700,16 +1701,16 @@ data Distinction expr ty
   = All (expr ty)
   | Distinct (expr ty)
   deriving (GHC.Generic,Show,Eq,Ord)
-instance NFData (Distinction (Expression grp commons schemas params from) ty)
-instance RenderSQL (Distinction (Expression grp commons schemas params from) ty) where
+instance NFData (Distinction (Expression outer grp commons schemas params from) ty)
+instance RenderSQL (Distinction (Expression outer grp commons schemas params from) ty) where
   renderSQL = \case
     All x -> "ALL" <+> renderSQL x
     Distinct x -> "DISTINCT" <+> renderSQL x
 instance RenderSQL
   (Distinction
-    ( Expression grp commons schemas params from
+    ( Expression outer grp commons schemas params from
       :*:
-      Expression grp commons schemas params from) xty ) where
+      Expression outer grp commons schemas params from) xty ) where
         renderSQL = \case
           All (x :*: x') ->
             "ALL" <+> renderSQL x <> ", " <> renderSQL x'
@@ -1717,9 +1718,9 @@ instance RenderSQL
             "DISTINCT" <+> renderSQL x <> ", " <> renderSQL x'
 
 instance Aggregate
-  (Distinction (Expression 'Ungrouped commons schemas params from))
-  (Distinction (Expression 'Ungrouped commons schemas params from :*: Expression 'Ungrouped commons schemas params from))
-  (Expression ('Grouped bys) commons schemas params from) where
+  (Distinction (Expression outer 'Ungrouped commons schemas params from))
+  (Distinction (Expression outer 'Ungrouped commons schemas params from :*: Expression outer 'Ungrouped commons schemas params from))
+  (Expression outer ('Grouped bys) commons schemas params from) where
     countStar = UnsafeExpression "count(*)"
     count = unsafeAggregate1 "count"
     sum_ = unsafeAggregate1 "sum"
@@ -1751,9 +1752,9 @@ instance Aggregate
     varPop = unsafeAggregate1 "var_pop"
     varSamp = unsafeAggregate1 "var_samp"
 instance Aggregate
-  (Expression grp commons schemas params from)
-  (Expression grp commons schemas params from :*: Expression grp commons schemas params from)
-  (WindowFunction grp commons schemas params from) where
+  (Expression outer grp commons schemas params from)
+  (Expression outer grp commons schemas params from :*: Expression outer grp commons schemas params from)
+  (WindowFunction outer grp commons schemas params from) where
     countStar = UnsafeWindowFunction "count(*)"
     count = unsafeWindowFunction1 "count"
     sum_ = unsafeWindowFunction1 "sum"
@@ -1788,16 +1789,16 @@ instance Aggregate
 -- | escape hatch to define aggregate functions
 unsafeAggregate1
   :: ByteString -- ^ aggregate function
-  -> Distinction (Expression 'Ungrouped commons schemas params from) xty
-  -> Expression ('Grouped bys) commons schemas params from yty
+  -> Distinction (Expression outer 'Ungrouped commons schemas params from) xty
+  -> Expression outer ('Grouped bys) commons schemas params from yty
 unsafeAggregate1 fun x = UnsafeExpression $ mconcat
   [fun, "(", renderSQL x, ")"]
 
 -- | escape hatch to define aggregate binary functions
 unsafeAggregate2
   :: ByteString -- ^ aggregate function
-  -> Distinction (Expression 'Ungrouped commons schemas params from :*: Expression 'Ungrouped commons schemas params from) xty
-  -> Expression ('Grouped bys) commons schemas params from yty
+  -> Distinction (Expression outer 'Ungrouped commons schemas params from :*: Expression outer 'Ungrouped commons schemas params from) xty
+  -> Expression outer ('Grouped bys) commons schemas params from yty
 unsafeAggregate2 fun xx = UnsafeExpression $ mconcat
   [fun, "(", renderSQL xx, ")"]
 
@@ -1993,35 +1994,35 @@ Sorting
 -- `AscNullsLast`, `DescNullsFirst` and `DescNullsLast` options are used to
 -- determine whether nulls appear before or after non-null values in the sort
 -- ordering of a `Null` result column.
-data SortExpression grp commons schemas params from where
+data SortExpression outer grp commons schemas params from where
     Asc
-      :: Expression grp commons schemas params from ('NotNull ty)
-      -> SortExpression grp commons schemas params from
+      :: Expression outer grp commons schemas params from ('NotNull ty)
+      -> SortExpression outer grp commons schemas params from
     Desc
-      :: Expression grp commons schemas params from ('NotNull ty)
-      -> SortExpression grp commons schemas params from
+      :: Expression outer grp commons schemas params from ('NotNull ty)
+      -> SortExpression outer grp commons schemas params from
     AscNullsFirst
-      :: Expression grp commons schemas params from  ('Null ty)
-      -> SortExpression grp commons schemas params from
+      :: Expression outer grp commons schemas params from  ('Null ty)
+      -> SortExpression outer grp commons schemas params from
     AscNullsLast
-      :: Expression grp commons schemas params from  ('Null ty)
-      -> SortExpression grp commons schemas params from
+      :: Expression outer grp commons schemas params from  ('Null ty)
+      -> SortExpression outer grp commons schemas params from
     DescNullsFirst
-      :: Expression grp commons schemas params from  ('Null ty)
-      -> SortExpression grp commons schemas params from
+      :: Expression outer grp commons schemas params from  ('Null ty)
+      -> SortExpression outer grp commons schemas params from
     DescNullsLast
-      :: Expression grp commons schemas params from  ('Null ty)
-      -> SortExpression grp commons schemas params from
-deriving instance Show (SortExpression grp commons schemas params from)
+      :: Expression outer grp commons schemas params from  ('Null ty)
+      -> SortExpression outer grp commons schemas params from
+deriving instance Show (SortExpression outer grp commons schemas params from)
 
 class OrderBy expr where
   orderBy
-    :: [SortExpression grp commons schemas params from]
-    -> expr grp commons schemas params from
-    -> expr grp commons schemas params from
+    :: [SortExpression outer grp commons schemas params from]
+    -> expr outer grp commons schemas params from
+    -> expr outer grp commons schemas params from
 
 -- | Render a `SortExpression`.
-instance RenderSQL (SortExpression grp commons schemas params from) where
+instance RenderSQL (SortExpression outer grp commons schemas params from) where
   renderSQL = \case
     Asc expression -> renderSQL expression <+> "ASC"
     Desc expression -> renderSQL expression <+> "DESC"
@@ -2032,18 +2033,18 @@ instance RenderSQL (SortExpression grp commons schemas params from) where
     AscNullsLast expression -> renderSQL expression <+> "ASC NULLS LAST"
     DescNullsLast expression -> renderSQL expression <+> "DESC NULLS LAST"
 
-data WindowDefinition grp commons schemas params from where
+data WindowDefinition outer grp commons schemas params from where
   WindowDefinition
     :: SListI bys
-    => NP (Expression grp commons schemas params from) bys
-    -> [SortExpression grp commons schemas params from]
-    -> WindowDefinition grp commons schemas params from
+    => NP (Expression outer grp commons schemas params from) bys
+    -> [SortExpression outer grp commons schemas params from]
+    -> WindowDefinition outer grp commons schemas params from
 
 instance OrderBy WindowDefinition where
   orderBy sortsR (WindowDefinition parts sortsL)
     = WindowDefinition parts (sortsL ++ sortsR)
 
-instance RenderSQL (WindowDefinition commons schemas from grp params) where
+instance RenderSQL (WindowDefinition outer commons schemas from grp params) where
   renderSQL (WindowDefinition part ord) =
     renderPartitionByClause part <> renderOrderByClause ord
     where
@@ -2057,11 +2058,12 @@ instance RenderSQL (WindowDefinition commons schemas from grp params) where
 
 partitionBy
   :: SListI bys
-  => NP (Expression grp commons schemas params from) bys
-  -> WindowDefinition grp commons schemas params from
+  => NP (Expression outer grp commons schemas params from) bys
+  -> WindowDefinition outer grp commons schemas params from
 partitionBy bys = WindowDefinition bys []
 
 newtype WindowFunction
+  (outer :: FromType)
   (grp :: Grouping)
   (commons :: FromType)
   (schemas :: SchemasType)
@@ -2071,20 +2073,20 @@ newtype WindowFunction
     = UnsafeWindowFunction { renderWindowFunction :: ByteString }
     deriving (GHC.Generic,Show,Eq,Ord,NFData)
 
-instance RenderSQL (WindowFunction grp commons schemas params from ty) where
+instance RenderSQL (WindowFunction outer grp commons schemas params from ty) where
   renderSQL = renderWindowFunction
 
 unsafeWindowFunction1
   :: ByteString
-  -> Expression grp commons schemas params from ty0
-  -> WindowFunction grp commons schemas params from ty1
+  -> Expression outer grp commons schemas params from ty0
+  -> WindowFunction outer grp commons schemas params from ty1
 unsafeWindowFunction1 fun x
   = UnsafeWindowFunction $ fun <> parenthesized (renderSQL x)
 
 unsafeWindowFunction2
   :: ByteString
-  -> (Expression grp commons schemas params from :*: Expression grp commons schemas params from) ty0
-  -> WindowFunction grp commons schemas params from ty1
+  -> (Expression outer grp commons schemas params from :*: Expression outer grp commons schemas params from) ty0
+  -> WindowFunction outer grp commons schemas params from ty1
 unsafeWindowFunction2 fun (x :*: x')
   = UnsafeWindowFunction $ fun <> parenthesized (renderSQL x <> ", " <> renderSQL x')
 
@@ -2092,28 +2094,28 @@ unsafeWindowFunction2 fun (x :*: x')
 >>> printSQL rank
 rank()
 -}
-rank :: WindowFunction grp commons schemas params from ('NotNull 'PGint8)
+rank :: WindowFunction outer grp commons schemas params from ('NotNull 'PGint8)
 rank = UnsafeWindowFunction "rank()"
 
 {- | number of the current row within its partition, counting from 1
 >>> printSQL rowNumber
 row_number()
 -}
-rowNumber :: WindowFunction grp commons schemas params from ('NotNull 'PGint8)
+rowNumber :: WindowFunction outer grp commons schemas params from ('NotNull 'PGint8)
 rowNumber = UnsafeWindowFunction "row_number()"
 
 {- | rank of the current row without gaps; this function counts peer groups
 >>> printSQL denseRank
 dense_rank()
 -}
-denseRank :: WindowFunction grp commons schemas params from ('NotNull 'PGint8)
+denseRank :: WindowFunction outer grp commons schemas params from ('NotNull 'PGint8)
 denseRank = UnsafeWindowFunction "dense_rank()"
 
 {- | relative rank of the current row: (rank - 1) / (total partition rows - 1)
 >>> printSQL percentRank
 percent_rank()
 -}
-percentRank :: WindowFunction grp commons schemas params from ('NotNull 'PGfloat8)
+percentRank :: WindowFunction outer grp commons schemas params from ('NotNull 'PGfloat8)
 percentRank = UnsafeWindowFunction "percent_rank()"
 
 {- | cumulative distribution: (number of partition rows
@@ -2121,16 +2123,16 @@ preceding or peer with current row) / total partition rows
 >>> printSQL cumeDist
 cume_dist()
 -}
-cumeDist :: WindowFunction grp commons schemas params from ('NotNull 'PGfloat8)
+cumeDist :: WindowFunction outer grp commons schemas params from ('NotNull 'PGfloat8)
 cumeDist = UnsafeWindowFunction "cume_dist()"
 
 {- | integer ranging from 1 to the argument value,
 dividing the partition as equally as possible
 -}
 ntile
-  :: Expression grp commons schemas params from ('NotNull 'PGint4)
+  :: Expression outer grp commons schemas params from ('NotNull 'PGint4)
   -- ^ num buckets
-  -> WindowFunction grp commons schemas params from ('NotNull 'PGint4)
+  -> WindowFunction outer grp commons schemas params from ('NotNull 'PGint4)
 ntile = unsafeWindowFunction1 "ntile"
 
 {- | returns value evaluated at the row that is offset rows before the current
@@ -2139,13 +2141,13 @@ row within the partition; if there is no such row, instead return default
 evaluated with respect to the current row.
 -}
 lag
-  :: Expression grp commons schemas params from ty
+  :: Expression outer grp commons schemas params from ty
   -- ^ value
-  -> Expression grp commons schemas params from ('NotNull 'PGint4)
+  -> Expression outer grp commons schemas params from ('NotNull 'PGint4)
   -- ^ offset
-  -> Expression grp commons schemas params from ty
+  -> Expression outer grp commons schemas params from ty
   -- ^ default
-  -> WindowFunction grp commons schemas params from ty
+  -> WindowFunction outer grp commons schemas params from ty
 lag value offset def = UnsafeWindowFunction $ "lag"
   <> parenthesized
   (commaSeparated ([renderSQL value, renderSQL offset, renderSQL def]))
@@ -2156,13 +2158,13 @@ row within the partition; if there is no such row, instead return default
 evaluated with respect to the current row.
 -}
 lead
-  :: Expression grp commons schemas params from ty
+  :: Expression outer grp commons schemas params from ty
   -- ^ value
-  -> Expression grp commons schemas params from ('NotNull 'PGint4)
+  -> Expression outer grp commons schemas params from ('NotNull 'PGint4)
   -- ^ offset
-  -> Expression grp commons schemas params from ty
+  -> Expression outer grp commons schemas params from ty
   -- ^ default
-  -> WindowFunction grp commons schemas params from ty
+  -> WindowFunction outer grp commons schemas params from ty
 lead value offset def = UnsafeWindowFunction $ "lag"
   <> parenthesized
   (commaSeparated ([renderSQL value, renderSQL offset, renderSQL def]))
@@ -2171,28 +2173,28 @@ lead value offset def = UnsafeWindowFunction $ "lag"
 first row of the window frame
 -}
 firstValue
-  :: Expression grp commons schemas params from ty
+  :: Expression outer grp commons schemas params from ty
   -- ^ value
-  -> WindowFunction grp commons schemas params from ty
+  -> WindowFunction outer grp commons schemas params from ty
 firstValue = unsafeWindowFunction1 "first_value"
 
 {- | returns value evaluated at the row that is the
 last row of the window frame
 -}
 lastValue
-  :: Expression grp commons schemas params from ty
+  :: Expression outer grp commons schemas params from ty
   -- ^ value
-  -> WindowFunction grp commons schemas params from ty
+  -> WindowFunction outer grp commons schemas params from ty
 lastValue = unsafeWindowFunction1 "last_value"
 
 {- | returns value evaluated at the row that is the nth
 row of the window frame (counting from 1); null if no such row
 -}
 nthValue
-  :: Expression grp commons schemas params from (nullity ty)
+  :: Expression outer grp commons schemas params from (nullity ty)
   -- ^ value
-  -> Expression grp commons schemas params from ('NotNull 'PGint4)
+  -> Expression outer grp commons schemas params from ('NotNull 'PGint4)
   -- ^ nth
-  -> WindowFunction grp commons schemas params from ('Null ty)
+  -> WindowFunction outer grp commons schemas params from ('Null ty)
 nthValue value nth = UnsafeWindowFunction $ "nth_value"
   <> parenthesized (commaSeparated [renderSQL value, renderSQL nth])

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
@@ -173,9 +173,10 @@ type Schema3 =
 let
   manipulation :: Manipulation '[] (Public Schema3) '[] '[]
   manipulation =
-    deleteFrom_ #tab (Using (table #other_tab & also (table #third_tab)))
+    deleteFrom #tab (Using (table #other_tab & also (table #third_tab)))
     ( (#tab ! #col2 .== #other_tab ! #col2)
     .&& (#tab ! #col2 .== #third_tab ! #col2) )
+    (Returning_ Nil)
 in printSQL manipulation
 :}
 DELETE FROM "tab" USING "other_tab" AS "other_tab", "third_tab" AS "third_tab" WHERE (("tab"."col2" = "other_tab"."col2") AND ("tab"."col2" = "third_tab"."col2"))

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -289,7 +289,7 @@ deleteMigration = deleteFrom_ (#migrations ! #schema_migrations) (#name .== para
 -- the time at which it was executed.
 selectMigration
   :: Has "migrations" schemas MigrationsSchema
-  => Query '[] schemas '[ 'NotNull 'PGtext ]
+  => Query '[] '[] schemas '[ 'NotNull 'PGtext ]
     '[ "executed_at" ::: 'NotNull 'PGtimestamptz ]
 selectMigration = select_
   (#executed_at `as` #executed_at)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
@@ -333,13 +333,13 @@ class Monad pq => MonadPQ schemas pq | pq -> schemas where
 
   runQueryParams
     :: ToParams x params
-    => Query '[] schemas params ys
+    => Query '[] '[] schemas params ys
     -- ^ `select` and friends
     -> x -> pq (K LibPQ.Result ys)
   runQueryParams = manipulateParams . queryStatement
 
   runQuery
-    :: Query '[] schemas '[] ys
+    :: Query '[] '[] schemas '[] ys
     -- ^ `select` and friends
     -> pq (K LibPQ.Result ys)
   runQuery q = runQueryParams q ()

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -281,7 +281,7 @@ value queries:
 
 >>> :{
 let
-  query :: Query commons schemas '[] '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+  query :: Query outer commons schemas '[] '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
   query = values (1 `as` #foo :* true `as` #bar) [2 `as` #foo :* false `as` #bar]
 in printSQL query
 :}
@@ -323,23 +323,24 @@ in printSQL query
 SELECT "col1" AS "col1", rank() OVER (PARTITION BY "col1" ORDER BY "col2" ASC) AS "rank" FROM "tab" AS "tab"
 -}
 newtype Query
+  (outer :: FromType)
   (commons :: FromType)
   (schemas :: SchemasType)
   (params :: [NullityType])
   (row :: RowType)
     = UnsafeQuery { renderQuery :: ByteString }
     deriving (GHC.Generic,Show,Eq,Ord,NFData)
-instance RenderSQL (Query commons schemas params row) where renderSQL = renderQuery
+instance RenderSQL (Query outer commons schemas params row) where renderSQL = renderQuery
 
 type family Query_ (schemas :: SchemasType) (params :: Type) (row :: Type) where
-  Query_ schemas params row = Query '[] schemas (TuplePG params) (RowPG row)
+  Query_ schemas params row = Query '[] '[] schemas (TuplePG params) (RowPG row)
 
 -- | The results of two queries can be combined using the set operation
 -- `union`. Duplicate rows are eliminated.
 union
-  :: Query commons schemas params columns
-  -> Query commons schemas params columns
-  -> Query commons schemas params columns
+  :: Query outer commons schemas params columns
+  -> Query outer commons schemas params columns
+  -> Query outer commons schemas params columns
 q1 `union` q2 = UnsafeQuery $
   parenthesized (renderSQL q1)
   <+> "UNION"
@@ -348,9 +349,9 @@ q1 `union` q2 = UnsafeQuery $
 -- | The results of two queries can be combined using the set operation
 -- `unionAll`, the disjoint union. Duplicate rows are retained.
 unionAll
-  :: Query commons schemas params columns
-  -> Query commons schemas params columns
-  -> Query commons schemas params columns
+  :: Query outer commons schemas params columns
+  -> Query outer commons schemas params columns
+  -> Query outer commons schemas params columns
 q1 `unionAll` q2 = UnsafeQuery $
   parenthesized (renderSQL q1)
   <+> "UNION" <+> "ALL"
@@ -359,9 +360,9 @@ q1 `unionAll` q2 = UnsafeQuery $
 -- | The results of two queries can be combined using the set operation
 -- `intersect`, the intersection. Duplicate rows are eliminated.
 intersect
-  :: Query commons schemas params columns
-  -> Query commons schemas params columns
-  -> Query commons schemas params columns
+  :: Query outer commons schemas params columns
+  -> Query outer commons schemas params columns
+  -> Query outer commons schemas params columns
 q1 `intersect` q2 = UnsafeQuery $
   parenthesized (renderSQL q1)
   <+> "INTERSECT"
@@ -370,9 +371,9 @@ q1 `intersect` q2 = UnsafeQuery $
 -- | The results of two queries can be combined using the set operation
 -- `intersectAll`, the intersection. Duplicate rows are retained.
 intersectAll
-  :: Query commons schemas params columns
-  -> Query commons schemas params columns
-  -> Query commons schemas params columns
+  :: Query outer commons schemas params columns
+  -> Query outer commons schemas params columns
+  -> Query outer commons schemas params columns
 q1 `intersectAll` q2 = UnsafeQuery $
   parenthesized (renderSQL q1)
   <+> "INTERSECT" <+> "ALL"
@@ -381,9 +382,9 @@ q1 `intersectAll` q2 = UnsafeQuery $
 -- | The results of two queries can be combined using the set operation
 -- `except`, the set difference. Duplicate rows are eliminated.
 except
-  :: Query commons schemas params columns
-  -> Query commons schemas params columns
-  -> Query commons schemas params columns
+  :: Query outer commons schemas params columns
+  -> Query outer commons schemas params columns
+  -> Query outer commons schemas params columns
 q1 `except` q2 = UnsafeQuery $
   parenthesized (renderSQL q1)
   <+> "EXCEPT"
@@ -392,9 +393,9 @@ q1 `except` q2 = UnsafeQuery $
 -- | The results of two queries can be combined using the set operation
 -- `exceptAll`, the set difference. Duplicate rows are retained.
 exceptAll
-  :: Query commons schemas params columns
-  -> Query commons schemas params columns
-  -> Query commons schemas params columns
+  :: Query outer commons schemas params columns
+  -> Query outer commons schemas params columns
+  -> Query outer commons schemas params columns
 q1 `exceptAll` q2 = UnsafeQuery $
   parenthesized (renderSQL q1)
   <+> "EXCEPT" <+> "ALL"
@@ -404,54 +405,58 @@ q1 `exceptAll` q2 = UnsafeQuery $
 SELECT queries
 -----------------------------------------}
 
-data Selection grp commons schemas params from row where
+data Selection outer grp commons schemas params from row where
   List
     :: SListI row
-    => NP (Aliased (Expression grp commons schemas params from)) row
-    -> Selection grp commons schemas params from row
+    => NP (Aliased (Expression outer grp commons schemas params from)) row
+    -> Selection outer grp commons schemas params from row
   Star
     :: HasUnique tab from row
-    => Selection 'Ungrouped commons schemas params from row
+    => Selection outer 'Ungrouped commons schemas params from row
   DotStar
     :: Has tab from row
     => Alias tab
-    -> Selection 'Ungrouped commons schemas params from row
+    -> Selection outer 'Ungrouped commons schemas params from row
   Also
-    :: Selection grp commons schemas params from right
-    -> Selection grp commons schemas params from left
-    -> Selection grp commons schemas params from (Join left right)
+    :: Selection outer grp commons schemas params from right
+    -> Selection outer grp commons schemas params from left
+    -> Selection outer grp commons schemas params from (Join left right)
   Over
     :: SListI row
-    => NP (Aliased (WindowFunction grp commons schemas params from)) row
-    -> WindowDefinition grp commons schemas params from
-    -> Selection grp commons schemas params from row
+    => NP (Aliased (WindowFunction outer grp commons schemas params from)) row
+    -> WindowDefinition outer grp commons schemas params from
+    -> Selection outer grp commons schemas params from row
 instance (KnownSymbol col, row ~ '[col ::: ty])
   => Aliasable col
-    (Expression grp commons schemas params from ty)
-    (Selection grp commons schemas params from row) where
+    (Expression outer grp commons schemas params from ty)
+    (Selection outer grp commons schemas params from row) where
       expr `as` col = List (expr `as` col)
-instance (Has tab from row0, Has col row0 ty, row1 ~ '[col ::: ty])
-  => IsQualified tab col (Selection 'Ungrouped commons schemas params from row1) where
-    tab ! col = tab ! col `as` col
+instance (Has tab (Join outer from) row0, Has col row0 ty, row1 ~ '[col ::: ty])
+  => IsQualified tab col
+    (Selection outer 'Ungrouped commons schemas params from row1) where
+      tab ! col = tab ! col `as` col
 instance
-  ( Has tab from row0
+  ( Has tab (Join outer from) row0
   , Has col row0 ty
   , row1 ~ '[col ::: ty]
   , GroupedBy tab col bys )
-  => IsQualified tab col (Selection ('Grouped bys) commons schemas params from row1) where
-    tab ! col = tab ! col `as` col
-instance (HasUnique tab from row0, Has col row0 ty, row1 ~ '[col ::: ty])
-  => IsLabel col (Selection 'Ungrouped commons schemas params from row1) where
-    fromLabel = fromLabel @col `as` Alias
+  => IsQualified tab col
+    (Selection outer ('Grouped bys) commons schemas params from row1) where
+      tab ! col = tab ! col `as` col
+instance (HasUnique tab (Join outer from) row0, Has col row0 ty, row1 ~ '[col ::: ty])
+  => IsLabel col
+    (Selection outer 'Ungrouped commons schemas params from row1) where
+      fromLabel = fromLabel @col `as` Alias
 instance
-  ( HasUnique tab from row0
+  ( HasUnique tab (Join outer from) row0
   , Has col row0 ty
   , row1 ~ '[col ::: ty]
   , GroupedBy tab col bys )
-  => IsLabel col (Selection ('Grouped bys) commons schemas params from row1) where
-    fromLabel = fromLabel @col `as` Alias
+  => IsLabel col
+    (Selection outer ('Grouped bys) commons schemas params from row1) where
+      fromLabel = fromLabel @col `as` Alias
 
-instance RenderSQL (Selection grp commons schemas params from row) where
+instance RenderSQL (Selection outer grp commons schemas params from row) where
   renderSQL = \case
     List list -> renderCommaSeparated (renderAliased renderSQL) list
     Star -> "*"
@@ -460,7 +465,7 @@ instance RenderSQL (Selection grp commons schemas params from row) where
     Over winFns winDef ->
       let
         renderOver
-          :: Aliased (WindowFunction grp commons schemas params from) field
+          :: Aliased (WindowFunction outer grp commons schemas params from) field
           -> ByteString
         renderOver (winFn `As` col) = renderSQL winFn
           <+> "OVER" <+> parenthesized (renderSQL winDef)
@@ -475,11 +480,11 @@ instance RenderSQL (Selection grp commons schemas params from row) where
 -- the intermediate table are actually output.
 select
   :: (SListI row, row ~ (x ': xs))
-  => Selection grp commons schemas params from row
+  => Selection outer grp commons schemas params from row
   -- ^ select list
-  -> TableExpression grp commons schemas params from
+  -> TableExpression outer grp commons schemas params from
   -- ^ intermediate virtual table
-  -> Query commons schemas params row
+  -> Query outer commons schemas params row
 select selection tabexpr = UnsafeQuery $
   "SELECT"
   <+> renderSQL selection
@@ -487,20 +492,20 @@ select selection tabexpr = UnsafeQuery $
 
 select_
   :: (SListI row, row ~ (x ': xs))
-  => NP (Aliased (Expression grp commons schemas params from)) row
-  -> TableExpression grp commons schemas params from
-  -> Query commons schemas params row
+  => NP (Aliased (Expression outer grp commons schemas params from)) row
+  -> TableExpression outer grp commons schemas params from
+  -> Query outer commons schemas params row
 select_ list = select (List list)
 
 -- | After the select list has been processed, the result table can
 -- be subject to the elimination of duplicate rows using `selectDistinct`.
 selectDistinct
   :: (SListI columns, columns ~ (col ': cols))
-  => Selection 'Ungrouped commons schemas params from columns
+  => Selection outer 'Ungrouped commons schemas params from columns
   -- ^ select list
-  -> TableExpression 'Ungrouped commons schemas params from
+  -> TableExpression outer 'Ungrouped commons schemas params from
   -- ^ intermediate virtual table
-  -> Query commons schemas params columns
+  -> Query outer commons schemas params columns
 selectDistinct selection tabexpr = UnsafeQuery $
   "SELECT DISTINCT"
   <+> renderSQL selection
@@ -508,11 +513,11 @@ selectDistinct selection tabexpr = UnsafeQuery $
 
 selectDistinct_
   :: (SListI columns, columns ~ (col ': cols))
-  => NP (Aliased (Expression 'Ungrouped commons schemas params from)) columns
+  => NP (Aliased (Expression outer 'Ungrouped commons schemas params from)) columns
   -- ^ select list
-  -> TableExpression 'Ungrouped commons schemas params from
+  -> TableExpression outer 'Ungrouped commons schemas params from
   -- ^ intermediate virtual table
-  -> Query commons schemas params columns
+  -> Query outer commons schemas params columns
 selectDistinct_ list = select (List list)
 
 -- | `values` computes a row value or set of row values
@@ -521,16 +526,16 @@ selectDistinct_ list = select (List list)
 -- but it can be used on its own.
 --
 -- >>> type Row = '["a" ::: 'NotNull 'PGint4, "b" ::: 'NotNull 'PGtext]
--- >>> let query = values (1 `as` #a :* "one" `as` #b) [] :: Query commons schemas '[] Row
+-- >>> let query = values (1 `as` #a :* "one" `as` #b) [] :: Query outer commons schemas '[] Row
 -- >>> printSQL query
 -- SELECT * FROM (VALUES (1, E'one')) AS t ("a", "b")
 values
   :: SListI cols
-  => NP (Aliased (Expression 'Ungrouped commons schemas params '[] )) cols
-  -> [NP (Aliased (Expression 'Ungrouped commons schemas params '[] )) cols]
+  => NP (Aliased (Expression outer 'Ungrouped commons schemas params '[] )) cols
+  -> [NP (Aliased (Expression outer 'Ungrouped commons schemas params '[] )) cols]
   -- ^ When more than one row is specified, all the rows must
   -- must have the same number of elements
-  -> Query commons schemas params cols
+  -> Query outer commons schemas params cols
 values rw rws = UnsafeQuery $ "SELECT * FROM"
   <+> parenthesized (
     "VALUES"
@@ -541,7 +546,7 @@ values rw rws = UnsafeQuery $ "SELECT * FROM"
   <+> parenthesized (renderCommaSeparated renderAliasPart rw)
   where
     renderAliasPart, renderValuePart
-      :: Aliased (Expression 'Ungrouped commons schemas params '[] ) ty -> ByteString
+      :: Aliased (Expression outer 'Ungrouped commons schemas params '[] ) ty -> ByteString
     renderAliasPart (_ `As` name) = renderSQL name
     renderValuePart (value `As` _) = renderSQL value
 
@@ -549,9 +554,9 @@ values rw rws = UnsafeQuery $ "SELECT * FROM"
 -- specified by value expressions.
 values_
   :: SListI cols
-  => NP (Aliased (Expression 'Ungrouped commons schemas params '[] )) cols
+  => NP (Aliased (Expression outer 'Ungrouped commons schemas params '[] )) cols
   -- ^ one row of values
-  -> Query commons schemas params cols
+  -> Query outer commons schemas params cols
 values_ rw = values rw []
 
 {-----------------------------------------
@@ -565,16 +570,17 @@ Table Expressions
 -- to a table on disk, a so-called base table, but more complex expressions
 -- can be used to modify or combine base tables in various ways.
 data TableExpression
+  (outer :: FromType)
   (grp :: Grouping)
   (commons :: FromType)
   (schemas :: SchemasType)
   (params :: [NullityType])
   (from :: FromType)
     = TableExpression
-    { fromClause :: FromClause commons schemas params from
+    { fromClause :: FromClause outer commons schemas params from
     -- ^ A table reference that can be a table name, or a derived table such
     -- as a subquery, a @JOIN@ construct, or complex combinations of these.
-    , whereClause :: [Condition 'Ungrouped commons schemas params from]
+    , whereClause :: [Condition outer 'Ungrouped commons schemas params from]
     -- ^ optional search coditions, combined with `.&&`. After the processing
     -- of the `fromClause` is done, each row of the derived virtual table
     -- is checked against the search condition. If the result of the
@@ -590,13 +596,13 @@ data TableExpression
     -- set of rows having common values into one group row that represents all
     -- rows in the group. This is done to eliminate redundancy in the output
     -- and/or compute aggregates that apply to these groups.
-    , havingClause :: HavingClause grp commons schemas params from
+    , havingClause :: HavingClause outer grp commons schemas params from
     -- ^ If a table has been grouped using `groupBy`, but only certain groups
     -- are of interest, the `havingClause` can be used, much like a
     -- `whereClause`, to eliminate groups from the result. Expressions in the
     -- `havingClause` can refer both to grouped expressions and to ungrouped
     -- expressions (which necessarily involve an aggregate function).
-    , orderByClause :: [SortExpression grp commons schemas params from]
+    , orderByClause :: [SortExpression outer grp commons schemas params from]
     -- ^ The `orderByClause` is for optional sorting. When more than one
     -- `SortExpression` is specified, the later (right) values are used to sort
     -- rows that are equal according to the earlier (left) values.
@@ -613,7 +619,7 @@ data TableExpression
     }
 
 -- | Render a `TableExpression`
-instance RenderSQL (TableExpression grp commons schemas params from) where
+instance RenderSQL (TableExpression outer grp commons schemas params from) where
   renderSQL
     (TableExpression frm' whs' grps' hvs' srts' lims' offs') = mconcat
       [ "FROM ", renderSQL frm'
@@ -622,8 +628,7 @@ instance RenderSQL (TableExpression grp commons schemas params from) where
       , renderSQL hvs'
       , renderOrderByClause srts'
       , renderLimits lims'
-      , renderOffsets offs'
-      ]
+      , renderOffsets offs' ]
       where
         renderWheres = \case
           [] -> ""
@@ -646,16 +651,16 @@ instance RenderSQL (TableExpression grp commons schemas params from) where
 -- `group`, `having`, `orderBy`, `limit` and `offset`, using the `&` operator
 -- to match the left-to-right sequencing of their placement in SQL.
 from
-  :: FromClause commons schemas params from -- ^ table reference
-  -> TableExpression 'Ungrouped commons schemas params from
-from rels = TableExpression rels [] NoGroups NoHaving [] [] []
+  :: FromClause outer commons schemas params from -- ^ table reference
+  -> TableExpression outer 'Ungrouped commons schemas params from
+from tab = TableExpression tab [] NoGroups NoHaving [] [] []
 
 -- | A `where_` is an endomorphism of `TableExpression`s which adds a
 -- search condition to the `whereClause`.
 where_
-  :: Condition 'Ungrouped commons schemas params from -- ^ filtering condition
-  -> TableExpression grp commons schemas params from
-  -> TableExpression grp commons schemas params from
+  :: Condition outer 'Ungrouped commons schemas params from -- ^ filtering condition
+  -> TableExpression outer grp commons schemas params from
+  -> TableExpression outer grp commons schemas params from
 where_ wh rels = rels {whereClause = wh : whereClause rels}
 
 -- | A `groupBy` is a transformation of `TableExpression`s which switches
@@ -664,8 +669,8 @@ where_ wh rels = rels {whereClause = wh : whereClause rels}
 groupBy
   :: SListI bys
   => NP (By from) bys -- ^ grouped columns
-  -> TableExpression 'Ungrouped commons schemas params from
-  -> TableExpression ('Grouped bys) commons schemas params from
+  -> TableExpression outer 'Ungrouped commons schemas params from
+  -> TableExpression outer ('Grouped bys) commons schemas params from
 groupBy bys rels = TableExpression
   { fromClause = fromClause rels
   , whereClause = whereClause rels
@@ -679,9 +684,9 @@ groupBy bys rels = TableExpression
 -- | A `having` is an endomorphism of `TableExpression`s which adds a
 -- search condition to the `havingClause`.
 having
-  :: Condition ('Grouped bys) commons schemas params from -- ^ having condition
-  -> TableExpression ('Grouped bys) commons schemas params from
-  -> TableExpression ('Grouped bys) commons schemas params from
+  :: Condition outer ('Grouped bys) commons schemas params from -- ^ having condition
+  -> TableExpression outer ('Grouped bys) commons schemas params from
+  -> TableExpression outer ('Grouped bys) commons schemas params from
 having hv rels = rels
   { havingClause = case havingClause rels of Having hvs -> Having (hv:hvs) }
 
@@ -692,16 +697,16 @@ instance OrderBy TableExpression where
 -- `limitClause`.
 limit
   :: Word64 -- ^ limit parameter
-  -> TableExpression grp commons schemas params from
-  -> TableExpression grp commons schemas params from
+  -> TableExpression outer grp commons schemas params from
+  -> TableExpression outer grp commons schemas params from
 limit lim rels = rels {limitClause = lim : limitClause rels}
 
 -- | An `offset` is an endomorphism of `TableExpression`s which adds to the
 -- `offsetClause`.
 offset
   :: Word64 -- ^ offset parameter
-  -> TableExpression grp commons schemas params from
-  -> TableExpression grp commons schemas params from
+  -> TableExpression outer grp commons schemas params from
+  -> TableExpression outer grp commons schemas params from
 offset off rels = rels {offsetClause = off : offsetClause rels}
 
 {-----------------------------------------
@@ -710,56 +715,56 @@ JSON stuff
 
 unsafeSetOfFunction
   :: ByteString
-  -> Expression 'Ungrouped commons schemas params '[]  ty
-  -> Query commons schemas params row
+  -> Expression outer 'Ungrouped commons schemas params '[]  ty
+  -> Query outer commons schemas params row
 unsafeSetOfFunction fun expr = UnsafeQuery $
   "SELECT * FROM " <> fun <> "(" <> renderSQL expr <> ")"
 
 -- | Expands the outermost JSON object into a set of key/value pairs.
 jsonEach
-  :: Expression 'Ungrouped commons schemas params '[]  (nullity 'PGjson) -- ^ json object
-  -> Query commons schemas params
+  :: Expression outer 'Ungrouped commons schemas params '[]  (nullity 'PGjson) -- ^ json object
+  -> Query outer commons schemas params
       '["key" ::: 'NotNull 'PGtext, "value" ::: 'NotNull 'PGjson]
 jsonEach = unsafeSetOfFunction "json_each"
 
 -- | Expands the outermost binary JSON object into a set of key/value pairs.
 jsonbEach
-  :: Expression 'Ungrouped commons schemas params '[]  (nullity 'PGjsonb) -- ^ jsonb object
-  -> Query commons schemas params
+  :: Expression outer 'Ungrouped commons schemas params '[]  (nullity 'PGjsonb) -- ^ jsonb object
+  -> Query outer commons schemas params
       '["key" ::: 'NotNull 'PGtext, "value" ::: 'NotNull 'PGjsonb]
 jsonbEach = unsafeSetOfFunction "jsonb_each"
 
 -- | Expands the outermost JSON object into a set of key/value pairs.
 jsonEachAsText
-  :: Expression 'Ungrouped commons schemas params '[]  (nullity 'PGjson) -- ^ json object
-  -> Query commons schemas params
+  :: Expression outer 'Ungrouped commons schemas params '[]  (nullity 'PGjson) -- ^ json object
+  -> Query outer commons schemas params
       '["key" ::: 'NotNull 'PGtext, "value" ::: 'NotNull 'PGtext]
 jsonEachAsText = unsafeSetOfFunction "json_each_text"
 
 -- | Expands the outermost binary JSON object into a set of key/value pairs.
 jsonbEachAsText
-  :: Expression 'Ungrouped commons schemas params '[]  (nullity 'PGjsonb) -- ^ jsonb object
-  -> Query commons schemas params
+  :: Expression outer 'Ungrouped commons schemas params '[]  (nullity 'PGjsonb) -- ^ jsonb object
+  -> Query outer commons schemas params
     '["key" ::: 'NotNull 'PGtext, "value" ::: 'NotNull 'PGtext]
 jsonbEachAsText = unsafeSetOfFunction "jsonb_each_text"
 
 -- | Returns set of keys in the outermost JSON object.
 jsonObjectKeys
-  :: Expression 'Ungrouped commons schemas params '[]  (nullity 'PGjson) -- ^ json object
-  -> Query commons schemas params '["json_object_keys" ::: 'NotNull 'PGtext]
+  :: Expression outer 'Ungrouped commons schemas params '[]  (nullity 'PGjson) -- ^ json object
+  -> Query outer commons schemas params '["json_object_keys" ::: 'NotNull 'PGtext]
 jsonObjectKeys = unsafeSetOfFunction "json_object_keys"
 
 -- | Returns set of keys in the outermost JSON object.
 jsonbObjectKeys
-  :: Expression 'Ungrouped commons schemas params '[]  (nullity 'PGjsonb) -- ^ jsonb object
-  -> Query commons schemas params '["jsonb_object_keys" ::: 'NotNull 'PGtext]
+  :: Expression outer 'Ungrouped commons schemas params '[]  (nullity 'PGjsonb) -- ^ jsonb object
+  -> Query outer commons schemas params '["jsonb_object_keys" ::: 'NotNull 'PGtext]
 jsonbObjectKeys = unsafeSetOfFunction "jsonb_object_keys"
 
 unsafePopulateFunction
   :: ByteString
   -> TypeExpression schemas (nullity ('PGcomposite row))
-  -> Expression 'Ungrouped commons schemas params '[]  ty
-  -> Query commons schemas params row
+  -> Expression outer 'Ungrouped commons schemas params '[]  ty
+  -> Query outer commons schemas params row
 unsafePopulateFunction fun ty expr = UnsafeQuery $
   "SELECT * FROM " <> fun <> "("
     <> "null::" <> renderSQL ty <> ", "
@@ -769,24 +774,24 @@ unsafePopulateFunction fun ty expr = UnsafeQuery $
 -- type defined by the given table.
 jsonPopulateRecord
   :: TypeExpression schemas (nullity ('PGcomposite row)) -- ^ row type
-  -> Expression 'Ungrouped commons schemas params '[]  (nullity 'PGjson) -- ^ json object
-  -> Query commons schemas params row
+  -> Expression outer 'Ungrouped commons schemas params '[]  (nullity 'PGjson) -- ^ json object
+  -> Query outer commons schemas params row
 jsonPopulateRecord = unsafePopulateFunction "json_populate_record"
 
 -- | Expands the binary JSON expression to a row whose columns match the record
 -- type defined by the given table.
 jsonbPopulateRecord
   :: TypeExpression schemas (nullity ('PGcomposite row)) -- ^ row type
-  -> Expression 'Ungrouped commons schemas params '[]  (nullity 'PGjsonb) -- ^ jsonb object
-  -> Query commons schemas params row
+  -> Expression outer 'Ungrouped commons schemas params '[]  (nullity 'PGjsonb) -- ^ jsonb object
+  -> Query outer commons schemas params row
 jsonbPopulateRecord = unsafePopulateFunction "jsonb_populate_record"
 
 -- | Expands the outermost array of objects in the given JSON expression to a
 -- set of rows whose columns match the record type defined by the given table.
 jsonPopulateRecordSet
   :: TypeExpression schemas (nullity ('PGcomposite row)) -- ^ row type
-  -> Expression 'Ungrouped commons schemas params '[]  (nullity 'PGjson) -- ^ json array
-  -> Query commons schemas params row
+  -> Expression outer 'Ungrouped commons schemas params '[]  (nullity 'PGjson) -- ^ json array
+  -> Query outer commons schemas params row
 jsonPopulateRecordSet = unsafePopulateFunction "json_populate_record_set"
 
 -- | Expands the outermost array of objects in the given binary JSON expression
@@ -794,16 +799,16 @@ jsonPopulateRecordSet = unsafePopulateFunction "json_populate_record_set"
 -- table.
 jsonbPopulateRecordSet
   :: TypeExpression schemas (nullity ('PGcomposite row)) -- ^ row type
-  -> Expression 'Ungrouped commons schemas params '[]  (nullity 'PGjsonb) -- ^ jsonb array
-  -> Query commons schemas params row
+  -> Expression outer 'Ungrouped commons schemas params '[]  (nullity 'PGjsonb) -- ^ jsonb array
+  -> Query outer commons schemas params row
 jsonbPopulateRecordSet = unsafePopulateFunction "jsonb_populate_record_set"
 
 unsafeRecordFunction
   :: (SListI record, json `In` PGJsonType)
   => ByteString
-  -> Expression 'Ungrouped commons schemas params '[]  (nullity json)
+  -> Expression outer 'Ungrouped commons schemas params '[]  (nullity json)
   -> NP (Aliased (TypeExpression schemas)) record
-  -> Query commons schemas params record
+  -> Query outer commons schemas params record
 unsafeRecordFunction fun expr types = UnsafeQuery $
   "SELECT * FROM " <> fun <> "("
     <> renderSQL expr <> ")"
@@ -816,33 +821,33 @@ unsafeRecordFunction fun expr types = UnsafeQuery $
 -- | Builds an arbitrary record from a JSON object.
 jsonToRecord
   :: SListI record
-  => Expression 'Ungrouped commons schemas params '[]  (nullity 'PGjson) -- ^ json object
+  => Expression outer 'Ungrouped commons schemas params '[]  (nullity 'PGjson) -- ^ json object
   -> NP (Aliased (TypeExpression schemas)) record -- ^ record types
-  -> Query commons schemas params record
+  -> Query outer commons schemas params record
 jsonToRecord = unsafeRecordFunction "json_to_record"
 
 -- | Builds an arbitrary record from a binary JSON object.
 jsonbToRecord
   :: SListI record
-  => Expression 'Ungrouped commons schemas params '[]  (nullity 'PGjsonb) -- ^ jsonb object
+  => Expression outer 'Ungrouped commons schemas params '[]  (nullity 'PGjsonb) -- ^ jsonb object
   -> NP (Aliased (TypeExpression schemas)) record -- ^ record types
-  -> Query commons schemas params record
+  -> Query outer commons schemas params record
 jsonbToRecord = unsafeRecordFunction "jsonb_to_record"
 
 -- | Builds an arbitrary set of records from a JSON array of objects.
 jsonToRecordSet
   :: SListI record
-  => Expression 'Ungrouped commons schemas params '[]  (nullity 'PGjson) -- ^ json array
+  => Expression outer 'Ungrouped commons schemas params '[]  (nullity 'PGjson) -- ^ json array
   -> NP (Aliased (TypeExpression schemas)) record -- ^ record types
-  -> Query commons schemas params record
+  -> Query outer commons schemas params record
 jsonToRecordSet = unsafeRecordFunction "json_to_record_set"
 
 -- | Builds an arbitrary set of records from a binary JSON array of objects.
 jsonbToRecordSet
   :: SListI record
-  => Expression 'Ungrouped commons schemas params '[]  (nullity 'PGjsonb) -- ^ jsonb array
+  => Expression outer 'Ungrouped commons schemas params '[]  (nullity 'PGjsonb) -- ^ jsonb array
   -> NP (Aliased (TypeExpression schemas)) record -- ^ record types
-  -> Query commons schemas params record
+  -> Query outer commons schemas params record
 jsonbToRecordSet = unsafeRecordFunction "jsonb_to_record_set"
 
 {-----------------------------------------
@@ -853,38 +858,38 @@ FROM clauses
 A `FromClause` can be a table name, or a derived table such
 as a subquery, a @JOIN@ construct, or complex combinations of these.
 -}
-newtype FromClause commons schemas params from
+newtype FromClause outer commons schemas params from
   = UnsafeFromClause { renderFromClause :: ByteString }
   deriving (GHC.Generic,Show,Eq,Ord,NFData)
-instance RenderSQL (FromClause commons schemas params from) where
+instance RenderSQL (FromClause outer commons schemas params from) where
   renderSQL = renderFromClause
 
 -- | A real `table` is a table from the database.
 table
   :: (Has sch schemas schema, Has tab schema ('Table table))
   => Aliased (QualifiedAlias sch) (alias ::: tab)
-  -> FromClause commons schemas params '[alias ::: TableToRow table]
+  -> FromClause outer commons schemas params '[alias ::: TableToRow table]
 table (tab `As` alias) = UnsafeFromClause $
   renderSQL tab <+> "AS" <+> renderSQL alias
 
 -- | `subquery` derives a table from a `Query`.
 subquery
-  :: Aliased (Query commons schemas params) query
-  -> FromClause commons schemas params '[query]
+  :: Aliased (Query outer commons schemas params) query
+  -> FromClause outer commons schemas params '[query]
 subquery = UnsafeFromClause . renderAliased (parenthesized . renderQuery)
 
 -- | `view` derives a table from a `View`.
 view
   :: (Has sch schemas schema, Has vw schema ('View view))
   => Aliased (QualifiedAlias sch) (alias ::: vw)
-  -> FromClause commons schemas params '[alias ::: view]
+  -> FromClause outer commons schemas params '[alias ::: view]
 view (vw `As` alias) = UnsafeFromClause $
   renderSQL vw <+> "AS" <+> renderSQL alias
 
 common
   :: Has cte commons common
   => Aliased Alias (alias ::: cte)
-  -> FromClause commons schemas params '[alias ::: common]
+  -> FromClause outer commons schemas params '[alias ::: common]
 common (cte `As` alias) = UnsafeFromClause $
   renderSQL cte <+> "AS" <+> renderSQL alias
 
@@ -895,11 +900,11 @@ common (cte `As` alias) = UnsafeFromClause $
     have @n * m@ rows.
 -}
 crossJoin
-  :: FromClause commons schemas params right
+  :: FromClause outer commons schemas params right
   -- ^ right
-  -> FromClause commons schemas params left
+  -> FromClause outer commons schemas params left
   -- ^ left
-  -> FromClause commons schemas params (Join left right)
+  -> FromClause outer commons schemas params (Join left right)
 crossJoin right left = UnsafeFromClause $
   renderSQL left <+> "CROSS JOIN" <+> renderSQL right
 
@@ -907,13 +912,13 @@ crossJoin right left = UnsafeFromClause $
 the @on@ condition.
 -}
 innerJoin
-  :: FromClause commons schemas params right
+  :: FromClause outer commons schemas params right
   -- ^ right
-  -> Condition 'Ungrouped commons schemas params (Join left right)
+  -> Condition outer 'Ungrouped commons schemas params (Join left right)
   -- ^ @on@ condition
-  -> FromClause commons schemas params left
+  -> FromClause outer commons schemas params left
   -- ^ left
-  -> FromClause commons schemas params (Join left right)
+  -> FromClause outer commons schemas params (Join left right)
 innerJoin right on left = UnsafeFromClause $
   renderSQL left <+> "INNER JOIN" <+> renderSQL right
   <+> "ON" <+> renderSQL on
@@ -924,13 +929,13 @@ innerJoin right on left = UnsafeFromClause $
     Thus, the joined table always has at least one row for each row in @left@.
 -}
 leftOuterJoin
-  :: FromClause commons schemas params right
+  :: FromClause outer commons schemas params right
   -- ^ right
-  -> Condition 'Ungrouped commons schemas params (Join left right)
+  -> Condition outer 'Ungrouped commons schemas params (Join left right)
   -- ^ @on@ condition
-  -> FromClause commons schemas params left
+  -> FromClause outer commons schemas params left
   -- ^ left
-  -> FromClause commons schemas params (Join left (NullifyFrom right))
+  -> FromClause outer commons schemas params (Join left (NullifyFrom right))
 leftOuterJoin right on left = UnsafeFromClause $
   renderSQL left <+> "LEFT OUTER JOIN" <+> renderSQL right
   <+> "ON" <+> renderSQL on
@@ -942,13 +947,13 @@ leftOuterJoin right on left = UnsafeFromClause $
     have a row for each row in @right@.
 -}
 rightOuterJoin
-  :: FromClause commons schemas params right
+  :: FromClause outer commons schemas params right
   -- ^ right
-  -> Condition 'Ungrouped commons schemas params (Join left right)
+  -> Condition outer 'Ungrouped commons schemas params (Join left right)
   -- ^ @on@ condition
-  -> FromClause commons schemas params left
+  -> FromClause outer commons schemas params left
   -- ^ left
-  -> FromClause commons schemas params (Join (NullifyFrom left) right)
+  -> FromClause outer commons schemas params (Join (NullifyFrom left) right)
 rightOuterJoin right on left = UnsafeFromClause $
   renderSQL left <+> "RIGHT OUTER JOIN" <+> renderSQL right
   <+> "ON" <+> renderSQL on
@@ -961,13 +966,13 @@ rightOuterJoin right on left = UnsafeFromClause $
     is added.
 -}
 fullOuterJoin
-  :: FromClause commons schemas params right
+  :: FromClause outer commons schemas params right
   -- ^ right
-  -> Condition 'Ungrouped commons schemas params (Join left right)
+  -> Condition outer 'Ungrouped commons schemas params (Join left right)
   -- ^ @on@ condition
-  -> FromClause commons schemas params left
+  -> FromClause outer commons schemas params left
   -- ^ left
-  -> FromClause commons schemas params
+  -> FromClause outer commons schemas params
       (Join (NullifyFrom left) (NullifyFrom right))
 fullOuterJoin right on left = UnsafeFromClause $
   renderSQL left <+> "FULL OUTER JOIN" <+> renderSQL right
@@ -1036,17 +1041,17 @@ instance RenderSQL (GroupByClause grp from) where
 -- An `Ungrouped` `TableExpression` may only use `NoHaving` while a `Grouped`
 -- `TableExpression` must use `Having` whose conditions are combined with
 -- `.&&`.
-data HavingClause grp commons schemas params from where
-  NoHaving :: HavingClause 'Ungrouped commons schemas params from
+data HavingClause outer grp commons schemas params from where
+  NoHaving :: HavingClause outer 'Ungrouped commons schemas params from
   Having
-    :: [Condition ('Grouped bys) commons schemas params from]
-    -> HavingClause ('Grouped bys) commons schemas params from
-deriving instance Show (HavingClause grp commons schemas params from)
-deriving instance Eq (HavingClause grp commons schemas params from)
-deriving instance Ord (HavingClause grp commons schemas params from)
+    :: [Condition outer ('Grouped bys) commons schemas params from]
+    -> HavingClause outer ('Grouped bys) commons schemas params from
+deriving instance Show (HavingClause outer grp commons schemas params from)
+deriving instance Eq (HavingClause outer grp commons schemas params from)
+deriving instance Ord (HavingClause outer grp commons schemas params from)
 
 -- | Render a `HavingClause`.
-instance RenderSQL (HavingClause grp commons schemas params from) where
+instance RenderSQL (HavingClause outer grp commons schemas params from) where
   renderSQL = \case
     NoHaving -> ""
     Having [] -> ""
@@ -1055,18 +1060,18 @@ instance RenderSQL (HavingClause grp commons schemas params from) where
 
 unsafeSubqueryExpression
   :: ByteString
-  -> Expression grp commons schemas params from ty
-  -> Query commons schemas params '[alias ::: ty]
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  -> Expression outer grp commons schemas params from ty
+  -> Query from commons schemas params '[alias ::: ty]
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 unsafeSubqueryExpression op x q = UnsafeExpression $
   renderSQL x <+> op <+> parenthesized (renderSQL q)
 
 unsafeRowSubqueryExpression
   :: SListI row
   => ByteString
-  -> NP (Aliased (Expression grp commons schemas params from)) row
-  -> Query commons schemas params row
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  -> NP (Aliased (Expression outer grp commons schemas params from)) row
+  -> Query from commons schemas params row
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 unsafeRowSubqueryExpression op xs q = UnsafeExpression $
   renderSQL (row xs) <+> op <+> parenthesized (renderSQL q)
 
@@ -1079,9 +1084,9 @@ unsafeRowSubqueryExpression op xs q = UnsafeExpression $
 -- >>> printSQL $ true `in_` values_ (true `as` #foo)
 -- TRUE IN (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 in_
-  :: Expression grp commons schemas params from ty -- ^ expression
-  -> Query commons schemas params '[alias ::: ty] -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from ty -- ^ expression
+  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 in_ = unsafeSubqueryExpression "IN"
 
 {- | The left-hand side of this form of `rowIn` is a row constructor.
@@ -1094,231 +1099,231 @@ is `true` if any equal subquery row is found.
 The result is `false` if no equal row is found
 (including the case where the subquery returns no rows).
 
->>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+>>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression outer grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 >>> printSQL $ myRow `rowIn` values_ myRow
 ROW(1, FALSE) IN (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 -}
 rowIn
   :: SListI row
-  => NP (Aliased (Expression grp commons schemas params from)) row -- ^ row constructor
-  -> Query commons schemas params row -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
+  -> Query from commons schemas params row -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowIn = unsafeRowSubqueryExpression "IN"
 
 -- | >>> printSQL $ true `eqAll` values_ (true `as` #foo)
 -- TRUE = ALL (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 eqAll
-  :: Expression grp commons schemas params from ty -- ^ expression
-  -> Query commons schemas params '[alias ::: ty] -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from ty -- ^ expression
+  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 eqAll = unsafeSubqueryExpression "= ALL"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression outer grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowEqAll` values_ myRow
 -- ROW(1, FALSE) = ALL (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowEqAll
   :: SListI row
-  => NP (Aliased (Expression grp commons schemas params from)) row -- ^ row constructor
-  -> Query commons schemas params row -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
+  -> Query from commons schemas params row -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowEqAll = unsafeRowSubqueryExpression "= ALL"
 
 -- | >>> printSQL $ true `eqAny` values_ (true `as` #foo)
 -- TRUE = ANY (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 eqAny
-  :: Expression grp commons schemas params from ty -- ^ expression
-  -> Query commons schemas params '[alias ::: ty] -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from ty -- ^ expression
+  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 eqAny = unsafeSubqueryExpression "= ANY"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression outer grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowEqAny` values_ myRow
 -- ROW(1, FALSE) = ANY (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowEqAny
   :: SListI row
-  => NP (Aliased (Expression grp commons schemas params from)) row -- ^ row constructor
-  -> Query commons schemas params row -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
+  -> Query from commons schemas params row -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowEqAny = unsafeRowSubqueryExpression "= ANY"
 
 -- | >>> printSQL $ true `neqAll` values_ (true `as` #foo)
 -- TRUE <> ALL (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 neqAll
-  :: Expression grp commons schemas params from ty -- ^ expression
-  -> Query commons schemas params '[alias ::: ty] -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from ty -- ^ expression
+  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 neqAll = unsafeSubqueryExpression "<> ALL"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression outer grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowNeqAll` values_ myRow
 -- ROW(1, FALSE) <> ALL (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowNeqAll
   :: SListI row
-  => NP (Aliased (Expression grp commons schemas params from)) row -- ^ row constructor
-  -> Query commons schemas params row -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
+  -> Query from commons schemas params row -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowNeqAll = unsafeRowSubqueryExpression "<> ALL"
 
 -- | >>> printSQL $ true `neqAny` values_ (true `as` #foo)
 -- TRUE <> ANY (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 neqAny
-  :: Expression grp commons schemas params from ty -- ^ expression
-  -> Query commons schemas params '[alias ::: ty] -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from ty -- ^ expression
+  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 neqAny = unsafeSubqueryExpression "<> ANY"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression outer grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowNeqAny` values_ myRow
 -- ROW(1, FALSE) <> ANY (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowNeqAny
   :: SListI row
-  => NP (Aliased (Expression grp commons schemas params from)) row -- ^ row constructor
-  -> Query commons schemas params row -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
+  -> Query from commons schemas params row -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowNeqAny = unsafeRowSubqueryExpression "<> ANY"
 
 -- | >>> printSQL $ true `allLt` values_ (true `as` #foo)
 -- TRUE ALL < (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 allLt
-  :: Expression grp commons schemas params from ty -- ^ expression
-  -> Query commons schemas params '[alias ::: ty] -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from ty -- ^ expression
+  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 allLt = unsafeSubqueryExpression "ALL <"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression outer grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowLtAll` values_ myRow
 -- ROW(1, FALSE) ALL < (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowLtAll
   :: SListI row
-  => NP (Aliased (Expression grp commons schemas params from)) row -- ^ row constructor
-  -> Query commons schemas params row -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
+  -> Query from commons schemas params row -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowLtAll = unsafeRowSubqueryExpression "ALL <"
 
 -- | >>> printSQL $ true `ltAny` values_ (true `as` #foo)
 -- TRUE ANY < (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 ltAny
-  :: Expression grp commons schemas params from ty -- ^ expression
-  -> Query commons schemas params '[alias ::: ty] -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from ty -- ^ expression
+  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 ltAny = unsafeSubqueryExpression "ANY <"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression outer grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowLtAll` values_ myRow
 -- ROW(1, FALSE) ALL < (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowLtAny
   :: SListI row
-  => NP (Aliased (Expression grp commons schemas params from)) row -- ^ row constructor
-  -> Query commons schemas params row -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
+  -> Query from commons schemas params row -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowLtAny = unsafeRowSubqueryExpression "ANY <"
 
 -- | >>> printSQL $ true `lteAll` values_ (true `as` #foo)
 -- TRUE <= ALL (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 lteAll
-  :: Expression grp commons schemas params from ty -- ^ expression
-  -> Query commons schemas params '[alias ::: ty] -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from ty -- ^ expression
+  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 lteAll = unsafeSubqueryExpression "<= ALL"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression outer grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowLteAll` values_ myRow
 -- ROW(1, FALSE) <= ALL (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowLteAll
   :: SListI row
-  => NP (Aliased (Expression grp commons schemas params from)) row -- ^ row constructor
-  -> Query commons schemas params row -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
+  -> Query from commons schemas params row -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowLteAll = unsafeRowSubqueryExpression "<= ALL"
 
 -- | >>> printSQL $ true `lteAny` values_ (true `as` #foo)
 -- TRUE <= ANY (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 lteAny
-  :: Expression grp commons schemas params from ty -- ^ expression
-  -> Query commons schemas params '[alias ::: ty] -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from ty -- ^ expression
+  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 lteAny = unsafeSubqueryExpression "<= ANY"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression outer grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowLteAny` values_ myRow
 -- ROW(1, FALSE) <= ANY (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowLteAny
   :: SListI row
-  => NP (Aliased (Expression grp commons schemas params from)) row -- ^ row constructor
-  -> Query commons schemas params row -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
+  -> Query from commons schemas params row -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowLteAny = unsafeRowSubqueryExpression "<= ANY"
 
 -- | >>> printSQL $ true `gtAll` values_ (true `as` #foo)
 -- TRUE > ALL (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 gtAll
-  :: Expression grp commons schemas params from ty -- ^ expression
-  -> Query commons schemas params '[alias ::: ty] -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from ty -- ^ expression
+  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 gtAll = unsafeSubqueryExpression "> ALL"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression outer grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowGtAll` values_ myRow
 -- ROW(1, FALSE) > ALL (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowGtAll
   :: SListI row
-  => NP (Aliased (Expression grp commons schemas params from)) row -- ^ row constructor
-  -> Query commons schemas params row -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
+  -> Query from commons schemas params row -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowGtAll = unsafeRowSubqueryExpression "> ALL"
 
 -- | >>> printSQL $ true `gtAny` values_ (true `as` #foo)
 -- TRUE > ANY (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 gtAny
-  :: Expression grp commons schemas params from ty -- ^ expression
-  -> Query commons schemas params '[alias ::: ty] -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from ty -- ^ expression
+  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 gtAny = unsafeSubqueryExpression "> ANY"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression outer grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowGtAny` values_ myRow
 -- ROW(1, FALSE) > ANY (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowGtAny
   :: SListI row
-  => NP (Aliased (Expression grp commons schemas params from)) row -- ^ row constructor
-  -> Query commons schemas params row -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
+  -> Query from commons schemas params row -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowGtAny = unsafeRowSubqueryExpression "> ANY"
 
 -- | >>> printSQL $ true `gteAll` values_ (true `as` #foo)
 -- TRUE >= ALL (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 gteAll
-  :: Expression grp commons schemas params from ty -- ^ expression
-  -> Query commons schemas params '[alias ::: ty] -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from ty -- ^ expression
+  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 gteAll = unsafeSubqueryExpression ">= ALL"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression outer grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowGteAll` values_ myRow
 -- ROW(1, FALSE) >= ALL (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowGteAll
   :: SListI row
-  => NP (Aliased (Expression grp commons schemas params from)) row -- ^ row constructor
-  -> Query commons schemas params row -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
+  -> Query from commons schemas params row -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowGteAll = unsafeRowSubqueryExpression ">= ALL"
 
 -- | >>> printSQL $ true `gteAny` values_ (true `as` #foo)
 -- TRUE >= ANY (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 gteAny
-  :: Expression grp commons schemas params from ty -- ^ expression
-  -> Query commons schemas params '[alias ::: ty] -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  :: Expression outer grp commons schemas params from ty -- ^ expression
+  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 gteAny = unsafeSubqueryExpression ">= ANY"
 
--- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+-- | >>> let myRow = 1 `as` #foo :* false `as` #bar :: NP (Aliased (Expression outer grp commons schemas params from)) '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
 -- >>> printSQL $ myRow `rowGteAny` values_ myRow
 -- ROW(1, FALSE) >= ANY (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowGteAny
   :: SListI row
-  => NP (Aliased (Expression grp commons schemas params from)) row -- ^ row constructor
-  -> Query commons schemas params row -- ^ subquery
-  -> Expression grp commons schemas params from (nullity 'PGbool)
+  => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
+  -> Query from commons schemas params row -- ^ subquery
+  -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowGteAny = unsafeRowSubqueryExpression ">= ANY"
 
 -- | A `CommonTableExpression` is an auxiliary statement in a `with` clause.
@@ -1360,7 +1365,7 @@ class With statement where
     -> statement commons1 schemas params row
     -- ^ larger query
     -> statement commons0 schemas params row
-instance With Query where
+instance With (Query outer) where
   with Done query = query
   with ctes query = UnsafeQuery $
     "WITH" <+> renderSQL ctes <+> renderSQL query

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -143,7 +143,7 @@ simple query:
 >>> type Schema = '["tab" ::: 'Table ('[] :=> Columns)]
 >>> :{
 let
-  query :: Query '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = select Star (from (table #tab))
 in printSQL query
 :}
@@ -153,7 +153,7 @@ restricted query:
 
 >>> :{
 let
-  query :: Query '[] (Public Schema) '[] '["sum" ::: 'NotNull 'PGint4, "col1" ::: 'NotNull 'PGint4]
+  query :: Query '[] '[] (Public Schema) '[] '["sum" ::: 'NotNull 'PGint4, "col1" ::: 'NotNull 'PGint4]
   query =
     select_ ((#col1 + #col2) `as` #sum :* #col1)
       ( from (table #tab)
@@ -167,7 +167,7 @@ subquery:
 
 >>> :{
 let
-  query :: Query '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = select Star (from (subquery (select Star (from (table #tab)) `as` #sub)))
 in printSQL query
 :}
@@ -177,7 +177,7 @@ limits and offsets:
 
 >>> :{
 let
-  query :: Query '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = select Star (from (table #tab) & limit 100 & offset 2 & limit 50 & offset 2)
 in printSQL query
 :}
@@ -187,7 +187,7 @@ parameterized query:
 
 >>> :{
 let
-  query :: Query '[] (Public Schema) '[ 'NotNull 'PGint4] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] '[] (Public Schema) '[ 'NotNull 'PGint4] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = select Star (from (table #tab) & where_ (#col1 .> param @1))
 in printSQL query
 :}
@@ -197,7 +197,7 @@ aggregation query:
 
 >>> :{
 let
-  query :: Query '[] (Public Schema) '[] '["sum" ::: 'NotNull 'PGint4, "col1" ::: 'NotNull 'PGint4 ]
+  query :: Query '[] '[] (Public Schema) '[] '["sum" ::: 'NotNull 'PGint4, "col1" ::: 'NotNull 'PGint4 ]
   query =
     select_ (sum_ (All #col2) `as` #sum :* #col1)
     ( from (table (#tab `as` #table1))
@@ -211,7 +211,7 @@ sorted query:
 
 >>> :{
 let
-  query :: Query '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = select Star (from (table #tab) & orderBy [#col1 & Asc])
 in printSQL query
 :}
@@ -248,7 +248,7 @@ type OrdersSchema =
 
 >>> :{
 let
-  query :: Query '[] (Public OrdersSchema)
+  query :: Query '[] '[] (Public OrdersSchema)
     '[]
     '[ "order_price" ::: 'NotNull 'PGfloat4
      , "customer_name" ::: 'NotNull 'PGtext
@@ -271,7 +271,7 @@ self-join:
 
 >>> :{
 let
-  query :: Query '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = select (#t1 & DotStar) (from (table (#tab `as` #t1) & crossJoin (table (#tab `as` #t2))))
 in printSQL query
 :}
@@ -281,7 +281,7 @@ value queries:
 
 >>> :{
 let
-  query :: Query outer commons schemas '[] '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
+  query :: Query '[] commons schemas '[] '["foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGbool]
   query = values (1 `as` #foo :* true `as` #bar) [2 `as` #foo :* false `as` #bar]
 in printSQL query
 :}
@@ -291,7 +291,7 @@ set operations:
 
 >>> :{
 let
-  query :: Query '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = select Star (from (table #tab)) `unionAll` select Star (from (table #tab))
 in printSQL query
 :}
@@ -301,7 +301,7 @@ with queries:
 
 >>> :{
 let
-  query :: Query '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
+  query :: Query '[] '[] (Public Schema) '[] '["col1" ::: 'NotNull 'PGint4, "col2" ::: 'NotNull 'PGint4]
   query = with (
     select Star (from (table #tab)) `as` #cte1 :>>
     select Star (from (common #cte1)) `as` #cte2
@@ -314,7 +314,7 @@ window function queries
 
 >>> :{
 let
-  query :: Query '[] (Public Schema) '[] ["col1" ::: 'NotNull 'PGint4, "rank" ::: 'NotNull 'PGint8]
+  query :: Query '[] '[] (Public Schema) '[] ["col1" ::: 'NotNull 'PGint4, "rank" ::: 'NotNull 'PGint8]
   query = select
     (#col1 & Also (rank `as` #rank `Over` (partitionBy #col1 & orderBy [#col2 & Asc])))
     (from (table #tab))
@@ -1061,7 +1061,7 @@ instance RenderSQL (HavingClause outer grp commons schemas params from) where
 unsafeSubqueryExpression
   :: ByteString
   -> Expression outer grp commons schemas params from ty
-  -> Query from commons schemas params '[alias ::: ty]
+  -> Query (Join outer from) commons schemas params '[alias ::: ty]
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 unsafeSubqueryExpression op x q = UnsafeExpression $
   renderSQL x <+> op <+> parenthesized (renderSQL q)
@@ -1070,7 +1070,7 @@ unsafeRowSubqueryExpression
   :: SListI row
   => ByteString
   -> NP (Aliased (Expression outer grp commons schemas params from)) row
-  -> Query from commons schemas params row
+  -> Query (Join outer from) commons schemas params row
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 unsafeRowSubqueryExpression op xs q = UnsafeExpression $
   renderSQL (row xs) <+> op <+> parenthesized (renderSQL q)
@@ -1085,7 +1085,7 @@ unsafeRowSubqueryExpression op xs q = UnsafeExpression $
 -- TRUE IN (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 in_
   :: Expression outer grp commons schemas params from ty -- ^ expression
-  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Query (Join outer from) commons schemas params '[alias ::: ty] -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 in_ = unsafeSubqueryExpression "IN"
 
@@ -1106,7 +1106,7 @@ ROW(1, FALSE) IN (SELECT * FROM (VALUES (1, FALSE)) AS t ("foo", "bar"))
 rowIn
   :: SListI row
   => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
-  -> Query from commons schemas params row -- ^ subquery
+  -> Query (Join outer from) commons schemas params row -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowIn = unsafeRowSubqueryExpression "IN"
 
@@ -1114,7 +1114,7 @@ rowIn = unsafeRowSubqueryExpression "IN"
 -- TRUE = ALL (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 eqAll
   :: Expression outer grp commons schemas params from ty -- ^ expression
-  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Query (Join outer from) commons schemas params '[alias ::: ty] -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 eqAll = unsafeSubqueryExpression "= ALL"
 
@@ -1124,7 +1124,7 @@ eqAll = unsafeSubqueryExpression "= ALL"
 rowEqAll
   :: SListI row
   => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
-  -> Query from commons schemas params row -- ^ subquery
+  -> Query (Join outer from) commons schemas params row -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowEqAll = unsafeRowSubqueryExpression "= ALL"
 
@@ -1132,7 +1132,7 @@ rowEqAll = unsafeRowSubqueryExpression "= ALL"
 -- TRUE = ANY (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 eqAny
   :: Expression outer grp commons schemas params from ty -- ^ expression
-  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Query (Join outer from) commons schemas params '[alias ::: ty] -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 eqAny = unsafeSubqueryExpression "= ANY"
 
@@ -1142,7 +1142,7 @@ eqAny = unsafeSubqueryExpression "= ANY"
 rowEqAny
   :: SListI row
   => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
-  -> Query from commons schemas params row -- ^ subquery
+  -> Query (Join outer from) commons schemas params row -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowEqAny = unsafeRowSubqueryExpression "= ANY"
 
@@ -1150,7 +1150,7 @@ rowEqAny = unsafeRowSubqueryExpression "= ANY"
 -- TRUE <> ALL (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 neqAll
   :: Expression outer grp commons schemas params from ty -- ^ expression
-  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Query (Join outer from) commons schemas params '[alias ::: ty] -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 neqAll = unsafeSubqueryExpression "<> ALL"
 
@@ -1160,7 +1160,7 @@ neqAll = unsafeSubqueryExpression "<> ALL"
 rowNeqAll
   :: SListI row
   => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
-  -> Query from commons schemas params row -- ^ subquery
+  -> Query (Join outer from) commons schemas params row -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowNeqAll = unsafeRowSubqueryExpression "<> ALL"
 
@@ -1168,7 +1168,7 @@ rowNeqAll = unsafeRowSubqueryExpression "<> ALL"
 -- TRUE <> ANY (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 neqAny
   :: Expression outer grp commons schemas params from ty -- ^ expression
-  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Query (Join outer from) commons schemas params '[alias ::: ty] -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 neqAny = unsafeSubqueryExpression "<> ANY"
 
@@ -1178,7 +1178,7 @@ neqAny = unsafeSubqueryExpression "<> ANY"
 rowNeqAny
   :: SListI row
   => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
-  -> Query from commons schemas params row -- ^ subquery
+  -> Query (Join outer from) commons schemas params row -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowNeqAny = unsafeRowSubqueryExpression "<> ANY"
 
@@ -1186,7 +1186,7 @@ rowNeqAny = unsafeRowSubqueryExpression "<> ANY"
 -- TRUE ALL < (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 allLt
   :: Expression outer grp commons schemas params from ty -- ^ expression
-  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Query (Join outer from) commons schemas params '[alias ::: ty] -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 allLt = unsafeSubqueryExpression "ALL <"
 
@@ -1196,7 +1196,7 @@ allLt = unsafeSubqueryExpression "ALL <"
 rowLtAll
   :: SListI row
   => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
-  -> Query from commons schemas params row -- ^ subquery
+  -> Query (Join outer from) commons schemas params row -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowLtAll = unsafeRowSubqueryExpression "ALL <"
 
@@ -1204,7 +1204,7 @@ rowLtAll = unsafeRowSubqueryExpression "ALL <"
 -- TRUE ANY < (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 ltAny
   :: Expression outer grp commons schemas params from ty -- ^ expression
-  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Query (Join outer from) commons schemas params '[alias ::: ty] -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 ltAny = unsafeSubqueryExpression "ANY <"
 
@@ -1214,7 +1214,7 @@ ltAny = unsafeSubqueryExpression "ANY <"
 rowLtAny
   :: SListI row
   => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
-  -> Query from commons schemas params row -- ^ subquery
+  -> Query (Join outer from) commons schemas params row -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowLtAny = unsafeRowSubqueryExpression "ANY <"
 
@@ -1222,7 +1222,7 @@ rowLtAny = unsafeRowSubqueryExpression "ANY <"
 -- TRUE <= ALL (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 lteAll
   :: Expression outer grp commons schemas params from ty -- ^ expression
-  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Query (Join outer from) commons schemas params '[alias ::: ty] -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 lteAll = unsafeSubqueryExpression "<= ALL"
 
@@ -1232,7 +1232,7 @@ lteAll = unsafeSubqueryExpression "<= ALL"
 rowLteAll
   :: SListI row
   => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
-  -> Query from commons schemas params row -- ^ subquery
+  -> Query (Join outer from) commons schemas params row -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowLteAll = unsafeRowSubqueryExpression "<= ALL"
 
@@ -1240,7 +1240,7 @@ rowLteAll = unsafeRowSubqueryExpression "<= ALL"
 -- TRUE <= ANY (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 lteAny
   :: Expression outer grp commons schemas params from ty -- ^ expression
-  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Query (Join outer from) commons schemas params '[alias ::: ty] -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 lteAny = unsafeSubqueryExpression "<= ANY"
 
@@ -1250,7 +1250,7 @@ lteAny = unsafeSubqueryExpression "<= ANY"
 rowLteAny
   :: SListI row
   => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
-  -> Query from commons schemas params row -- ^ subquery
+  -> Query (Join outer from) commons schemas params row -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowLteAny = unsafeRowSubqueryExpression "<= ANY"
 
@@ -1258,7 +1258,7 @@ rowLteAny = unsafeRowSubqueryExpression "<= ANY"
 -- TRUE > ALL (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 gtAll
   :: Expression outer grp commons schemas params from ty -- ^ expression
-  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Query (Join outer from) commons schemas params '[alias ::: ty] -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 gtAll = unsafeSubqueryExpression "> ALL"
 
@@ -1268,7 +1268,7 @@ gtAll = unsafeSubqueryExpression "> ALL"
 rowGtAll
   :: SListI row
   => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
-  -> Query from commons schemas params row -- ^ subquery
+  -> Query (Join outer from) commons schemas params row -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowGtAll = unsafeRowSubqueryExpression "> ALL"
 
@@ -1276,7 +1276,7 @@ rowGtAll = unsafeRowSubqueryExpression "> ALL"
 -- TRUE > ANY (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 gtAny
   :: Expression outer grp commons schemas params from ty -- ^ expression
-  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Query (Join outer from) commons schemas params '[alias ::: ty] -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 gtAny = unsafeSubqueryExpression "> ANY"
 
@@ -1286,7 +1286,7 @@ gtAny = unsafeSubqueryExpression "> ANY"
 rowGtAny
   :: SListI row
   => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
-  -> Query from commons schemas params row -- ^ subquery
+  -> Query (Join outer from) commons schemas params row -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowGtAny = unsafeRowSubqueryExpression "> ANY"
 
@@ -1294,7 +1294,7 @@ rowGtAny = unsafeRowSubqueryExpression "> ANY"
 -- TRUE >= ALL (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 gteAll
   :: Expression outer grp commons schemas params from ty -- ^ expression
-  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Query (Join outer from) commons schemas params '[alias ::: ty] -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 gteAll = unsafeSubqueryExpression ">= ALL"
 
@@ -1304,7 +1304,7 @@ gteAll = unsafeSubqueryExpression ">= ALL"
 rowGteAll
   :: SListI row
   => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
-  -> Query from commons schemas params row -- ^ subquery
+  -> Query (Join outer from) commons schemas params row -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowGteAll = unsafeRowSubqueryExpression ">= ALL"
 
@@ -1312,7 +1312,7 @@ rowGteAll = unsafeRowSubqueryExpression ">= ALL"
 -- TRUE >= ANY (SELECT * FROM (VALUES (TRUE)) AS t ("foo"))
 gteAny
   :: Expression outer grp commons schemas params from ty -- ^ expression
-  -> Query from commons schemas params '[alias ::: ty] -- ^ subquery
+  -> Query (Join outer from) commons schemas params '[alias ::: ty] -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 gteAny = unsafeSubqueryExpression ">= ANY"
 
@@ -1322,7 +1322,7 @@ gteAny = unsafeSubqueryExpression ">= ANY"
 rowGteAny
   :: SListI row
   => NP (Aliased (Expression outer grp commons schemas params from)) row -- ^ row constructor
-  -> Query from commons schemas params row -- ^ subquery
+  -> Query (Join outer from) commons schemas params row -- ^ subquery
   -> Expression outer grp commons schemas params from (nullity 'PGbool)
 rowGteAny = unsafeRowSubqueryExpression ">= ANY"
 


### PR DESCRIPTION
* Resolves #86 by adding a new `outer` scope variable and `exists`.
* Takes some ideas from #74 and simplifies subqueries
  * `in_` just takes a list
  * `notIn` added
  * `subAll`/`subAny` unifies the rest
  * removes row constructor subqueries (we can add them back later if anyone needs them)