### PR TITLE
Simplify migration signatures

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -143,11 +143,8 @@ module Squeal.PostgreSQL.Migration
   , Terminally (..)
   , terminally
   , pureMigration
-    -- * Migrations table
   , MigrationsTable
-   -- * CLI
   , defaultMain
-  , MigrateCommand (..)
   ) where
 
 import           Control.Category
@@ -386,6 +383,8 @@ data MigrateCommand
   | MigrateUp
   | MigrateDown deriving (GHC.Generic, Show)
 
+{- | `defaultMain` creates a simple executable
+from a connection string and a list of `Migration`s. -}
 defaultMain
   :: Migratory p
   => ByteString

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -130,6 +130,7 @@ module Squeal.PostgreSQL.Migration
     Migration (..)
   , Unital
   , unitally
+  , pureMigration
   , Migratory (..)
     -- * Migration table
   , MigrationsTable

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -161,6 +161,8 @@ import           Squeal.PostgreSQL
 import           System.Environment
 
 -- | A `Migration` is a named "isomorphism" over a given category.
+-- It should contain an inverse pair of `up` and `down`
+-- instructions and a unique `name`.
 data Migration p schemas0 schemas1 = Migration
   { name :: Text -- ^ The `name` of a `Migration`.
     -- Each `name` in a `Migration` should be unique.

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -118,8 +118,7 @@ module Squeal.PostgreSQL.Migration
     Migration (..)
   , Unital
   , unitally
-  , migrateUp
-  , migrateDown
+  , Migratory (..)
     -- * Migration table
   , MigrationsTable
   , createMigrations

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Migration.hs
@@ -81,21 +81,33 @@ Rollback
 We can also create a simple executable using `defaultMain`.
 
 >>> let main = defaultMain "host=localhost port=5432 dbname=exampledb" migrations
+
 >>> withArgs [] main
 Invalid command: "". Use:
 migrate    to run all available migrations
 rollback   to rollback all available migrations
 status     to display migrations run and migrations left to run
+
 >>> withArgs ["status"] main
 Migrations already run:
   None
 Migrations left to run:
   - make users table
   - make emails table
+
 >>> withArgs ["migrate"] main
-asdf
+Migrations already run:
+  - make users table
+  - make emails table
+Migrations left to run:
+  None
+
 >>> withArgs ["rollback"] main
-asdf
+Migrations already run:
+  None
+Migrations left to run:
+  - make users table
+  - make emails table
 -}
 {-# LANGUAGE
     DataKinds

--- a/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/PQ.hs
@@ -202,8 +202,7 @@ evalPQ (PQ pq) conn = unK <$> pq conn
 -- [enriched category](https://ncatlab.org/nlab/show/enriched+category).
 -- An indexed monad transformer transforms a `Monad` into an indexed monad.
 -- And, `IndexedMonadTransPQ` is a class for indexed monad transformers that
--- support running `Definition`s using `define` and embedding a computation
--- in a larger schema using `pqEmbed`.
+-- support running `Definition`s using `define`.
 class IndexedMonadTransPQ pq where
 
   -- | indexed analog of `<*>`
@@ -243,12 +242,6 @@ class IndexedMonadTransPQ pq where
     -> x -> pq schemas0 schemas2 m z
   pqAndThen g f x = pqBind g (f x)
 
-  -- | Safely embed a computation in a larger schema.
-  pqEmbed
-    :: Monad m
-    => pq schemas0 schemas1 m x
-    -> pq (schema ': schemas0) (schema : schemas1) m x
-
   -- | Run a `Definition` with `LibPQ.exec`, we expect that libpq obeys the law
   --
   -- @define statement1 & pqThen (define statement2) = define (statement1 >>> statement2)@
@@ -267,10 +260,6 @@ instance IndexedMonadTransPQ PQ where
   pqBind f (PQ x) = PQ $ \ conn -> do
     K x' <- x conn
     unPQ (f x') (K (unK conn))
-
-  pqEmbed (PQ pq) = PQ $ \ (K conn) -> do
-    K x <- pq (K conn)
-    return $ K x
 
   define (UnsafeDefinition q) = PQ $ \ (K conn) -> do
     resultMaybe <- liftBase $ LibPQ.exec conn q

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Schema.hs
@@ -78,8 +78,9 @@ module Squeal.PostgreSQL.Schema
   , GroupedBy
     -- * Aligned lists
   , AlignedList (..)
-  , extractList
   , single
+  , extractList
+  , alignedMap
     -- * Data Definitions
   , Create
   , Drop
@@ -703,9 +704,6 @@ There are several reasons why one might want to use schemas:
 -}
 type SchemasType = [(Symbol,SchemaType)]
 
-{-|
-
--}
 type family Public (schema :: SchemaType) :: SchemasType
   where Public schema = '["public" ::: schema]
 
@@ -755,6 +753,14 @@ extractList :: (forall a0 a1. p a0 a1 -> b) -> AlignedList p x0 x1 -> [b]
 extractList f = \case
   Done -> []
   step :>> steps -> (f step):extractList f steps
+
+alignedMap
+  :: (forall z0 z1. p z0 z1 -> q z0 z1)
+  -> AlignedList p x0 x1
+  -> AlignedList q x0 x1
+alignedMap f = \case
+  Done -> Done
+  x :>> xs -> f x :>> alignedMap f xs
 
 -- | A `single` step.
 single :: p x0 x1 -> AlignedList p x0 x1

--- a/squeal-postgresql/test/Specs/ExceptionHandling.hs
+++ b/squeal-postgresql/test/Specs/ExceptionHandling.hs
@@ -82,10 +82,10 @@ setup =
 teardown :: Definition Schemas (Public '[])
 teardown = dropTable #emails >>> dropTable #users
 
-migration :: Migration IO (Public '[]) Schemas
+migration :: Migration Definition (Public '[]) Schemas
 migration = Migration { name = "test"
-                      , up = void $ define setup
-                      , down = void $ define teardown }
+                      , up = setup
+                      , down = teardown }
 
 setupDB :: IO ()
 setupDB = void . withConnection connectionString $


### PR DESCRIPTION
* Change the signatures of `migrateUp` and `migrateDown` to be more interoperable with sessions
* Remain compatible with Squeal 0.4 by putting the `schema_migrations` table back in the `public` schema.
* Add doctests for `defaultMain`
* Enable both pure and impure migrations with `Migratory` typeclass and `Terminally` newtype.
