### PR TITLE
Add default main utility for migrations

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -85,6 +85,7 @@ module Squeal.PostgreSQL.Schema
     -- * Aligned lists
   , AlignedList (..)
   , single
+  , extractList
     -- * Data Definitions
   , Create
   , Drop
@@ -875,6 +876,11 @@ instance (forall t0 t1. RenderSQL (p t0 t1))
       Done -> ""
       step :>> Done -> renderSQL step
       step :>> steps -> renderSQL step <> ", " <> renderSQL steps
+
+extractList :: (forall a0 a1. p a0 a1 -> b) -> AlignedList p x0 x1 -> [b]
+extractList f = \case
+  Done -> []
+  step :>> steps -> (f step):extractList f steps
 
 -- | A `single` step.
 single :: p x0 x1 -> AlignedList p x0 x1

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -84,8 +84,8 @@ module Squeal.PostgreSQL.Schema
   , GroupedBy
     -- * Aligned lists
   , AlignedList (..)
-  , single
   , extractList
+  , single
     -- * Data Definitions
   , Create
   , Drop


### PR DESCRIPTION
# In summary

Proposal to start implementing #57.

I have tried many - clearly overengineered - other solutions but I think I've taken too much time on a feature that we should really add to Squeal, so here's a simpler, more down-to-earth implementation. It lets you migrate up, down and display everything.

# Small notes on implementation

- Migrate one up or migrate X up could be implemented by modifying the `migrateUp` signature and taking an optional counter. Not the prettiest solution possible, but probably the easiest way to implement this. Same for migrate down.
- The `optparse-generic` is a _suggestion_, but I'm ready to change it. @echatav, I know you found it was a heavy dependency to add. I first tried my hand with `getopt-generics` as you suggested, but it doesn't support sum type. I can rewrite the parser using it to fetch a string and try to `read` over it, but considering the simplicity of the task at hand, a simple manual main could also do the job. Just tell me what you prefer and I'll make the changes !
- Output is fairly basic (no colour schemes and so on). I have splitted it in smaller functions in case we want to improve on this end.

# Example use of the feature in client code

```
import Squeal.PostgreSQL.Migration
import Squeal.PostgreSQL
import MyProject.Migrations (baseMigration, migration1, migration2, migration3)

-- | Usage:
-- > stack exec myexe allup
-- to run all migrations up
-- > stack exec myexe alldown
-- to run all migrations down
-- > stack exec myexe display
-- to show the current migration state
main :: IO ()
main = do
  cs <- getEnv "pg_uri" -- provided a connection string is available in the environment
  let migs = baseMigration :>> migration1 :>> migration2 :>> migration3 :>> Done
  defaultMain cs migs
```