### PR TITLE
provide a more useful error message for Has

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/Alias.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/Alias.hs
@@ -187,8 +187,9 @@ type HasUnique alias fields field = fields ~ '[alias ::: field]
 type Has (alias :: Symbol) (fields :: [(Symbol,kind)]) (field :: kind)
   = HasErr fields alias fields field
 
-{- | @HasErr err alias fields field@ hosts an @err@,
-the original @fields@ in `Has`, if it fails to find an instance because
+{- | `HasErr` @err alias fields field@ hosts an @err@,
+the original @fields@ in `Has` @alias fields field@,
+if it fails to find an instance because
 @fields@ does not have @alias@.
 -}
 class KnownSymbol alias =>

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/Alias.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/Alias.hs
@@ -44,6 +44,7 @@ module Squeal.PostgreSQL.Type.Alias
   , mapAliased
   , Has
   , HasUnique
+  , HasErr
   , HasAll
   , HasIn
     -- * Qualified Aliases
@@ -183,13 +184,20 @@ type HasUnique alias fields field = fields ~ '[alias ::: field]
 -- | @Has alias fields field@ is a constraint that proves that
 -- @fields@ has a field of @alias ::: field@, inferring @field@
 -- from @alias@ and @fields@.
+type Has (alias :: Symbol) (fields :: [(Symbol,kind)]) (field :: kind)
+  = HasErr fields alias fields field
+
+{- | @HasErr err alias fields field@ hosts an @err@,
+the original @fields@ in `Has`, if it fails to find an instance because
+@fields@ does not have @alias@.
+-}
 class KnownSymbol alias =>
-  Has (alias :: Symbol) (fields :: [(Symbol,kind)]) (field :: kind)
+  HasErr err (alias :: Symbol) (fields :: [(Symbol,kind)]) (field :: kind)
   | alias fields -> field where
 instance {-# OVERLAPPING #-} (KnownSymbol alias, field0 ~ field1)
-  => Has alias (alias ::: field0 ': fields) field1
-instance {-# OVERLAPPABLE #-} (KnownSymbol alias, Has alias fields field)
-  => Has alias (field' ': fields) field
+  => HasErr err alias (alias ::: field0 ': fields) field1
+instance {-# OVERLAPPABLE #-} (KnownSymbol alias, HasErr err alias fields field)
+  => HasErr err alias (field' ': fields) field
 
 {-| @HasIn fields (alias ::: field)@ is a constraint that proves that
 @fields@ has a field of @alias ::: field@. It is used in @UPDATE@s to


### PR DESCRIPTION
include the original fields when a `Has` instance is not found