### PR TITLE
making cross schema foreign keys backwards compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ type EmailsColumns =
    , "email" ::: 'NoDef :=> 'Null 'PGtext ]
 type EmailsConstraints =
   '[ "pk_emails"  ::: 'PrimaryKey '["id"]
-   , "fk_user_id" ::: 'ForeignKey '["user_id"] "public" "users" '["id"] ]
+   , "fk_user_id" ::: 'ForeignKey '["user_id"] "users" '["id"] ]
 type Schema =
   '[ "users" ::: 'Table (UsersConstraints :=> UsersColumns)
    , "emails" ::: 'Table (EmailsConstraints :=> EmailsColumns) ]

--- a/RELEASE NOTES.md
+++ b/RELEASE NOTES.md
@@ -1404,7 +1404,7 @@ It's also used for table constraints which are new in `0.2`.
 ```haskell
 "emails" :::
     '[ "pk_emails"  ::: 'PrimaryKey '["id"]
-     , "fk_user_id" ::: 'ForeignKey '["user_id"] "public" "users" '["id"]
+     , "fk_user_id" ::: 'ForeignKey '["user_id"] "users" '["id"]
      ] :=>
     '[ "id"      :::   'Def :=> 'NotNull 'PGint4
      , "user_id" ::: 'NoDef :=> 'NotNull 'PGint4

--- a/squeal-postgresql/bench/Gauge/Schema.hs
+++ b/squeal-postgresql/bench/Gauge/Schema.hs
@@ -72,7 +72,7 @@ type UserDevicesColumns = '[
 
 type UserDevicesConstraints = '[
   "pk_user_devices" ::: 'PrimaryKey '["id"]
-  , "fk_user_id" ::: 'ForeignKey '["user_id"] "public" "users" '["id"]
+  , "fk_user_id" ::: 'ForeignKey '["user_id"] "users" '["id"]
   , "token" ::: 'Unique '["token"]
   ]
 

--- a/squeal-postgresql/exe/Example.hs
+++ b/squeal-postgresql/exe/Example.hs
@@ -31,7 +31,7 @@ type UserSchema =
         ])
    , "emails" ::: 'Table (
        '[  "pk_emails" ::: 'PrimaryKey '["id"]
-        , "fk_user_id" ::: 'ForeignKey '["user_id"] "user" "users" '["id"]
+        , "fk_user_id" ::: 'ForeignKey '["user_id"] "users" '["id"]
         ] :=>
        '[ "id" ::: 'Def :=> 'NotNull 'PGint4
         , "user_id" ::: 'NoDef :=> 'NotNull 'PGint4
@@ -48,8 +48,8 @@ type OrgSchema =
          , "name" ::: 'NoDef :=> 'NotNull 'PGtext
          ])
    , "members" ::: 'Table (
-        '[ "fk_member" ::: 'ForeignKey '["member"] "user" "users" '["id"]
-         , "fk_organization" ::: 'ForeignKey '["organization"] "org" "organizations" '["id"] ] :=>
+        '[ "fk_member" ::: 'ForeignKey '["member"] "user.users" '["id"]
+         , "fk_organization" ::: 'ForeignKey '["organization"] "organizations" '["id"] ] :=>
         '[ "member" ::: 'NoDef :=> 'NotNull 'PGint4
          , "organization" ::: 'NoDef :=> 'NotNull 'PGint4 ])
    ]

--- a/squeal-postgresql/src/Squeal/PostgreSQL.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL.hs
@@ -40,7 +40,7 @@ type EmailsColumns =
    , "email" ::: 'NoDef :=> 'Null 'PGtext ]
 type EmailsConstraints =
   '[ "pk_emails"  ::: 'PrimaryKey '["id"]
-   , "fk_user_id" ::: 'ForeignKey '["user_id"] "public" "users" '["id"] ]
+   , "fk_user_id" ::: 'ForeignKey '["user_id"] "users" '["id"] ]
 type Schema =
   '[ "users" ::: 'Table (UsersConstraints :=> UsersColumns)
    , "emails" ::: 'Table (EmailsConstraints :=> EmailsColumns) ]

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition/Constraint.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition/Constraint.hs
@@ -200,7 +200,7 @@ type Schema =
         ])
    , "emails" ::: 'Table (
        '[  "pk_emails" ::: 'PrimaryKey '["id"]
-        , "fk_user_id" ::: 'ForeignKey '["user_id"] "public" "users" '["id"]
+        , "fk_user_id" ::: 'ForeignKey '["user_id"] "users" '["id"]
         ] :=>
        '[ "id" ::: 'Def :=> 'NotNull 'PGint4
         , "user_id" ::: 'NoDef :=> 'NotNull 'PGint4
@@ -235,7 +235,7 @@ A `foreignKey` can even be a table self-reference.
 type Schema =
   '[ "employees" ::: 'Table (
        '[ "employees_pk"          ::: 'PrimaryKey '["id"]
-        , "employees_employer_fk" ::: 'ForeignKey '["employer_id"] "public" "employees" '["id"]
+        , "employees_employer_fk" ::: 'ForeignKey '["employer_id"] "employees" '["id"]
         ] :=>
        '[ "id"          :::   'Def :=> 'NotNull 'PGint4
         , "name"        ::: 'NoDef :=> 'NotNull 'PGtext
@@ -279,7 +279,7 @@ foreignKey
   -> OnUpdateClause
   -- ^ what to do when reference is updated
   -> TableConstraintExpression sch1 child db
-      ('ForeignKey columns sch0 parent refcolumns)
+      ('ForeignKey columns (References sch0 parent sch1) refcolumns)
 foreignKey keys parent refs ondel onupd = UnsafeTableConstraintExpression $
   "FOREIGN KEY" <+> parenthesized (renderSQL keys)
   <+> "REFERENCES" <+> renderSQL parent

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition/Constraint.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition/Constraint.hs
@@ -260,26 +260,25 @@ in printSQL setup
 CREATE TABLE "employees" ("id" serial, "name" text NOT NULL, "employer_id" integer NULL, CONSTRAINT "employees_pk" PRIMARY KEY ("id"), CONSTRAINT "employees_employer_fk" FOREIGN KEY ("employer_id") REFERENCES "employees" ("id") ON DELETE CASCADE ON UPDATE CASCADE);
 -}
 foreignKey
-  :: (ForeignKeyed db 
+  :: ( ForeignKeyed db
         sch0 sch1
-        schema0 schema1 
-        child parent
-        table reftable
-        columns refcolumns
-        constraints cols
-        reftys tys )
-  => NP Alias columns
+        schema0 schema1
+        tab0 tab1
+        table0 table1
+        columns0 columns1
+        tys0 tys1 )
+  => NP Alias columns1
   -- ^ column or columns in the table
-  -> QualifiedAlias sch0 parent
+  -> QualifiedAlias sch0 tab0
   -- ^ reference table
-  -> NP Alias refcolumns
+  -> NP Alias columns0
   -- ^ reference column or columns in the reference table
   -> OnDeleteClause
   -- ^ what to do when reference is deleted
   -> OnUpdateClause
   -- ^ what to do when reference is updated
-  -> TableConstraintExpression sch1 child db
-      ('ForeignKey columns (References sch0 parent sch1) refcolumns)
+  -> TableConstraintExpression sch1 tab1 db
+      ('ForeignKey columns1 (References sch0 tab0 sch1) columns0)
 foreignKey keys parent refs ondel onupd = UnsafeTableConstraintExpression $
   "FOREIGN KEY" <+> parenthesized (renderSQL keys)
   <+> "REFERENCES" <+> renderSQL parent
@@ -291,20 +290,19 @@ foreignKey keys parent refs ondel onupd = UnsafeTableConstraintExpression $
 type ForeignKeyed db
   sch0 sch1
   schema0 schema1
-  child parent
-  table reftable
-  columns refcolumns
-  constraints cols
-  reftys tys =
+  tab0 tab1
+  table0 table1
+  columns0 columns1
+  tys0 tys1 =
     ( Has sch0 db schema0
     , Has sch1 db schema1
-    , Has parent schema0 ('Table reftable)
-    , Has child schema1 ('Table table)
-    , HasAll columns (TableToColumns table) tys
-    , reftable ~ (constraints :=> cols)
-    , HasAll refcolumns cols reftys
-    , SOP.AllZip SamePGType tys reftys
-    , Uniquely refcolumns constraints )
+    , Has tab0 schema0 ('Table table0)
+    , Has tab1 schema1 ('Table table1)
+    , HasAll columns0 (TableToColumns table0) tys1
+    , HasAll columns1 (TableToColumns table1) tys0
+    , SOP.AllZip SamePGType tys0 tys1
+    , Uniquely columns0 (TableToConstraints table0)
+    )
 
 -- | `OnDeleteClause` indicates what to do with rows that reference a deleted row.
 data OnDeleteClause

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -207,8 +207,8 @@ type OrdersColumns =
 >>> :{
 type OrdersConstraints =
   '["pk_orders" ::: PrimaryKey '["id"]
-  ,"fk_customers" ::: ForeignKey '["customer_id"] "public" "customers" '["id"]
-  ,"fk_shippers" ::: ForeignKey '["shipper_id"] "public" "shippers" '["id"] ]
+   ,"fk_customers" ::: ForeignKey '["customer_id"] "customers" '["id"]
+   ,"fk_shippers" ::: ForeignKey '["shipper_id"] "shippers" '["id"] ]
 :}
 
 >>> type NamesColumns = '["id" ::: 'NoDef :=> 'NotNull 'PGint4, "name" ::: 'NoDef :=> 'NotNull 'PGtext]

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Migration.hs
@@ -26,7 +26,7 @@ type UsersTable =
 >>> :{
 type EmailsTable =
   '[ "pk_emails" ::: 'PrimaryKey '["id"]
-   , "fk_user_id" ::: 'ForeignKey '["user_id"] "public" "users" '["id"]
+   , "fk_user_id" ::: 'ForeignKey '["user_id"] "users" '["id"]
    ] :=>
   '[ "id" ::: 'Def :=> 'NotNull 'PGint4
    , "user_id" ::: 'NoDef :=> 'NotNull 'PGint4

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
@@ -91,6 +91,7 @@ module Squeal.PostgreSQL.Type.Schema
   , NullifyFrom
     -- * Table Conversion
   , TableToColumns
+  , TableToConstraints
   , ColumnsToRow
   , TableToRow
     -- * Updatable
@@ -214,6 +215,7 @@ data TableConstraint
   | PrimaryKey [Symbol]
   | ForeignKey [Symbol] Symbol [Symbol]
 
+-- | A type family which calculates an intra- or cross-schema table reference name.
 type family References (sch :: Symbol) (tab :: Symbol) (sch0 :: Symbol) where
   References sch tab sch = tab
   References sch tab _   = sch `AppendSymbol` "." `AppendSymbol` tab
@@ -278,6 +280,10 @@ type family ColumnsToRow (columns :: ColumnsType) :: RowType where
 -- | `TableToColumns` removes table constraints.
 type family TableToColumns (table :: TableType) :: ColumnsType where
   TableToColumns (constraints :=> columns) = columns
+
+-- | `TableToConstraints` removes table columns.
+type family TableToConstraints (table :: TableType) :: TableConstraints where
+  TableToConstraints (constraints :=> columns) = constraints
 
 -- | Convert a table to a row type.
 type family TableToRow (table :: TableType) :: RowType where

--- a/squeal-presentation-raveline.md
+++ b/squeal-presentation-raveline.md
@@ -108,7 +108,7 @@ type ParliamentaryGroup =
 ```haskell
 type MemberOfParliament =
     '[ "pk_mp" ::: 'PrimaryKey '["mp_id"]
-    , "fk_mp_groupp" ::: 'ForeignKey '["mp_group"] "public" "groupp" '["groupp_id"]
+    , "fk_mp_groupp" ::: 'ForeignKey '["mp_group"] "groupp" '["groupp_id"]
     ] :=> MpCols
 ```
 


### PR DESCRIPTION
In Squeal 0.6 the `ForeignKey` constuctor has three arguments

```Haskell
ForeignKey [Symbol] Symbol [Symbol]
```

The second argument was the table being referenced; but there was a bug in cross-schema support for doing a `createTable` with a cross-schema `foreignKey`.

The obvious solution is to add a fourth argument with the schema being referenced. But that causes a backward compatibility problem since users will have to update their schema definitions. Also, it causes a problem for squealgen because it then has to be squeal version aware.

So, instead we'll do what squealgen is _already_ doing; for intra-schema references, just use the table name, and for cross-schema references, use the schema qualified table name. Now it's automatically backwards compatible (except for enabling cross-schema foreign keys) and automatically compatible with squealgen. To do that, we define a type family `References` that computes the string for either intra- or cross-schema references.

```Haskell
type family References (sch :: Symbol) (tab :: Symbol) (sch0 :: Symbol) where
  References sch tab sch = tab
  References sch tab _   = sch `AppendSymbol` "." `AppendSymbol` tab
```