### PR TITLE
Add in PQ instance for MonadCatch, MonadThrow, and MonadMask

### DIFF
--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -94,6 +94,7 @@ library
     , bytestring >= 0.10.10.0
     , bytestring-strict-builder >= 0.4.5.3
     , deepseq >= 1.4.4.0
+    , exceptions >= 0.10.3
     , free-categories >= 0.2.0.0
     , generics-sop >= 0.5.1.0
     , mmorph >= 1.1.3


### PR DESCRIPTION
This PR adds in three new instances for the `PQ` monad, `MonadCatch`, `MonadThrow`, and `MonadMask`. 
Additionally, I've added a dependency on the hackage library [exceptions](https://hackage.haskell.org/package/exceptions-0.10.4/docs/Control-Monad-Catch.html) which defines the typeclasses above mentioned.
Finally, test suite is passing on my local machine.