### PR TITLE
Added benchmarks for DB queries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
       - run: stack upgrade && stack update
       - run: stack build --fast
       - run: stack test
+      - run: stack bench
       - run: stack haddock
       - save_cache:
           key: dependency-cache

--- a/squeal-postgresql/benchmarks/Main.hs
+++ b/squeal-postgresql/benchmarks/Main.hs
@@ -22,6 +22,8 @@ import           Gauge.Main.Options             ( defaultConfig
 import           GHC.Generics
 import qualified Generics.SOP                  as SOP
 import           Test.QuickCheck
+-- For CI
+import           Main.Utf8                      ( withUtf8 )
 -- For keeping a track of which question ID to query
 import           Data.Int                       ( Int64 )
 import           Data.IORef
@@ -91,7 +93,7 @@ main = do
             ]
         ]
 
-  defaultMain [queryRenderGroup, dbInsertsGroup, dbSelectsGroup]
+  withUtf8 $ defaultMain [queryRenderGroup, dbInsertsGroup, dbSelectsGroup]
 
 
 -- | Configure the benchmark to run only once (per IO action)

--- a/squeal-postgresql/benchmarks/Main.hs
+++ b/squeal-postgresql/benchmarks/Main.hs
@@ -13,9 +13,15 @@
 
 import           Squeal.PostgreSQL       hiding ( defaultMain )
 import           Gauge.Main
+import           Gauge.Main.Options             ( defaultConfig
+                                                , Config(..)
+                                                )
 import           GHC.Generics
 import qualified Generics.SOP                  as SOP
 import           Test.QuickCheck
+-- For keeping a track of which question ID to query
+import           Data.Int                       ( Int64 )
+import           Data.IORef
 -- Project imports
 import           Schema
 import           Queries
@@ -25,40 +31,68 @@ import           DBHelpers                      ( initDBWithPool
                                                 , runDbWithPool
                                                 )
 
+-- Configure the number of iterations to 6000
+-- If we don't set it fixed, the benchmark will try to query more
+-- SELECTs than there are rows, causing exceptions. This is probably
+-- because SELECTs are faster, and the default config prioritizes homogenous bench time
+-- over iteration count
+config :: Config
+config = defaultConfig { iters = Just (6000 :: Int64) }
 
 main :: IO ()
-main = defaultMain [queryRenderGroup, dbManipulationsGroup]
-
-queryRenderGroup :: Benchmark
-queryRenderGroup = bgroup
-  "Render Queries"
-  [ bench "createUser: weak head normal form" $ whnf renderSQL createUser
-  , bench "createUser: normal form" $ nf renderSQL createUser
-  , bench "userDetails: weak head normal form" $ whnf renderSQL userDetails
-  , bench "userDetails: normal form" $ nf renderSQL userDetails
-  , bench "insertDeviceDetails: weak head normal form"
-    $ whnf renderSQL insertDeviceDetails
-  , bench "insertDeviceDetails: normal form" $ nf renderSQL insertDeviceDetails
-  ]
-
--- 1. Initialize Schema to DB
--- 2. Make connection pool and pass it to tests
--- 3. Generate users on the fly and add them to DB
--- 4. Tear the Schema down from the DB
-dbManipulationsGroup :: Benchmark
-dbManipulationsGroup =
-  envWithCleanup initDBWithPool (const teardownDB) $ \pool -> bgroup
-    "Run individual queries and manipulations against DB using a connection pool"
-    [ bgroup
-      "INSERT: add 100 users to the table users"
-      [ bench "Weak head normal form" $ makeRunOnce $ perRunEnv
-          getRandomUser
-          (\(user :: InsertUser) -> runDbWithPool pool $ createUserSession user)
+main = do
+  -- A mutable hack here to keep track of
+  -- pulling a new user by ID from the db instead of the same id
+  currentId <- newIORef (1 :: UserId)
+  -- Define benchmarks
+  let
+    queryRenderGroup :: Benchmark
+    queryRenderGroup = bgroup
+      "Render Queries"
+      [ bench "createUser: weak head normal form" $ whnf renderSQL createUser
+      , bench "createUser: normal form" $ nf renderSQL createUser
+      , bench "userDetails: weak head normal form" $ whnf renderSQL userDetails
+      , bench "userDetails: normal form" $ nf renderSQL userDetails
+      , bench "insertDeviceDetails: weak head normal form"
+        $ whnf renderSQL insertDeviceDetails
+      , bench "insertDeviceDetails: normal form"
+        $ nf renderSQL insertDeviceDetails
       ]
-    , bgroup "SELECT: fetch 100 users from the table"
-             [bench "PLACEHOLDER" $ nf renderSQL createUser]
-    ]
+    -- 1. Initialize Schema to DB
+    -- 2. Make connection pool and pass it to tests
+    -- 3. Generate users on the fly and add them to DB
+    -- 4. Tear the Schema down from the DB
+    dbManipulationsGroup :: Benchmark
+    dbManipulationsGroup =
+      envWithCleanup initDBWithPool (const teardownDB) $ \pool -> bgroup
+        "Run individual queries and manipulations against DB using a connection pool"
+        [ bgroup
+          "INSERT: add thousands of users to the table users"
+          [ bench "Run individual INSERT statement" $ makeRunOnce $ perRunEnv
+              getRandomUser
+                -- The actual action to benchmark
+              (\(user :: InsertUser) ->
+                runDbWithPool pool $ createUserSession user
+              )
+          ]
+        , bgroup
+          "SELECT: fetch all users from the table users individually"
+          [ bench "Run individual SELECT statement" $ makeRunOnce $ perRunEnv
+              (getAndIncrementId currentId)
+              (\(id_ :: UserId) -> runDbWithPool pool $ userDetailsSession id_)
+          ]
+        ]
 
+    getAndIncrementId :: (IORef UserId) -> IO UserId
+    getAndIncrementId currentId = do
+      current <- readIORef currentId
+      writeIORef currentId (current + 1)
+      return current
+  -- run all benchmarks with modified config
+  defaultMainWith config [queryRenderGroup, dbManipulationsGroup]
+
+
+-- | Configure the benchmark to run only once (per IO action)
 makeRunOnce :: Benchmarkable -> Benchmarkable
 makeRunOnce current = current { perRun = True }
 

--- a/squeal-postgresql/benchmarks/Main.hs
+++ b/squeal-postgresql/benchmarks/Main.hs
@@ -40,16 +40,20 @@ main = defaultMain
     , bench "insertDeviceDetails: normal form"
       $ nf renderSQL insertDeviceDetails
     ]
+    -- 1. Initialize Schema to DB
+    -- 2. Make connection pool and pass it to tests
+    -- 3. Generate users on the fly and add them to DB
+    -- 4. Tear the Schema down from the DB
   , envWithCleanup initDBWithPool (const teardownDB) $ \pool -> bgroup
     "Run individual queries and manipulations against DB using a connection pool"
     [ bgroup
       "INSERT: add 100 users to the table users"
       [ bench "Weak head normal form" $ perRunEnv
           getRandomUser
-          (\user -> runDbWithPool pool $ manipulateParams createUser user)
+          (\(user :: InsertUser) -> runDbWithPool pool $ createUserSession user)
       ]
     , bgroup "SELECT: fetch 100 users from the table"
-             [bench "SELECT: normal form" $ nf renderSQL createUser]
+             [bench "PLACEHOLDER" $ nf renderSQL createUser]
     ]
   ]
 

--- a/squeal-postgresql/benchmarks/Main.hs
+++ b/squeal-postgresql/benchmarks/Main.hs
@@ -10,28 +10,47 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 -- Don't define 'module Main where' here
 -- or otherwise 'stack bench' won't work.
+-- module Main where
 
 import           Squeal.PostgreSQL       hiding ( defaultMain )
-import           Criterion.Main
+import           Gauge.Main
 import           GHC.Generics
 import qualified Generics.SOP                  as SOP
 import           Test.QuickCheck
 -- Project imports
 import           Schema
 import           Queries
+import           DBSetup                        ( teardownDB )
+import           DBHelpers                      ( initDBWithPool
+                                                , getRandomUser
+                                                , runDbWithPool
+                                                )
 
+
+main :: IO ()
 main = defaultMain
   [ bgroup
-      "Render Queries"
-      [ bench "createUser: weak head normal form" $ whnf renderSQL createUser
-      , bench "createUser: normal form" $ nf renderSQL createUser
-      , bench "userDetails: weak head normal form" $ whnf renderSQL userDetails
-      , bench "userDetails: normal form" $ nf renderSQL userDetails
-      , bench "insertDeviceDetails: weak head normal form"
-        $ whnf renderSQL insertDeviceDetails
-      , bench "insertDeviceDetails: normal form"
-        $ nf renderSQL insertDeviceDetails
+    "Render Queries"
+    [ bench "createUser: weak head normal form" $ whnf renderSQL createUser
+    , bench "createUser: normal form" $ nf renderSQL createUser
+    , bench "userDetails: weak head normal form" $ whnf renderSQL userDetails
+    , bench "userDetails: normal form" $ nf renderSQL userDetails
+    , bench "insertDeviceDetails: weak head normal form"
+      $ whnf renderSQL insertDeviceDetails
+    , bench "insertDeviceDetails: normal form"
+      $ nf renderSQL insertDeviceDetails
+    ]
+  , envWithCleanup initDBWithPool (const teardownDB) $ \pool -> bgroup
+    "Run individual queries and manipulations against DB using a connection pool"
+    [ bgroup
+      "INSERT: add 100 users to the table users"
+      [ bench "Weak head normal form" $ perRunEnv
+          getRandomUser
+          (\user -> runDbWithPool pool $ manipulateParams createUser user)
       ]
+    , bgroup "SELECT: fetch 100 users from the table"
+             [bench "SELECT: normal form" $ nf renderSQL createUser]
+    ]
   ]
 
 {- 

--- a/squeal-postgresql/benchmarks/lib/DBHelpers.hs
+++ b/squeal-postgresql/benchmarks/lib/DBHelpers.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE DeriveAnyClass                #-}
 {-# LANGUAGE DerivingStrategies                #-}
 {-# LANGUAGE ScopedTypeVariables                #-}
+{-# LANGUAGE StandaloneDeriving              #-}
 
 module DBHelpers where
 
@@ -21,17 +22,23 @@ import           Control.Monad.Except           ( MonadIO
                                                 , throwError
                                                 )
 import           Control.Monad.IO.Class         ( liftIO )
-import           GHC.Generics
+import           GHC.Generics                   ( Generic
+                                                , Generic1
+                                                )
 import           Test.QuickCheck
 import           Squeal.PostgreSQL
 import qualified Squeal.PostgreSQL.PQ.Pool     as SPG
 import qualified Data.ByteString.Char8         as C
+import           Control.DeepSeq
 -- Project imports
 import           Schema                         ( Schemas )
 import           Queries                        ( InsertUser )
 import           DBSetup
 
-newtype SquealPool = SquealPool {getSquealPool :: SPG.Pool (K Connection Schemas)}
+newtype SquealPool = SquealPool {getSquealPool :: SPG.Pool (K Connection Schemas)} deriving (Generic)
+-- Below may be very wrong - it may screw up the whole connection pool using in tests
+instance NFData SquealPool where
+  rnf = rwhnf
 
 runDbErr
   :: SquealPool -> PQ Schemas Schemas IO b -> IO (Either SquealException b)

--- a/squeal-postgresql/benchmarks/lib/DBHelpers.hs
+++ b/squeal-postgresql/benchmarks/lib/DBHelpers.hs
@@ -49,8 +49,7 @@ runDbWithPool :: SquealPool -> PQ Schemas Schemas IO b -> IO b
 runDbWithPool pool session = do
   errOrResult <- runDbErr pool session
   case errOrResult of
-    Left err -> throwSqueal
-      $ ConnectionException "Running query with connection pool failed"
+    Left  err    -> throwSqueal err
     Right result -> return result
 
 -- | Helper

--- a/squeal-postgresql/benchmarks/lib/DBHelpers.hs
+++ b/squeal-postgresql/benchmarks/lib/DBHelpers.hs
@@ -1,0 +1,66 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass                #-}
+{-# LANGUAGE DerivingStrategies                #-}
+{-# LANGUAGE ScopedTypeVariables                #-}
+
+module DBHelpers where
+
+import           Data.ByteString                ( ByteString )
+import qualified Data.ByteString.Char8         as C
+import           Control.Monad                  ( void )
+import           Data.Pool                      ( withResource )
+import           Control.Monad.Except           ( MonadIO
+                                                , throwError
+                                                )
+import           Control.Monad.IO.Class         ( liftIO )
+import           GHC.Generics
+import           Test.QuickCheck
+import           Squeal.PostgreSQL
+import qualified Squeal.PostgreSQL.PQ.Pool     as SPG
+import qualified Data.ByteString.Char8         as C
+-- Project imports
+import           Schema                         ( Schemas )
+import           Queries                        ( InsertUser )
+import           DBSetup
+
+newtype SquealPool = SquealPool {getSquealPool :: SPG.Pool (K Connection Schemas)}
+
+runDbErr
+  :: SquealPool -> PQ Schemas Schemas IO b -> IO (Either SquealException b)
+runDbErr pool session = do
+  liftIO . runUsingConnPool pool $ trySqueal (transactionally_ session)
+
+runDbWithPool :: SquealPool -> PQ Schemas Schemas IO b -> IO b
+runDbWithPool pool session = do
+  errOrResult <- runDbErr pool session
+  case errOrResult of
+    Left err -> throwSqueal
+      $ ConnectionException "Running query with connection pool failed"
+    Right result -> return result
+
+-- | Helper
+runUsingConnPool :: SquealPool -> PQ Schemas Schemas IO x -> IO x
+runUsingConnPool (SquealPool pool) (PQ session) =
+  unK <$> withResource pool session
+
+makePool :: C.ByteString -> IO SquealPool
+makePool connStr = do
+  pool <- SPG.createConnectionPool connStr 1 0.5 10
+  return $ SquealPool pool
+
+initDBWithPool :: IO SquealPool
+initDBWithPool = do
+  void initDB
+  pool <- makePool connectionString
+  return pool
+
+getRandomUser :: IO InsertUser
+getRandomUser = generate arbitrary

--- a/squeal-postgresql/benchmarks/lib/DBSetup.hs
+++ b/squeal-postgresql/benchmarks/lib/DBSetup.hs
@@ -99,8 +99,7 @@ makeConnStr PGConfig { pgHost = host, pgPort = portNumber, pgDbname = dbName, pg
     <> show portNumber
 
 connectionString :: ByteString
-connectionString =
-  "host=localhost dbname=exampledb user=postgres password=postgres port=5432"
+connectionString = "host=localhost port=5432 dbname=exampledb"
 
 performDBAction :: Definition a b -> String -> IO ()
 performDBAction action message = do

--- a/squeal-postgresql/benchmarks/lib/DBSetup.hs
+++ b/squeal-postgresql/benchmarks/lib/DBSetup.hs
@@ -1,0 +1,137 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass                #-}
+{-# LANGUAGE DerivingStrategies                #-}
+{-# LANGUAGE ScopedTypeVariables                #-}
+
+module DBSetup where
+
+import           Data.ByteString                ( ByteString )
+import qualified Data.ByteString.Char8         as C
+import           Control.Monad                  ( void )
+import           GHC.Generics
+import           Test.QuickCheck
+import           Squeal.PostgreSQL
+-- Project imports
+import           Schema                         ( Schemas
+                                                , DeviceOS
+                                                , IPLocation
+                                                )
+import           Queries                        ( InsertUser )
+
+
+-- First create enums as they're needed in the Schema
+setup :: Definition (Public '[]) Schemas
+setup =
+  createTypeEnumFrom @DeviceOS #device_os
+    >>> createTypeCompositeFrom @IPLocation #ip_location
+    >>> createTable
+          #users
+          (    serial8
+          `as` #id
+          :*   (text & notNullable)
+          `as` #email
+          :*   (text & notNullable)
+          `as` #password
+          :*   (text & nullable)
+          `as` #first_name
+          :*   (int2 & nullable)
+          `as` #birthyear
+          )
+          (primaryKey #id `as` #pk_users :* unique #email `as` #email)
+    >>> createTable
+          #user_devices
+          (    serial8
+          `as` #id
+          :*   notNullable int8
+          `as` #user_id
+          :*   (text & notNullable)
+          `as` #token
+          :*   (typedef #device_os & notNullable)
+          `as` #os
+          )
+          (    primaryKey #id
+          `as` #pk_user_devices
+          :*   foreignKey #user_id #users #id OnDeleteCascade OnUpdateCascade
+          `as` #fk_user_id
+          :*   unique #token
+          `as` #token
+          )
+
+-- Drop types last because tables depend on them
+teardown :: Definition Schemas (Public '[])
+teardown =
+  dropTableCascade #user_devices
+    >>> dropTableCascade #users
+    >>> dropType #ip_location
+    >>> dropType #device_os
+
+-- With env vars, we could use the commented keys
+data PGConfig = PGConfig
+  { pgHost     :: String -- "PG_HOST"
+  , pgPort     :: Int    -- "PG_PORT"
+  , pgDbname   :: String -- "PG_DBNAME" 
+  , pgUser     :: String -- "PG_USER"
+  , pgPassword :: String -- "PG_PASSWORD" 
+  }
+  deriving (Generic, Show)
+
+-- | Helper: unused now, but primarily for testing locally
+makeConnStr :: PGConfig -> ByteString
+makeConnStr PGConfig { pgHost = host, pgPort = portNumber, pgDbname = dbName, pgUser = user, pgPassword = pw }
+  = C.pack
+    $  "host="
+    <> host
+    <> " dbname="
+    <> dbName
+    <> " user="
+    <> user
+    <> " password="
+    <> pw
+    <> " port="
+    <> show portNumber
+
+connectionString :: ByteString
+connectionString =
+  "host=localhost dbname=exampledb user=postgres password=postgres port=5432"
+
+performDBAction :: Definition a b -> String -> IO ()
+performDBAction action message = do
+  void
+    $ withConnection connectionString
+    $ manipulate_ (UnsafeManipulation "SET client_min_messages TO WARNING;")
+    & pqThen (define action)
+  putStrLn message
+
+initDB :: IO ()
+initDB =
+  performDBAction setup "Initialized Schema & corresponding tables for Database"
+
+teardownDB :: IO ()
+teardownDB = performDBAction teardown "Dropped all database tables"
+
+dbSchema :: Definition '["public" ::: '[]] (Drop "public" '["public" ::: '[]])
+dbSchema = dropSchemaCascade #public
+
+dropDBSchema :: IO ()
+dropDBSchema = performDBAction dbSchema "Dropped Public schema from database"
+
+-- | Concatenate two `ByteString`s with a space between.
+(<+>) :: ByteString -> ByteString -> ByteString
+infixr 7 <+>
+str1 <+> str2 = str1 <> " " <> str2
+
+-- | Drop table custom SQL statement with 'cascade'
+dropTableCascade
+  :: (Has sch schemas schema, Has tab schema ( 'Table table))
+  => QualifiedAlias sch tab -- ^ table to remove
+  -> Definition schemas (Alter sch (Drop tab schema) schemas)
+dropTableCascade tab =
+  UnsafeDefinition $ "DROP TABLE" <+> renderSQL tab <> " cascade;"

--- a/squeal-postgresql/benchmarks/lib/Queries.hs
+++ b/squeal-postgresql/benchmarks/lib/Queries.hs
@@ -32,8 +32,6 @@ import           Test.QuickCheck.Instances      ( )
 -- Project imports
 import           Schema
 
-import           Debug.Trace
-
 -- Types
 
 type UserId = Int64
@@ -116,6 +114,9 @@ createUser = insertInto
     `as` #birthyear
     )
   )
+
+userDetailsSession :: UserId -> PQ Schemas Schemas IO APIDBUser_
+userDetailsSession uID = getRow 0 =<< runQueryParams userDetails (Only uID)
 
 userDetails :: Query_ Schemas (Only UserId) APIDBUser_
 userDetails = select_

--- a/squeal-postgresql/benchmarks/lib/Queries.hs
+++ b/squeal-postgresql/benchmarks/lib/Queries.hs
@@ -32,6 +32,7 @@ import           Test.QuickCheck.Instances      ( )
 -- Project imports
 import           Schema
 
+import           Debug.Trace
 
 -- Types
 
@@ -83,7 +84,6 @@ type DeviceDetailsRow = Row3 UserId Text (Enumerated DeviceOS)
 
 -- -- Queries
 
--- createUserSession :: InsertUser -> IO APIDBUser_
 createUserSession :: InsertUser -> PQ Schemas Schemas IO APIDBUser_
 createUserSession insertUser =
   getRow 0 =<< manipulateParams createUser insertUser

--- a/squeal-postgresql/benchmarks/lib/Queries.hs
+++ b/squeal-postgresql/benchmarks/lib/Queries.hs
@@ -13,8 +13,10 @@
 module Queries where
 
 import           Squeal.PostgreSQL
-import           GHC.Generics            hiding ( from )
+import           GHC.Generics                   ( Generic )
 import qualified Generics.SOP                  as SOP
+-- Need below for deriving instances
+import           Control.DeepSeq
 import           Data.Text                      ( Text )
 import           Data.Int                       ( Int16
                                                 , Int64
@@ -41,7 +43,7 @@ data InsertUser = InsertUser
   , userFirstName :: Maybe Text
   , userBirthyear :: Maybe Int16
   }
-  deriving (Show, Generic)
+  deriving (Show, Eq, Generic, NFData)
 instance SOP.Generic InsertUser
 instance SOP.HasDatatypeInfo InsertUser
 -- Arbitrary instances for producing values with quickcheck
@@ -61,7 +63,7 @@ data APIDBUser_ = APIDBUser_
   , first_name :: Maybe Text
   , birthyear  :: Maybe Int16
   }
-  deriving (Show, Generic)
+  deriving (Show, Eq, Generic, NFData)
 instance SOP.Generic APIDBUser_
 instance SOP.HasDatatypeInfo APIDBUser_
 -- Arbitrary instances for producing values with quickcheck
@@ -79,7 +81,12 @@ data Row3 a b c = Row4
 -- (UserId, Token, OS)
 type DeviceDetailsRow = Row3 UserId Text (Enumerated DeviceOS)
 
--- Queries
+-- -- Queries
+
+-- createUserSession :: InsertUser -> IO APIDBUser_
+createUserSession :: InsertUser -> PQ Schemas Schemas IO APIDBUser_
+createUserSession insertUser =
+  getRow 0 =<< manipulateParams createUser insertUser
 
 createUser :: Manipulation_ Schemas InsertUser APIDBUser_
 createUser = insertInto

--- a/squeal-postgresql/benchmarks/lib/Schema.hs
+++ b/squeal-postgresql/benchmarks/lib/Schema.hs
@@ -28,13 +28,22 @@ instance SOP.HasDatatypeInfo DeviceOS
 type PGDeviceOS = PG (Enumerated DeviceOS)
 type DeviceOSType = 'Typedef PGDeviceOS
 
--- SCHEMA
+-- For composite type
+data IPLocation = IPLocation
+  { countryShort :: String
+  , region       :: String
+  , city         :: String
+  }
+  deriving (Show, Read, Eq, Generic)
 
--- | Helper: Joining timestamps to every table from here
-type TimestampColumns = '[
-  "inserted_at" ::: 'NoDef :=> 'NotNull 'PGtimestamptz
-  , "updated_at" ::: 'NoDef :=> 'NotNull 'PGtimestamptz
-  ]
+instance SOP.Generic IPLocation
+instance SOP.HasDatatypeInfo IPLocation
+
+-- IPLocation Composite type
+type PGIPLocation = PG (Composite IPLocation)
+type IPLocationType = 'Typedef PGIPLocation
+
+-- SCHEMA
 
 -- Users
 
@@ -51,7 +60,7 @@ type UsersConstraints = '[
     , "email" ::: 'Unique '["email"]
     ]
 
-type UsersTable = 'Table (UsersConstraints :=> Join UsersColumns TimestampColumns)
+type UsersTable = 'Table (UsersConstraints :=> UsersColumns)
 
 -- User devices
 type UserDevicesColumns = '[
@@ -67,7 +76,7 @@ type UserDevicesConstraints = '[
   , "token" ::: 'Unique '["token"]
   ]
 
-type UserDevicesTable = 'Table (UserDevicesConstraints :=> Join UserDevicesColumns TimestampColumns)
+type UserDevicesTable = 'Table (UserDevicesConstraints :=> UserDevicesColumns)
 
 -- Schema
 -- Make sure to put types before tables, otherwise won't compile
@@ -75,6 +84,8 @@ type Schema = '[
   -- Enum types:
     "device_os" ::: DeviceOSType
   -- Composite types:
+  , "ip_location" ::: IPLocationType
+  -- Tables:
   , "users" ::: UsersTable
   , "user_devices" ::: UserDevicesTable
   ]

--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -148,7 +148,7 @@ benchmark benchmarks
   type: exitcode-stdio-1.0
   hs-source-dirs: benchmarks, benchmarks/lib
   main-is: Main.hs
-  other-modules: Schema, Queries
+  other-modules: Schema, Queries, DBSetup, DBHelpers
   default-language: Haskell2010
   ghc-options:
     -O2
@@ -165,12 +165,12 @@ benchmark benchmarks
     , mtl >= 2.2.2
     , scientific >= 0.3.5.3
     , squeal-postgresql
-    , time >= 1.8.0.2
     , with-utf8 >= 1.0
-    , criterion
+    , gauge
     , QuickCheck
     , quickcheck-instances
     , generic-random
+    , resource-pool
 
 executable example
   default-language: Haskell2010

--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -171,6 +171,7 @@ benchmark benchmarks
     , quickcheck-instances
     , generic-random
     , resource-pool
+    , deepseq
 
 executable example
   default-language: Haskell2010

--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -172,6 +172,7 @@ benchmark benchmarks
     , generic-random
     , resource-pool
     , deepseq
+    , monad-loops
 
 executable example
   default-language: Haskell2010


### PR DESCRIPTION
This PR adds benchmarks running against an actual database.

So far `INSERT` manipulations are only tested, but the skeleton can be used to facilitate any queries.

Other changes:
* Swapped `criterion` in favor of `gauge` for a much lighter dependency footprint
* Cleaned up Schema a bit
* Added a composite type as requested (not benchmarked yet)

Again, the bench folder contains a lot of noise, mostly functionality for building up other benchmark groups.

## CI Pipeline
If this qualifies for a merge, may I suggest adding `stack bench` a part of the CI pipeline? I've never used CircleCI so I don't want to go around messing with it, but a separate job for benchmarks would help us keep an eye on performance regressions.