### PR TITLE
PQ instances for MonadBase and MonadBaseControl

### DIFF
--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -94,6 +94,7 @@ library
     , free-categories >= 0.2.0.0
     , generics-sop >= 0.3.2.0
     , mmorph >= 1.1.1
+    , monad-control >= 1.0.2.3
     , mtl >= 2.2.2
     , network-ip >= 0.3.0.2
     , postgresql-binary >= 0.12.1
@@ -105,6 +106,7 @@ library
     , text >= 1.2.3.0
     , time >= 1.8.0.2
     , transformers >= 0.5.2.0
+    , transformers-base >= 0.4.5.2
     , unliftio >= 0.2.10
     , unliftio-pool >= 0.2.1.0
     , uuid-types >= 1.0.3


### PR DESCRIPTION
The purpose of this PR is to add an instance of `MonadBaseControl` to the PQ monad. In doing so, I also had to add a `MonadBase` instance, and a helpful type alias.

This PR also required two new dependencies, [`monad-control`](https://www.stackage.org/lts-14.12/package/monad-control-1.0.2.3), and [`transformer-base`](https://www.stackage.org/lts-14.12/package/transformers-base-0.4.5.2). The versions added are available for all all three stack-lts-x.yml files listed in the root directory of the project.