### PR TITLE
Unrolled some type families

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/List.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/List.hs
@@ -84,7 +84,12 @@ infixl 9 *:
 -- | @Elem@ is a promoted `Data.List.elem`.
 type family Elem x xs where
   Elem x '[] = 'False
-  Elem x (x ': xs) = 'True
+  Elem x (x ': _) = 'True
+  Elem x (_ ': x ': _) = 'True
+  Elem x (_ ': _ ': x ': _) = 'True
+  Elem x (_ ': _ ': _ ': x ': _) = 'True
+  Elem x (_ ': _ ': _ ': _ ': x ': _) = 'True
+  Elem x (_ ': _ ': _ ': _ ': _ ': x ': _) = 'True
   Elem x (_ ': xs) = Elem x xs
 
 -- | @In x xs@ is a constraint that proves that @x@ is in @xs@.
@@ -99,5 +104,9 @@ Length '[Char,String,Bool,Double] :: Nat
 = 4
 -}
 type family Length (xs :: [k]) :: Nat where
-  Length (x : xs) = 1 + Length xs
+  Length (_ ': _ ': _ ': _ ': _ : xs) = 5 + Length xs
+  Length (_ ': _ ': _ ': _ : xs) = 4 + Length xs
+  Length (_ ': _ ': _ : xs) = 3 + Length xs
+  Length (_ ': _ : xs) = 2 + Length xs
+  Length (_ : xs) = 1 + Length xs
   Length '[] = 0

--- a/squeal-postgresql/src/Squeal/PostgreSQL/PG.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/PG.hs
@@ -178,8 +178,16 @@ type family RowPG (hask :: Type) :: RowType where
 
 -- | `RowOf` applies `NullPG` to the fields of a list.
 type family RowOf (record :: [(Symbol, Type)]) :: RowType where
-  RowOf '[] = '[]
+  RowOf (col ::: ty ': col1 ::: ty1 ': col2 ::: ty2 ': col3 ::: ty3 ': col4 ::: ty4 ': record) =
+    col ::: NullPG ty ': col1 ::: NullPG ty1 ': col2 ::: NullPG ty2 ': col3 ::: NullPG ty3 ': col4 ::: NullPG ty4 ': RowOf record
+  RowOf (col ::: ty ': col1 ::: ty1 ': col2 ::: ty2 ': col3 ::: ty3 ': record) =
+    col ::: NullPG ty ': col1 ::: NullPG ty1 ': col2 ::: NullPG ty2 ': col3 ::: NullPG ty3 ': RowOf record
+  RowOf (col ::: ty ': col1 ::: ty1 ': col2 ::: ty2 ': record) =
+    col ::: NullPG ty ': col1 ::: NullPG ty1 ': col2 ::: NullPG ty2 ': RowOf record
+  RowOf (col ::: ty ': col1 ::: ty1 ': record) =
+    col ::: NullPG ty ': col1::: NullPG ty1 ': RowOf record
   RowOf (col ::: ty ': record) = col ::: NullPG ty ': RowOf record
+  RowOf '[] = '[]
 
 {- | `NullPG` turns a Haskell type into a `NullityType`.
 
@@ -206,8 +214,17 @@ type family TuplePG (hask :: Type) :: [NullityType] where
 
 -- | `TupleOf` turns a list of Haskell `Type`s into a list of `NullityType`s.
 type family TupleOf (tuple :: [Type]) :: [NullityType] where
-  TupleOf '[] = '[]
+  TupleOf (hask ': hask1 ': hask2 ': hask3 ': hask4 ': hask5 ': tuple) =
+    NullPG hask ': NullPG hask1 ': NullPG hask2 ': NullPG hask3 ': NullPG hask4 ': NullPG hask5 ': TupleOf tuple
+  TupleOf (hask ': hask1 ': hask2 ': hask3 ': hask4 ': tuple) =
+    NullPG hask ': NullPG hask1 ': NullPG hask2 ': NullPG hask3 ': NullPG hask4 ': TupleOf tuple
+  TupleOf (hask ': hask1 ': hask2 ': hask3 ': tuple) =
+    NullPG hask ': NullPG hask1 ': NullPG hask2 ': NullPG hask3 ': TupleOf tuple
+  TupleOf (hask ': hask1 ': hask2 ': tuple) =
+    NullPG hask ': NullPG hask1 ': NullPG hask2 ': TupleOf tuple
+  TupleOf (hask ': hask1 ': tuple) = NullPG hask ': NullPG hask1 ': TupleOf tuple
   TupleOf (hask ': tuple) = NullPG hask ': TupleOf tuple
+  TupleOf '[] = '[]
 
 -- | `TupleCodeOf` takes the `SOP.Code` of a haskell `Type`
 -- and if it's a simple product returns it, otherwise giving a `TypeError`.


### PR DESCRIPTION
This should improve both compilation times and memory usage for large queries and tables.

This is super ugly but seems to work. This works around the way GHC currently handles recursive type families. Basically as far as I know when a type family matches one of the cases, it doesn't actually replace the types, but rather carries around the proofs, which consumes memory and makes things slower. What this PR should do is remove the amount and depth of carrying GHC should do.

I didn't tackle the more complicated type families yet.

Couldn't test actual performance since I don't have a large enough project using the latest version of squeal.

This whole thing could probably be done with TH, but I'm not familiar enough with it.

This might help with #28

@Raveline it would be great if you could test out if this PR helps at all.