### PR TITLE
[#109] Move from MonadBaseControl to MonadUnliftIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ We'll need some imports.
 
 ```Haskell
 >>> import Control.Monad (void)
->>> import Control.Monad.Base (liftBase)
+>>> import Control.Monad.IO.Class (liftIO)
 >>> import Data.Int (Int32)
 >>> import Data.Text (Text)
 >>> import Squeal.PostgreSQL
@@ -128,7 +128,7 @@ yielding a `TableType`, or to pair a `ColumnConstraint` with a `NullityType`,
 yielding a `ColumnType`. It is intended to connote Haskell's `=>` operator
 
 Next, we'll write `Definition`s to set up and tear down the schema. In
-Squeal, a `Definition` like `createTable`, `alterTable` or `dropTable` 
+Squeal, a `Definition` like `createTable`, `alterTable` or `dropTable`
 has two type parameters, corresponding to the schema
 before being run and the schema after. We can compose definitions using `>>>`.
 Here and in the rest of our commands we make use of overloaded
@@ -138,7 +138,7 @@ labels to refer to named tables and columns in our schema.
 >>> :{
 let
   setup :: Definition '[] Schema
-  setup = 
+  setup =
     createTable #users
       ( serial `as` #id :*
         (text & notNullable) `as` #name )
@@ -254,7 +254,7 @@ Let's also create some users to add to the database.
 >>> :{
 let
   users :: [User]
-  users = 
+  users =
     [ User "Alice" (Just "alice@gmail.com")
     , User "Bob" Nothing
     , User "Carole" (Just "carole@hotmail.com")
@@ -280,7 +280,7 @@ let
     traversePrepared_ insertEmail (zip (ids :: [Int32]) (userEmail <$> users))
     usersResult <- runQuery getUsers
     usersRows <- getRows usersResult
-    liftBase $ print (usersRows :: [User])
+    liftIO $ print (usersRows :: [User])
 in
   void . withConnection "host=localhost port=5432 dbname=exampledb" $
     define setup

--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -43,9 +43,7 @@ library
     , bytestring-strict-builder >= 0.4.5
     , deepseq >= 1.4.3.0
     , generics-sop >= 0.3.2.0
-    , lifted-base >= 0.2.3.12
     , mmorph >= 1.1.1
-    , monad-control >= 1.0.2.3
     , mtl >= 2.2.2
     , network-ip >= 0.3.0.2
     , postgresql-binary >= 0.12.1
@@ -56,7 +54,8 @@ library
     , text >= 1.2.3.0
     , time >= 1.8.0.2
     , transformers >= 0.5.2.0
-    , transformers-base >= 0.4.4
+    , unliftio >= 0.2.10
+    , unliftio-pool >= 0.2.1.0
     , uuid-types >= 1.0.3
     , vector >= 0.12.0.1
 
@@ -85,7 +84,6 @@ test-suite squeal-postgresql-specs
     , squeal-postgresql
     , text >= 1.2.2.2
     , transformers >= 0.5.2.0
-    , transformers-base >= 0.4.4
     , vector >= 0.12.0.1
 
 executable squeal-postgresql-example
@@ -101,5 +99,4 @@ executable squeal-postgresql-example
     , squeal-postgresql
     , text >= 1.2.2.2
     , transformers >= 0.5.2.0
-    , transformers-base >= 0.4.4
     , vector >= 0.12.0.1

--- a/squeal-postgresql/src/Squeal/PostgreSQL.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL.hs
@@ -17,7 +17,7 @@ features.
 We'll need some imports.
 
 >>> import Control.Monad (void)
->>> import Control.Monad.Base (liftBase)
+>>> import Control.Monad.IO.Class (liftIO)
 >>> import Data.Int (Int32)
 >>> import Data.Text (Text)
 >>> import Squeal.PostgreSQL
@@ -60,7 +60,7 @@ yielding a `TableType`, or to pair a `ColumnConstraint` with a `NullityType`,
 yielding a `ColumnType`. It is intended to connote Haskell's @=>@ operator
 
 Next, we'll write `Definition`s to set up and tear down the schema. In
-Squeal, a `Definition` like `createTable`, `alterTable` or `dropTable` 
+Squeal, a `Definition` like `createTable`, `alterTable` or `dropTable`
 has two type parameters, corresponding to the schema
 before being run and the schema after. We can compose definitions using `>>>`.
 Here and in the rest of our commands we make use of overloaded
@@ -69,7 +69,7 @@ labels to refer to named tables and columns in our schema.
 >>> :{
 let
   setup :: Definition (Public '[]) Schemas
-  setup = 
+  setup =
     createTable #users
       ( serial `as` #id :*
         (text & notNullable) `as` #name )
@@ -119,7 +119,7 @@ We'll need a Haskell type for users. We give the type `Generics.SOP.Generic` and
 `Generics.SOP.HasDatatypeInfo` instances so that we can decode the rows
 we receive when we run @getUsers@. Notice that the record fields of the
 @User@ type match the column names of @getUsers@.
- 
+
 >>> data User = User { userName :: Text, userEmail :: Maybe Text } deriving (Show, GHC.Generic)
 >>> instance SOP.Generic User
 >>> instance SOP.HasDatatypeInfo User
@@ -162,7 +162,7 @@ Let's create some users to add to the database.
 >>> :{
 let
   users :: [User]
-  users = 
+  users =
     [ User "Alice" (Just "alice@gmail.com")
     , User "Bob" Nothing
     , User "Carole" (Just "carole@hotmail.com")
@@ -184,7 +184,7 @@ let
     _ <- traversePrepared_ insertUser users
     usersResult <- runQuery getUsers
     usersRows <- getRows usersResult
-    liftBase $ print (usersRows :: [User])
+    liftIO $ print (usersRows :: [User])
 in
   void . withConnection "host=localhost port=5432 dbname=exampledb" $
     define setup

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Binary.hs
@@ -16,7 +16,7 @@ Let's see some examples. We'll need some imports
 >>> import Data.Int (Int16)
 >>> import Data.Text (Text)
 >>> import Control.Monad (void)
->>> import Control.Monad.Base (liftBase)
+>>> import Control.Monad.IO.Class (liftIO)
 >>> import Squeal.PostgreSQL
 
 Define a Haskell datatype @Row@ that will serve as both the input and output of a simple
@@ -42,7 +42,7 @@ the input and output should be equal.
 void . withConnection "host=localhost port=5432 dbname=exampledb" $ do
   result <- runQueryParams roundTrip input
   Just output <- firstRow result
-  liftBase . print $ input == output
+  liftIO . print $ input == output
 :}
 True
 
@@ -81,7 +81,7 @@ let
 void . withConnection "host=localhost port=5432 dbname=exampledb" $ do
   result <- runQueryParams roundTrip input
   Just output <- firstRow result
-  liftBase . print $ input == output
+  liftIO . print $ input == output
 :}
 True
 
@@ -168,7 +168,7 @@ let
   session = do
     result <- runQueryParams roundTrip input
     Just output <- firstRow result
-    liftBase . print $ input == output
+    liftIO . print $ input == output
 in
   void . withConnection "host=localhost port=5432 dbname=exampledb" $
     define setup
@@ -723,7 +723,7 @@ of the number of cents, i.e. @$2,000.20@ would be expressed as
 @Money { cents = 200020 }@.
 
 >>> import Control.Monad (void)
->>> import Control.Monad.Base (liftBase)
+>>> import Control.Monad.IO.Class (liftIO)
 >>> import Squeal.PostgreSQL
 >>> :{
 let
@@ -737,7 +737,7 @@ let
 void . withConnection "host=localhost port=5432 dbname=exampledb" $ do
   result <- runQueryParams roundTrip input
   Just output <- firstRow result
-  liftBase . print $ input == output
+  liftIO . print $ input == output
 :}
 True
 -}

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -73,7 +73,7 @@ let
   numMigrations = do
     result <- runQuery (select Star (from (table (#migrations ! #schema_migrations `as` #m))))
     num <- ntuples result
-    liftBase $ print num
+    liftIO $ print num
 :}
 
 >>> :{

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -115,8 +115,6 @@ module Squeal.PostgreSQL.Migration
   ) where
 
 import           Control.Monad
-import           Control.Monad.Base
-import           Control.Monad.Trans.Control
 import           Data.ByteString             (ByteString)
 import           Data.Foldable               (traverse_)
 import           Data.Function               ((&))
@@ -129,6 +127,7 @@ import qualified Generics.SOP                as SOP
 import qualified GHC.Generics                as GHC
 import           Squeal.PostgreSQL
 import           System.Environment
+import           UnliftIO                    (MonadUnliftIO, MonadIO (..))
 
 -- | A `Migration` should contain an inverse pair of
 -- `up` and `down` instructions and a unique `name`.
@@ -144,7 +143,7 @@ data Migration io schemas0 schemas1 = Migration
 -- query to see if the `Migration` is executed. If not, then
 -- execute the `Migration` and insert its row in the `MigrationsTable`.
 migrateUp
-  :: MonadBaseControl IO io
+  :: MonadUnliftIO io
   => AlignedList (Migration io) schemas0 schemas1 -- ^ migrations to run
   -> PQ
     ("migrations" ::: MigrationsSchema ': schemas0)
@@ -157,7 +156,7 @@ migrateUp migration =
   where
 
     upMigrations
-      :: MonadBaseControl IO io
+      :: MonadUnliftIO io
       => AlignedList (Migration io) schemas0 schemas1
       -> PQ
         ("migrations" ::: MigrationsSchema ': schemas0)
@@ -168,7 +167,7 @@ migrateUp migration =
       step :>> steps -> upMigration step & pqThen (upMigrations steps)
 
     upMigration
-      :: MonadBase IO io
+      :: MonadIO io
       => Migration io schemas0 schemas1 -> PQ
         ("migrations" ::: MigrationsSchema ': schemas0)
         ("migrations" ::: MigrationsSchema ': schemas1)
@@ -185,7 +184,7 @@ migrateUp migration =
             & pqBind okResult)
 
     queryExecuted
-      :: MonadBase IO io
+      :: MonadIO io
       => Migration io schemas0 schemas1 -> PQ
         ("migrations" ::: MigrationsSchema ': schemas0)
         ("migrations" ::: MigrationsSchema ': schemas0)
@@ -200,7 +199,7 @@ migrateUp migration =
 -- query to see if the `Migration` is executed. If it is, then
 -- rewind the `Migration` and delete its row in the `MigrationsTable`.
 migrateDown
-  :: MonadBaseControl IO io
+  :: MonadUnliftIO io
   => AlignedList (Migration io) schemas0 schemas1 -- ^ migrations to rewind
   -> PQ
     ("migrations" ::: MigrationsSchema ': schemas1)
@@ -213,7 +212,7 @@ migrateDown migrations =
   where
 
     downMigrations
-      :: MonadBaseControl IO io
+      :: MonadUnliftIO io
       => AlignedList (Migration io) schemas0 schemas1 -> PQ
         ("migrations" ::: MigrationsSchema ': schemas1)
         ("migrations" ::: MigrationsSchema ': schemas0)
@@ -223,7 +222,7 @@ migrateDown migrations =
       step :>> steps -> downMigrations steps & pqThen (downMigration step)
 
     downMigration
-      :: MonadBase IO io
+      :: MonadIO io
       => Migration io schemas0 schemas1 -> PQ
         ("migrations" ::: MigrationsSchema ': schemas1)
         ("migrations" ::: MigrationsSchema ': schemas0)
@@ -240,7 +239,7 @@ migrateDown migrations =
             & pqBind okResult)
 
     queryExecuted
-      :: MonadBase IO io
+      :: MonadIO io
       => Migration io schemas0 schemas1 -> PQ
         ("migrations" ::: MigrationsSchema ': schemas1)
         ("migrations" ::: MigrationsSchema ': schemas1)
@@ -250,7 +249,7 @@ migrateDown migrations =
       okResult result
       ntuples result
 
-okResult :: MonadBase IO io => K Result results -> PQ schema schema io ()
+okResult :: MonadIO io => K Result results -> PQ schema schema io ()
 okResult result = do
   status <- resultStatus result
   when (not (status `elem` [CommandOk, TuplesOk])) $ do
@@ -355,7 +354,7 @@ displayUsage = do
 
 type RunMigrationName = Text
 
-getRunMigrationNames :: (MonadBase IO m) => PQ db0 db0 m [RunMigrationName]
+getRunMigrationNames :: (MonadIO m) => PQ db0 db0 m [RunMigrationName]
 getRunMigrationNames =
   fmap migrationName <$> (unsafePQ (define createMigrations & pqThen (runQuery fetchAllMigrations)) >>= getRows)
 
@@ -388,7 +387,7 @@ performCommand connectTo migrations Display =
     runNames <- getRunMigrationNames
     let names = extractList name migrations
         unrunNames = names \\ runNames
-    liftBase $ displayRunned runNames >> displayUnrunned unrunNames
+    liftIO $ displayRunned runNames >> displayUnrunned unrunNames
 performCommand connectTo migrations AllUp =
   withConnection connectTo (migrateUp migrations)
   >> performCommand connectTo migrations Display

--- a/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
@@ -24,6 +24,7 @@ of executing Squeal commands.
   , FunctionalDependencies
   , FlexibleContexts
   , FlexibleInstances
+  , InstanceSigs
   , OverloadedStrings
   , RankNTypes
   , ScopedTypeVariables
@@ -69,11 +70,10 @@ module Squeal.PostgreSQL.PQ
   , handleSqueal
   ) where
 
-import Control.Exception.Lifted
-import Control.Monad.Base
+import Control.Exception (Exception, throw)
 import Control.Monad.Except
 import Control.Monad.Morph
-import Control.Monad.Trans.Control
+import UnliftIO (MonadUnliftIO (..), bracket, catch, handle)
 import Data.ByteString (ByteString)
 import Data.Foldable
 import Data.Function ((&))
@@ -132,19 +132,19 @@ with the wrong schema!
 -}
 connectdb
   :: forall schemas io
-   . MonadBase IO io
+   . MonadIO io
   => ByteString -- ^ conninfo
   -> io (K LibPQ.Connection schemas)
-connectdb = fmap K . liftBase . LibPQ.connectdb
+connectdb = fmap K . liftIO . LibPQ.connectdb
 
 -- | Closes the connection to the server.
-finish :: MonadBase IO io => K LibPQ.Connection schemas -> io ()
-finish = liftBase . LibPQ.finish . unK
+finish :: MonadIO io => K LibPQ.Connection schemas -> io ()
+finish = liftIO . LibPQ.finish . unK
 
 -- | Do `connectdb` and `finish` before and after a computation.
 withConnection
   :: forall schemas0 schemas1 io x
-   . MonadBaseControl IO io
+   . MonadUnliftIO io
   => ByteString
   -> PQ schemas0 schemas1 io x
   -> io x
@@ -253,7 +253,7 @@ class IndexedMonadTransPQ pq where
   --
   -- @define statement1 & pqThen (define statement2) = define (statement1 >>> statement2)@
   define
-    :: MonadBase IO io
+    :: MonadIO io
     => Definition schemas0 schemas1
     -> pq schemas0 schemas1 io (K LibPQ.Result '[])
 
@@ -273,7 +273,7 @@ instance IndexedMonadTransPQ PQ where
     return $ K x
 
   define (UnsafeDefinition q) = PQ $ \ (K conn) -> do
-    resultMaybe <- liftBase $ LibPQ.exec conn q
+    resultMaybe <- liftIO $ LibPQ.exec conn q
     case resultMaybe of
       Nothing -> throw $ ResultException
         "define: LibPQ.exec returned no results"
@@ -392,7 +392,7 @@ class Monad pq => MonadPQ schemas pq | pq -> schemas where
     => (LibPQ.Connection -> IO a) -> pq a
   liftPQ = lift . liftPQ
 
-instance (MonadBase IO io, schemas0 ~ schemas, schemas1 ~ schemas)
+instance (MonadIO io, schemas0 ~ schemas, schemas1 ~ schemas)
   => MonadPQ schemas (PQ schemas0 schemas1 io) where
 
   manipulateParams
@@ -403,7 +403,7 @@ instance (MonadBase IO io, schemas0 ~ schemas, schemas1 ~ schemas)
             (LibPQ.invalidOid, encodingBytes encoding, LibPQ.Binary)
           params' = fmap (fmap toParam') (hcollapse (toParams @x @ps params))
           q' = q <> ";"
-        resultMaybe <- liftBase $ LibPQ.execParams conn q' params' LibPQ.Binary
+        resultMaybe <- liftIO $ LibPQ.execParams conn q' params' LibPQ.Binary
         case resultMaybe of
           Nothing -> throw $ ResultException
             "manipulateParams: LibPQ.execParams returned no results"
@@ -413,7 +413,7 @@ instance (MonadBase IO io, schemas0 ~ schemas, schemas1 ~ schemas)
 
   traversePrepared
     (UnsafeManipulation q :: Manipulation '[] schemas xs ys) (list :: list x) =
-      PQ $ \ (K conn) -> liftBase $ do
+      PQ $ \ (K conn) -> liftIO $ do
         let temp = "temporary_statement"
         prepResultMaybe <- LibPQ.prepare conn temp q Nothing
         case prepResultMaybe of
@@ -440,7 +440,7 @@ instance (MonadBase IO io, schemas0 ~ schemas, schemas1 ~ schemas)
 
   traversePrepared_
     (UnsafeManipulation q :: Manipulation '[] schemas xs '[]) (list :: list x) =
-      PQ $ \ (K conn) -> liftBase $ do
+      PQ $ \ (K conn) -> liftIO $ do
         let temp = "temporary_statement"
         prepResultMaybe <- LibPQ.prepare conn temp q Nothing
         case prepResultMaybe of
@@ -464,7 +464,7 @@ instance (MonadBase IO io, schemas0 ~ schemas, schemas1 ~ schemas)
         return (K ())
 
   liftPQ pq = PQ $ \ (K conn) -> do
-    y <- liftBase $ pq conn
+    y <- liftIO $ pq conn
     return (K y)
 
 instance MonadPQ schemas m => MonadPQ schemas (IdentityT m)
@@ -505,13 +505,18 @@ instance schemas0 ~ schemas1 => MMonad (PQ schemas0 schemas1) where
   embed f (PQ pq) = PQ $ \ conn -> do
     evalPQ (f (pq conn)) conn
 
-instance (MonadBase b m, schemas0 ~ schemas1)
-  => MonadBase b (PQ schemas0 schemas1 m) where
-  liftBase = lift . liftBase
-
 instance (MonadIO m, schema0 ~ schema1)
   => MonadIO (PQ schema0 schema1 m) where
   liftIO = lift . liftIO
+
+instance (MonadUnliftIO m, schemas0 ~ schemas1)
+  => MonadUnliftIO (PQ schemas0 schemas1 m) where
+  withRunInIO
+      :: ((forall a . PQ schemas0 schema1 m a -> IO a) -> IO b)
+      -> PQ schemas0 schema1 m b
+  withRunInIO inner = PQ $ \conn ->
+    withRunInIO $ \(run :: (forall x . m x -> IO x)) ->
+      K <$> inner (\pq -> run $ unK <$> unPQ pq conn)
 
 -- | A snapshot of the state of a `PQ` computation.
 type PQRun schemas =
@@ -522,23 +527,16 @@ pqliftWith :: Functor m => (PQRun schemas -> m a) -> PQ schemas schemas m a
 pqliftWith f = PQ $ \ conn ->
   fmap K (f $ \ pq -> unPQ pq conn)
 
-instance (MonadBaseControl b m, schemas0 ~ schemas1)
-  => MonadBaseControl b (PQ schemas0 schemas1 m) where
-  type StM (PQ schemas0 schemas1 m) x = StM m (K x schemas0)
-  liftBaseWith f =
-    pqliftWith $ \ run -> liftBaseWith $ \ runInBase -> f $ runInBase . run
-  restoreM = PQ . const . restoreM
-
 -- | Get a row corresponding to a given row number from a `LibPQ.Result`,
 -- throwing an exception if the row number is out of bounds.
 getRow
-  :: (FromRow columns y, MonadBase IO io)
+  :: (FromRow columns y, MonadIO io)
   => LibPQ.Row
   -- ^ row number
   -> K LibPQ.Result columns
   -- ^ result
   -> io y
-getRow r (K result :: K LibPQ.Result columns) = liftBase $ do
+getRow r (K result :: K LibPQ.Result columns) = liftIO $ do
   numRows <- LibPQ.ntuples result
   when (numRows < r) $ throw $ ResultException $
     "getRow: expected at least " <> pack (show r) <> "rows but only saw "
@@ -556,13 +554,13 @@ getRow r (K result :: K LibPQ.Result columns) = liftBase $ do
 -- and a `LibPQ.Result` and given a row number if it's too large returns `Nothing`,
 -- otherwise returning the row along with the next row number.
 nextRow
-  :: (FromRow columns y, MonadBase IO io)
+  :: (FromRow columns y, MonadIO io)
   => LibPQ.Row -- ^ total number of rows
   -> K LibPQ.Result columns -- ^ result
   -> LibPQ.Row -- ^ row number
   -> io (Maybe (LibPQ.Row,y))
 nextRow total (K result :: K LibPQ.Result columns) r
-  = liftBase $ if r >= total then return Nothing else do
+  = liftIO $ if r >= total then return Nothing else do
     let len = fromIntegral (lengthSList (Proxy @columns))
     row' <- traverse (LibPQ.getvalue result r) [0 .. len - 1]
     case fromList row' of
@@ -573,10 +571,10 @@ nextRow total (K result :: K LibPQ.Result columns) r
 
 -- | Get all rows from a `LibPQ.Result`.
 getRows
-  :: (FromRow columns y, MonadBase IO io)
+  :: (FromRow columns y, MonadIO io)
   => K LibPQ.Result columns -- ^ result
   -> io [y]
-getRows (K result :: K LibPQ.Result columns) = liftBase $ do
+getRows (K result :: K LibPQ.Result columns) = liftIO $ do
   let len = fromIntegral (lengthSList (Proxy @columns))
   numRows <- LibPQ.ntuples result
   for [0 .. numRows - 1] $ \ r -> do
@@ -589,10 +587,10 @@ getRows (K result :: K LibPQ.Result columns) = liftBase $ do
 
 -- | Get the first row if possible from a `LibPQ.Result`.
 firstRow
-  :: (FromRow columns y, MonadBase IO io)
+  :: (FromRow columns y, MonadIO io)
   => K LibPQ.Result columns -- ^ result
   -> io (Maybe y)
-firstRow (K result :: K LibPQ.Result columns) = liftBase $ do
+firstRow (K result :: K LibPQ.Result columns) = liftIO $ do
   numRows <- LibPQ.ntuples result
   if numRows <= 0 then return Nothing else do
     let len = fromIntegral (lengthSList (Proxy @columns))
@@ -605,23 +603,23 @@ firstRow (K result :: K LibPQ.Result columns) = liftBase $ do
 
 -- | Lifts actions on results from @LibPQ@.
 liftResult
-  :: MonadBase IO io
+  :: MonadIO io
   => (LibPQ.Result -> IO x)
   -> K LibPQ.Result results -> io x
-liftResult f (K result) = liftBase $ f result
+liftResult f (K result) = liftIO $ f result
 
 -- | Returns the number of rows (tuples) in the query result.
-ntuples :: MonadBase IO io => K LibPQ.Result columns -> io LibPQ.Row
+ntuples :: MonadIO io => K LibPQ.Result columns -> io LibPQ.Row
 ntuples = liftResult LibPQ.ntuples
 
 -- | Returns the result status of the command.
-resultStatus :: MonadBase IO io => K LibPQ.Result results -> io LibPQ.ExecStatus
+resultStatus :: MonadIO io => K LibPQ.Result results -> io LibPQ.ExecStatus
 resultStatus = liftResult LibPQ.resultStatus
 
 -- | Returns the error message most recently generated by an operation
 -- on the connection.
 resultErrorMessage
-  :: MonadBase IO io => K LibPQ.Result results -> io (Maybe ByteString)
+  :: MonadIO io => K LibPQ.Result results -> io (Maybe ByteString)
 resultErrorMessage = liftResult LibPQ.resultErrorMessage
 
 -- | Returns the error code most recently generated by an operation
@@ -629,7 +627,7 @@ resultErrorMessage = liftResult LibPQ.resultErrorMessage
 --
 -- https://www.postgresql.org/docs/current/static/errcodes-appendix.html
 resultErrorCode
-  :: MonadBase IO io
+  :: MonadIO io
   => K LibPQ.Result results
   -> io (Maybe ByteString)
 resultErrorCode = liftResult (flip LibPQ.resultErrorField LibPQ.DiagSqlstate)
@@ -648,10 +646,10 @@ data SquealException
 instance Exception SquealException
 
 tryResult
-  :: MonadBase IO io
+  :: MonadIO io
   => LibPQ.Result
   -> io ()
-tryResult result = liftBase $ do
+tryResult result = liftIO $ do
   status <- LibPQ.resultStatus result
   case status of
     LibPQ.CommandOk -> return ()
@@ -663,7 +661,7 @@ tryResult result = liftBase $ do
 
 -- | Catch `SquealException`s.
 catchSqueal
-  :: MonadBaseControl IO io
+  :: MonadUnliftIO io
   => io a
   -> (SquealException -> io a) -- ^ handler
   -> io a
@@ -671,7 +669,7 @@ catchSqueal = catch
 
 -- | Handle `SquealException`s.
 handleSqueal
-  :: MonadBaseControl IO io
+  :: MonadUnliftIO io
   => (SquealException -> io a) -- ^ handler
   -> io a -> io a
 handleSqueal = handle

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Render.hs
@@ -38,7 +38,7 @@ module Squeal.PostgreSQL.Render
   , printSQL
   ) where
 
-import Control.Monad.Base
+import Control.Monad.IO.Class (MonadIO (..))
 import Data.ByteString (ByteString)
 import Data.Maybe (catMaybes)
 import Data.Monoid ((<>))
@@ -126,5 +126,5 @@ renderSymbol = fromString (symbolVal' (proxy# :: Proxy# s))
 class RenderSQL sql where renderSQL :: sql -> ByteString
 
 -- | Print SQL.
-printSQL :: (RenderSQL sql, MonadBase IO io) => sql -> io ()
-printSQL = liftBase . Char8.putStrLn . renderSQL
+printSQL :: (RenderSQL sql, MonadIO io) => sql -> io ()
+printSQL = liftIO . Char8.putStrLn . renderSQL

--- a/squeal-postgresql/test/Specs/ExceptionHandling.hs
+++ b/squeal-postgresql/test/Specs/ExceptionHandling.hs
@@ -16,7 +16,7 @@ module ExceptionHandling
 where
 
 import           Control.Monad               (void)
-import           Control.Monad.Base          (MonadBase)
+import Control.Monad.IO.Class (MonadIO (..))
 import qualified Data.ByteString.Char8       as Char8
 import           Data.Int                    (Int16)
 import           Data.Text                   (Text)
@@ -103,10 +103,10 @@ connectionString = "host=localhost port=5432 dbname=exampledb"
 testUser :: User
 testUser = User "TestUser" Nothing (VarArray [])
 
-newUser :: (MonadBase IO m, MonadPQ Schemas m) => User -> m ()
+newUser :: (MonadIO m, MonadPQ Schemas m) => User -> m ()
 newUser u = void $ manipulateParams insertUser (userName u, userVec u)
 
-insertUserTwice :: (MonadBase IO m, MonadPQ Schemas m) => m ()
+insertUserTwice :: (MonadIO m, MonadPQ Schemas m) => m ()
 insertUserTwice = newUser testUser >> newUser testUser
 
 specs :: SpecWith ()

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,6 @@
 resolver: lts-13.8
 packages:
 - squeal-postgresql
+
+extra-deps:
+- unliftio-pool-0.2.1.0


### PR DESCRIPTION
Resolves #109 

This is my attempt to move away from `MonadBaseControl` to `MonadUnliftIO`. Let me know what do you think! What can be done further:

1. Add `MonadUnliftIO` instance for `PoolPQ`
2. Replace all usages of `MonadBase IO` with `MonadIO` (because they are essentially the same thing but `MonadIO` is much simpler).

I didn't remove helper functions that can help to create `MonadBaseControl` instances in order to simplify migration for the existing users.