### PR TITLE
custom enum decoder

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Decode.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Decode.hs
@@ -32,6 +32,7 @@ module Squeal.PostgreSQL.Session.Decode
     FromPG (..)
   , devalue
   , rowValue
+  , enumValue
     -- * Decode Rows
   , DecodeRow (..)
   , decodeRow
@@ -60,6 +61,7 @@ import Data.Int (Int16, Int32, Int64)
 import Data.Kind
 import Data.Scientific (Scientific)
 import Data.String (fromString)
+import Data.Text (Text)
 import Data.Time (Day, TimeOfDay, TimeZone, LocalTime, UTCTime, DiffTime)
 import Data.UUID.Types (UUID)
 import Data.Vector (Vector)
@@ -533,3 +535,33 @@ runField
   => SOP.K (Maybe Strict.ByteString) ty
   -> Except Strict.Text (SOP.P y)
 runField = liftEither . fromField @ty . SOP.unK
+
+{- |
+>>> :{
+data Dir = North | East | South | West
+instance IsPG Dir where
+  type PG Dir = 'PGenum '["north", "south", "east", "west"]
+instance FromPG Dir where
+  fromPG = enumValue $
+    label @"north" North :*
+    label @"south" South :*
+    label @"east" East :*
+    label @"west" West
+:}
+-}
+enumValue
+  :: (SOP.All KnownSymbol labels, PG y ~ 'PGenum labels)
+  => NP (SOP.K y) labels
+  -> StateT Strict.ByteString (Except Strict.Text) y
+enumValue labels = devalue (enum (enumLabels labels))
+  where
+  enumLabels
+    :: SOP.All KnownSymbol labels
+    => NP (SOP.K y) labels
+    -> Text -> Maybe y
+  enumLabels = \case
+    Nil -> \_ -> Nothing
+    ((y :: SOP.K y label) :* ys) -> \ str ->
+      if str == fromString (symbolVal (SOP.Proxy @label))
+      then Just (SOP.unK y)
+      else enumLabels ys str

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Decode.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Decode.hs
@@ -553,15 +553,15 @@ enumValue
   :: (SOP.All KnownSymbol labels, PG y ~ 'PGenum labels)
   => NP (SOP.K y) labels
   -> StateT Strict.ByteString (Except Strict.Text) y
-enumValue labels = devalue (enum (enumLabels labels))
+enumValue = devalue . enum . labels
   where
-  enumLabels
+  labels
     :: SOP.All KnownSymbol labels
     => NP (SOP.K y) labels
     -> Text -> Maybe y
-  enumLabels = \case
+  labels = \case
     Nil -> \_ -> Nothing
     ((y :: SOP.K y label) :* ys) -> \ str ->
       if str == fromString (symbolVal (SOP.Proxy @label))
       then Just (SOP.unK y)
-      else enumLabels ys str
+      else labels ys str

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
@@ -564,6 +564,8 @@ instance label ~ label1
   => IsPGlabel label (PGlabel label1) where label = PGlabel
 instance labels ~ '[label]
   => IsPGlabel label (NP PGlabel labels) where label = PGlabel :* Nil
+instance IsPGlabel label (y -> K y label) where label = K
+instance IsPGlabel label (y -> NP (K y) '[label]) where label y = K y :* Nil
 -- | A `PGlabel` unit type with an `IsPGlabel` instance
 data PGlabel (label :: Symbol) = PGlabel
 instance KnownSymbol label => RenderSQL (PGlabel label) where


### PR DESCRIPTION
Sometimes your Haskell enum doesn't exactly match your PG enum so you must hand-roll a decoder. This is a convenient combinator for that.