### PR TITLE
polymorphic lateral context

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression.hs
@@ -203,46 +203,46 @@ unsafeFunctionVar :: ByteString -> FunctionVar x0 x1 y
 unsafeFunctionVar fun xs x = UnsafeExpression $ fun <> parenthesized
   (commaSeparated (renderSQL <$> xs) <> ", " <> renderSQL x)
 
-instance (HasUnique tab (Join lat from) row, Has col row ty)
+instance (HasUnique tab (Join from lat) row, Has col row ty)
   => IsLabel col (Expression 'Ungrouped lat with db params from ty) where
     fromLabel = UnsafeExpression $ renderSQL (Alias @col)
-instance (HasUnique tab (Join lat from) row, Has col row ty, tys ~ '[ty])
+instance (HasUnique tab (Join from lat) row, Has col row ty, tys ~ '[ty])
   => IsLabel col (NP (Expression 'Ungrouped lat with db params from) tys) where
     fromLabel = fromLabel @col :* Nil
-instance (HasUnique tab (Join lat from) row, Has col row ty, column ~ (col ::: ty))
+instance (HasUnique tab (Join from lat) row, Has col row ty, column ~ (col ::: ty))
   => IsLabel col
     (Aliased (Expression 'Ungrouped lat with db params from) column) where
     fromLabel = fromLabel @col `As` Alias
-instance (HasUnique tab (Join lat from) row, Has col row ty, columns ~ '[col ::: ty])
+instance (HasUnique tab (Join from lat) row, Has col row ty, columns ~ '[col ::: ty])
   => IsLabel col
     (NP (Aliased (Expression 'Ungrouped lat with db params from)) columns) where
     fromLabel = fromLabel @col :* Nil
 
-instance (Has tab (Join lat from) row, Has col row ty)
+instance (Has tab (Join from lat) row, Has col row ty)
   => IsQualified tab col (Expression 'Ungrouped lat with db params from ty) where
     tab ! col = UnsafeExpression $
       renderSQL tab <> "." <> renderSQL col
-instance (Has tab (Join lat from) row, Has col row ty, tys ~ '[ty])
+instance (Has tab (Join from lat) row, Has col row ty, tys ~ '[ty])
   => IsQualified tab col (NP (Expression 'Ungrouped lat with db params from) tys) where
     tab ! col = tab ! col :* Nil
-instance (Has tab (Join lat from) row, Has col row ty, column ~ (col ::: ty))
+instance (Has tab (Join from lat) row, Has col row ty, column ~ (col ::: ty))
   => IsQualified tab col
     (Aliased (Expression 'Ungrouped lat with db params from) column) where
     tab ! col = tab ! col `As` col
-instance (Has tab (Join lat from) row, Has col row ty, columns ~ '[col ::: ty])
+instance (Has tab (Join from lat) row, Has col row ty, columns ~ '[col ::: ty])
   => IsQualified tab col
     (NP (Aliased (Expression 'Ungrouped lat with db params from)) columns) where
     tab ! col = tab ! col :* Nil
 
 instance
-  ( HasUnique tab (Join lat from) row
+  ( HasUnique tab (Join from lat) row
   , Has col row ty
   , GroupedBy tab col bys
   ) => IsLabel col
     (Expression ('Grouped bys) lat with db params from ty) where
       fromLabel = UnsafeExpression $ renderSQL (Alias @col)
 instance
-  ( HasUnique tab (Join lat from) row
+  ( HasUnique tab (Join from lat) row
   , Has col row ty
   , GroupedBy tab col bys
   , tys ~ '[ty]
@@ -250,7 +250,7 @@ instance
     (NP (Expression ('Grouped bys) lat with db params from) tys) where
       fromLabel = fromLabel @col :* Nil
 instance
-  ( HasUnique tab (Join lat from) row
+  ( HasUnique tab (Join from lat) row
   , Has col row ty
   , GroupedBy tab col bys
   , column ~ (col ::: ty)
@@ -258,7 +258,7 @@ instance
     (Aliased (Expression ('Grouped bys) lat with db params from) column) where
       fromLabel = fromLabel @col `As` Alias
 instance
-  ( HasUnique tab (Join lat from) row
+  ( HasUnique tab (Join from lat) row
   , Has col row ty
   , GroupedBy tab col bys
   , columns ~ '[col ::: ty]
@@ -267,7 +267,7 @@ instance
       fromLabel = fromLabel @col :* Nil
 
 instance
-  ( Has tab (Join lat from) row
+  ( Has tab (Join from lat) row
   , Has col row ty
   , GroupedBy tab col bys
   ) => IsQualified tab col
@@ -275,7 +275,7 @@ instance
       tab ! col = UnsafeExpression $
         renderSQL tab <> "." <> renderSQL col
 instance
-  ( Has tab (Join lat from) row
+  ( Has tab (Join from lat) row
   , Has col row ty
   , GroupedBy tab col bys
   , tys ~ '[ty]
@@ -283,7 +283,7 @@ instance
     (NP (Expression ('Grouped bys) lat with db params from) tys) where
       tab ! col = tab ! col :* Nil
 instance
-  ( Has tab (Join lat from) row
+  ( Has tab (Join from lat) row
   , Has col row ty
   , GroupedBy tab col bys
   , column ~ (col ::: ty)
@@ -291,7 +291,7 @@ instance
     (Aliased (Expression ('Grouped bys) lat with db params from) column) where
       tab ! col = tab ! col `As` col
 instance
-  ( Has tab (Join lat from) row
+  ( Has tab (Join from lat) row
   , Has col row ty
   , GroupedBy tab col bys
   , columns ~ '[col ::: ty]

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query/Select.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query/Select.hs
@@ -103,24 +103,24 @@ instance (KnownSymbol col, row ~ '[col ::: ty])
     (Expression grp lat with db params from ty)
     (Selection grp lat with db params from row) where
       expr `as` col = List (expr `as` col)
-instance (Has tab (Join lat from) row0, Has col row0 ty, row1 ~ '[col ::: ty])
+instance (Has tab (Join from lat) row0, Has col row0 ty, row1 ~ '[col ::: ty])
   => IsQualified tab col
     (Selection 'Ungrouped lat with db params from row1) where
       tab ! col = tab ! col `as` col
 instance
-  ( Has tab (Join lat from) row0
+  ( Has tab (Join from lat) row0
   , Has col row0 ty
   , row1 ~ '[col ::: ty]
   , GroupedBy tab col bys )
   => IsQualified tab col
     (Selection ('Grouped bys) lat with db params from row1) where
       tab ! col = tab ! col `as` col
-instance (HasUnique tab (Join lat from) row0, Has col row0 ty, row1 ~ '[col ::: ty])
+instance (HasUnique tab (Join from lat) row0, Has col row0 ty, row1 ~ '[col ::: ty])
   => IsLabel col
     (Selection 'Ungrouped lat with db params from row1) where
       fromLabel = fromLabel @col `as` Alias
 instance
-  ( HasUnique tab (Join lat from) row0
+  ( HasUnique tab (Join from lat) row0
   , Has col row0 ty
   , row1 ~ '[col ::: ty]
   , GroupedBy tab col bys )


### PR DESCRIPTION
This change makes it possible to have polymorphic lateral context! When looking up a column heretofore, the relevant typeclasses would search through `Join lat from`. This is the "correct" ordering as far as the structure from left to right in the query, making `lat` consistently ordered as one goes through nested lateral joins or nested subquery expressions. However, it doesn't really matter how the lookup orders the columns. And if the lookup searches through `Join from lat` instead then thanks to good old Haskell lazy list appending, if a query only references columns in `from` then it will work no matter the `lat`. With a small proviso; if you leave `lat` polymorphic, then you _must_ qualify all columns since there _could_ be more than one table even if `from` has only one table in it.