### PR TITLE
Make `sum` aggregate returns a nullable value

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Aggregate.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Aggregate.hs
@@ -79,7 +79,7 @@ class Aggregate expr1 exprN aggr
 
   -- | >>> :{
   -- let
-  --   expression :: Expression '[] commons ('Grouped bys) schemas params '[tab ::: '["col" ::: 'Null 'PGnumeric]] ('NotNull 'PGnumeric)
+  --   expression :: Expression '[] commons ('Grouped bys) schemas params '[tab ::: '["col" ::: 'Null 'PGnumeric]] ('Null 'PGnumeric)
   --   expression = sum_ (Distinct #col)
   -- in printSQL expression
   -- :}
@@ -87,7 +87,7 @@ class Aggregate expr1 exprN aggr
   sum_
     :: ty `In` PGNum
     => expr1 (null ty)
-    -> aggr ('NotNull ty)
+    -> aggr ('Null ty)
 
   -- | input values, including nulls, concatenated into an array
   arrayAgg


### PR DESCRIPTION
I suspect this is a typo, but in case this requires some justification, here's an exceprt from [PostgreSQL documentation](https://www.postgresql.org/docs/11/functions-aggregate.html) - emphasis is mine :

> It should be noted that except for count, these functions return a null value when no rows are selected. **In particular, sum of no rows returns null, not zero as one might expect**, and array_agg returns null rather than an empty array when there are no input rows. The coalesce function can be used to substitute zero or an empty array for null when necessary.

So the `sum` aggregate should not return a `null` column - over aggregates seem to have the proper return, but sum did not. This PR fixes this.

__Edit__: fixed tests broken by the signature change. I opted for a simple COALESCE - well, `fromNull` to make sure sums would return 0. I suppose this idiom, which I suspect is rather frequent, could also be given as a predefined function in Squeal.