### PR TITLE
Rewrite of connection pools

### DIFF
--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -98,6 +98,7 @@ test-suite squeal-postgresql-specs
   other-modules: ExceptionHandling
   build-depends:
       base >= 4.10.0.0
+    , async >= 2.2.2
     , bytestring >= 0.10.8.2
     , generics-sop >= 0.3.1.0
     , hspec >= 2.4.8

--- a/squeal-postgresql/src/Squeal/PostgreSQL.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL.hs
@@ -217,6 +217,7 @@ import Squeal.PostgreSQL.List as X
 import Squeal.PostgreSQL.Manipulation as X
 import Squeal.PostgreSQL.Migration as X
 import Squeal.PostgreSQL.PG as X
+import Squeal.PostgreSQL.Pool as X
 import Squeal.PostgreSQL.PQ as X
 import Squeal.PostgreSQL.Query as X
 import Squeal.PostgreSQL.Render (RenderSQL(..), printSQL)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Pool.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Pool.hs
@@ -1,11 +1,33 @@
 {-|
-Module: Squeal.PostgreSQL.Definition
-Description: Pooled connections
+Module: Squeal.PostgreSQL.Pool
+Description: Connection pools
 Copyright: (c) Eitan Chatav, 2017
 Maintainer: eitan@morphism.tech
 Stability: experimental
 
-A `MonadPQ` for pooled connections.
+Connection pools.
+
+Typical use case would be to create your pool using `createConnectionPool`
+and run anything that requires the pool connection with `useConnectionPool`.
+
+Here's a simplified example:
+
+>>> import Squeal.PostgreSQL
+
+>>> :{
+do
+  let
+    query :: Query_ (Public '[]) () (Only Char)
+    query = values_ (literal 'a' `as` #fromOnly)
+  pool <- createConnectionPool "host=localhost port=5432 dbname=exampledb" 1 0.5 10
+  chr <- useConnectionPool pool $ do
+    result <- runQuery query
+    Just (Only a) <- firstRow result
+    return a
+  destroyConnectionPool pool
+  putChar chr
+:}
+a
 -}
 
 {-# LANGUAGE
@@ -23,51 +45,19 @@ A `MonadPQ` for pooled connections.
 
 module Squeal.PostgreSQL.Pool
   ( -- * Pools
-    PoolPQ (..)
+    Pool
   , createConnectionPool
-  , Pool
-  , destroyAllResources
+  , useConnectionPool
+  , destroyConnectionPool
   ) where
 
-import Control.Monad.Trans
 import Data.ByteString
 import Data.Time
-import Generics.SOP (K(..))
+import Generics.SOP (K(..), unK)
 import UnliftIO (MonadUnliftIO (..))
 import UnliftIO.Pool (Pool, createPool, destroyAllResources, withResource)
 
-import qualified Control.Monad.Fail as Fail
-
 import Squeal.PostgreSQL.PQ
-import Squeal.PostgreSQL.Schema
-
-{- | `PoolPQ` @schemas@ should be a drop-in replacement for `PQ` @schemas schemas@.
-
-Typical use case would be to create your pool using `createConnectionPool` and run anything that requires the pool connection with it.
-
-Here's a simplified example:
-
->>> import Squeal.PostgreSQL
->>> :{
-do
-  let
-    query :: Query_ (Public '[]) () (Only Char)
-    query = values_ $ literal 'a' `as` #fromOnly
-    session :: PoolPQ (Public '[]) IO Char
-    session = do
-      result <- runQuery query
-      Just (Only chr) <- firstRow result
-      return chr
-  pool <- createConnectionPool "host=localhost port=5432 dbname=exampledb" 1 0.5 10
-  chr <- runPoolPQ session pool
-  destroyAllResources pool
-  putChar chr
-:}
-a
--}
-newtype PoolPQ (schemas :: SchemasType) m x =
-  PoolPQ { runPoolPQ :: Pool (K Connection schemas) -> m x }
-  deriving Functor
 
 -- | Create a striped pool of connections.
 -- Although the garbage collector will destroy all idle connections when the pool is garbage collected it's recommended to manually `destroyAllResources` when you're done with the pool so that the connections are freed up as soon as possible.
@@ -92,63 +82,31 @@ createConnectionPool
 createConnectionPool conninfo stripes idle maxResrc =
   createPool (connectdb conninfo) finish stripes idle maxResrc
 
--- | `Applicative` instance for `PoolPQ`.
-instance Monad m => Applicative (PoolPQ schemas m) where
-  pure x = PoolPQ $ \ _ -> pure x
-  PoolPQ f <*> PoolPQ x = PoolPQ $ \ pool -> do
-    f' <- f pool
-    x' <- x pool
-    return $ f' x'
+useConnectionPool
+  :: MonadUnliftIO io
+  => Pool (K Connection schemas) -- ^ pool
+  -> PQ schemas schemas io x -- ^ session
+  -> io x
+useConnectionPool pool (PQ session) = unK <$> withResource pool session
 
--- | `Monad` instance for `PoolPQ`.
-instance Monad m => Monad (PoolPQ schemas m) where
-  return = pure
-  PoolPQ x >>= f = PoolPQ $ \ pool -> do
-    x' <- x pool
-    runPoolPQ (f x') pool
+{- |
+Destroy all connections in all stripes in the pool.
+Note that this will ignore any exceptions in the destroy function.
 
--- | `Fail.MonadFail` instance for `PoolPQ`.
-instance Monad m => Fail.MonadFail (PoolPQ schemas m) where
-  fail = Fail.fail
+This function is useful when you detect that all connections
+in the pool are broken. For example after a database has been
+restarted all connections opened before the restart will be broken.
+In that case it's better to close those connections so that
+`useConnectionPool` won't take a broken connection from the pool
+but will open a new connection instead.
 
--- | `MonadTrans` instance for `PoolPQ`.
-instance MonadTrans (PoolPQ schemas) where
-  lift m = PoolPQ $ \ _pool -> m
-
--- | `MonadPQ` instance for `PoolPQ`.
-instance MonadUnliftIO io => MonadPQ schemas (PoolPQ schemas io) where
-  manipulateParams manipulation params = PoolPQ $ \ pool -> do
-    withResource pool $ \ conn -> do
-      (K result :: K (K Result ys) schemas) <- flip unPQ conn $
-        manipulateParams manipulation params
-      return result
-  traversePrepared manipulation params = PoolPQ $ \ pool ->
-    withResource pool $ \ conn -> do
-      (K result :: K (list (K Result ys)) schemas) <- flip unPQ conn $
-        traversePrepared manipulation params
-      return result
-  traversePrepared_ manipulation params = PoolPQ $ \ pool -> do
-    withResource pool $ \ conn -> do
-      (_ :: K () schemas) <- flip unPQ conn $
-        traversePrepared_ manipulation params
-      return ()
-  liftPQ m = PoolPQ $ \ pool ->
-    withResource pool $ \ conn -> do
-      (K result :: K result schemas) <- flip unPQ conn $
-        liftPQ m
-      return result
-
--- | 'MonadIO' instance for 'PoolPQ'.
-instance (MonadIO m)
-  => MonadIO (PoolPQ schemas m) where
-  liftIO = lift . liftIO
-
--- | 'MonadUnliftIO' instance for 'PoolPQ'.
-instance (MonadUnliftIO m)
-  => MonadUnliftIO (PoolPQ schemas m) where
-  withRunInIO
-      :: ((forall a . PoolPQ schemas m a -> IO a) -> IO b)
-      -> PoolPQ schemas m b
-  withRunInIO inner = PoolPQ $ \pool ->
-    withRunInIO $ \(run :: (forall x . m x -> IO x)) ->
-      inner (\poolpq -> run $ runPoolPQ poolpq pool)
+Another use-case for this function is that when you know you are done
+with the pool you can destroy all idle connections immediately
+instead of waiting on the garbage collector to destroy them,
+thus freeing up those connections sooner.
+-}
+destroyConnectionPool
+  :: MonadUnliftIO io
+  => Pool (K Connection schemas) -- ^ pool
+  -> io ()
+destroyConnectionPool = destroyAllResources

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Pool.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Pool.hs
@@ -82,6 +82,16 @@ createConnectionPool
 createConnectionPool conninfo stripes idle maxResrc =
   createPool (connectdb conninfo) finish stripes idle maxResrc
 
+{-|
+Temporarily take a connection from a `Pool`, perform an action with it,
+and return it to the pool afterwards.
+
+If the pool has an idle connection available, it is used immediately.
+Otherwise, if the maximum number of connections has not yet been reached,
+a new connection is created and used.
+If the maximum number of connections has been reached, this function blocks
+until a connection becomes available.
+-}
 usingConnectionPool
   :: MonadUnliftIO io
   => Pool (K Connection schemas) -- ^ pool

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Pool.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Pool.hs
@@ -8,7 +8,7 @@ Stability: experimental
 Connection pools.
 
 Typical use case would be to create your pool using `createConnectionPool`
-and run anything that requires the pool connection with `useConnectionPool`.
+and run anything that requires the pool connection with `usingConnectionPool`.
 
 Here's a simplified example:
 
@@ -20,7 +20,7 @@ do
     query :: Query_ (Public '[]) () (Only Char)
     query = values_ (literal 'a' `as` #fromOnly)
   pool <- createConnectionPool "host=localhost port=5432 dbname=exampledb" 1 0.5 10
-  chr <- useConnectionPool pool $ do
+  chr <- usingConnectionPool pool $ do
     result <- runQuery query
     Just (Only a) <- firstRow result
     return a
@@ -47,7 +47,7 @@ module Squeal.PostgreSQL.Pool
   ( -- * Pools
     Pool
   , createConnectionPool
-  , useConnectionPool
+  , usingConnectionPool
   , destroyConnectionPool
   ) where
 
@@ -82,12 +82,12 @@ createConnectionPool
 createConnectionPool conninfo stripes idle maxResrc =
   createPool (connectdb conninfo) finish stripes idle maxResrc
 
-useConnectionPool
+usingConnectionPool
   :: MonadUnliftIO io
   => Pool (K Connection schemas) -- ^ pool
   -> PQ schemas schemas io x -- ^ session
   -> io x
-useConnectionPool pool (PQ session) = unK <$> withResource pool session
+usingConnectionPool pool (PQ session) = unK <$> withResource pool session
 
 {- |
 Destroy all connections in all stripes in the pool.
@@ -97,7 +97,7 @@ This function is useful when you detect that all connections
 in the pool are broken. For example after a database has been
 restarted all connections opened before the restart will be broken.
 In that case it's better to close those connections so that
-`useConnectionPool` won't take a broken connection from the pool
+`usingConnectionPool` won't take a broken connection from the pool
 but will open a new connection instead.
 
 Another use-case for this function is that when you know you are done

--- a/squeal-postgresql/test/Specs/ExceptionHandling.hs
+++ b/squeal-postgresql/test/Specs/ExceptionHandling.hs
@@ -132,7 +132,7 @@ specs = before_ setupDB $ after_ dropDB $
       let
         query :: Query_ (Public '[]) () (Only Char)
         query = values_ (literal 'a' `as` #fromOnly)
-        session = useConnectionPool pool . transactionally_ $ do
+        session = usingConnectionPool pool . transactionally_ $ do
           result <- runQuery query
           Just (Only chr) <- firstRow result
           return chr

--- a/squeal-postgresql/test/Specs/ExceptionHandling.hs
+++ b/squeal-postgresql/test/Specs/ExceptionHandling.hs
@@ -12,19 +12,21 @@
 module ExceptionHandling
   ( specs
   , User (..)
-  )
-where
+  ) where
 
-import           Control.Monad               (void)
+import Control.Concurrent.Async (replicateConcurrently)
+import Control.Monad (void)
 import Control.Monad.IO.Class (MonadIO (..))
-import qualified Data.ByteString.Char8       as Char8
-import           Data.Int                    (Int16)
-import           Data.Text                   (Text)
-import           Data.Vector                 (Vector)
-import qualified Generics.SOP                as SOP
-import qualified GHC.Generics                as GHC
-import           Squeal.PostgreSQL
-import           Test.Hspec
+import Data.Int (Int16)
+import Data.Text (Text)
+import Data.Vector (Vector)
+import Test.Hspec
+
+import qualified Data.ByteString.Char8 as Char8
+import qualified Generics.SOP as SOP
+import qualified GHC.Generics as GHC
+
+import Squeal.PostgreSQL
 
 type Schema =
   '[ "users" ::: 'Table (
@@ -123,3 +125,16 @@ specs = before_ setupDB $ after_ dropDB $
     it "should be rethrown for unique constraint violation in a manipulation by a transaction" $
       withConnection connectionString (transactionally_ insertUserTwice)
        `shouldThrow` (== dupKeyErr)
+
+    it "should handle concurrent transactions using pooled connections" $ do
+      pool <- createConnectionPool
+        "host=localhost port=5432 dbname=exampledb" 1 0.5 10
+      let
+        query :: Query_ (Public '[]) () (Only Char)
+        query = values_ (literal 'a' `as` #fromOnly)
+        session = useConnectionPool pool . transactionally_ $ do
+          result <- runQuery query
+          Just (Only chr) <- firstRow result
+          return chr
+      chrs <- replicateConcurrently 10 session
+      chrs `shouldSatisfy` (all (== 'a'))


### PR DESCRIPTION
Previously connection pools were handled by defining a `PoolPQ` monad with a `MonadPQ` instance. Turns out this was sort of dumb. What it did was run each query by taking a connection from the pool, running the query, and then returning the connection to the pool. This is _not_ what is usually expected in a real use case. In a real use case, like a web service, you probably want to use a single connection to serve an endpoint when it's called. This PR resolves #138.