### PR TITLE
Make manipulated tables aliasable

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL.hs
@@ -136,7 +136,7 @@ let
 :}
 
 >>> printSQL insertUser
-WITH "u" AS (INSERT INTO "users" ("id", "name") VALUES (DEFAULT, ($1 :: text)) RETURNING "id" AS "id", ($2 :: text) AS "email") INSERT INTO "emails" ("user_id", "email") SELECT "u"."id", "u"."email" FROM "u" AS "u"
+WITH "u" AS (INSERT INTO "users" AS "users" ("id", "name") VALUES (DEFAULT, ($1 :: text)) RETURNING "id" AS "id", ($2 :: text) AS "email") INSERT INTO "emails" AS "emails" ("user_id", "email") SELECT "u"."id", "u"."email" FROM "u" AS "u"
 
 Next we write a `Statement` to retrieve users from the database. We're not
 interested in the ids here, just the usernames and email addresses. We

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Definition/Procedure.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Definition/Procedure.hs
@@ -71,7 +71,7 @@ let
              $ [deleteFrom_ #things (#id .== param @1)]
 in printSQL definition
 :}
-CREATE PROCEDURE "proc" (int4) language sql as $$ DELETE FROM "things" WHERE ("id" = ($1 :: int4)); $$;
+CREATE PROCEDURE "proc" (int4) language sql as $$ DELETE FROM "things" AS "things" WHERE ("id" = ($1 :: int4)); $$;
 -}
 createProcedure
   :: ( Has sch db schema
@@ -100,7 +100,7 @@ let
              $ [deleteFrom_ #things (#id .== param @1)]
 in printSQL definition
 :}
-CREATE OR REPLACE PROCEDURE "proc" (int4) language sql as $$ DELETE FROM "things" WHERE ("id" = ($1 :: int4)); $$;
+CREATE OR REPLACE PROCEDURE "proc" (int4) language sql as $$ DELETE FROM "things" AS "things" WHERE ("id" = ($1 :: int4)); $$;
 -}
 createOrReplaceProcedure
   :: ( Has sch db schema

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation.hs
@@ -129,7 +129,7 @@ let
     insertInto_ #tab (Values_ (Set 2 `as` #col1 :* Default `as` #col2))
 in printSQL manipulation
 :}
-INSERT INTO "tab" ("col1", "col2") VALUES ((2 :: int4), DEFAULT)
+INSERT INTO "tab" AS "tab" ("col1", "col2") VALUES ((2 :: int4), DEFAULT)
 
 out-of-line parameterized insert:
 
@@ -143,7 +143,7 @@ let
       (Default `as` #col1 :* Set (param @1) `as` #col2)
 in printSQL manipulation
 :}
-INSERT INTO "tab" ("col1", "col2") VALUES (DEFAULT, ($1 :: int4))
+INSERT INTO "tab" AS "tab" ("col1", "col2") VALUES (DEFAULT, ($1 :: int4))
 
 in-line parameterized insert:
 
@@ -159,7 +159,7 @@ let
       [Row {col1 = NotDefault (3 :: Int32), col2 = 4 :: Int32}]
 in printSQL manipulation
 :}
-INSERT INTO "tab" ("col1", "col2") VALUES (DEFAULT, (2 :: int4)), ((3 :: int4), (4 :: int4))
+INSERT INTO "tab" AS "tab" ("col1", "col2") VALUES (DEFAULT, (2 :: int4)), ((3 :: int4), (4 :: int4))
 
 returning insert:
 
@@ -171,7 +171,7 @@ let
       OnConflictDoRaise (Returning (#col1 `as` #fromOnly))
 in printSQL manipulation
 :}
-INSERT INTO "tab" ("col1", "col2") VALUES ((2 :: int4), (3 :: int4)) RETURNING "col1" AS "fromOnly"
+INSERT INTO "tab" AS "tab" ("col1", "col2") VALUES ((2 :: int4), (3 :: int4)) RETURNING "col1" AS "fromOnly"
 
 upsert:
 
@@ -189,7 +189,7 @@ let
       (Returning_ Nil)
 in printSQL manipulation
 :}
-INSERT INTO "customers" ("name", "email") VALUES ((E'John Smith' :: text), (E'john@smith.com' :: text)) ON CONFLICT ON CONSTRAINT "uq" DO UPDATE SET "email" = ("excluded"."email" || ((E'; ' :: text) || "customers"."email"))
+INSERT INTO "customers" AS "customers" ("name", "email") VALUES ((E'John Smith' :: text), (E'john@smith.com' :: text)) ON CONFLICT ON CONSTRAINT "uq" DO UPDATE SET "email" = ("excluded"."email" || ((E'; ' :: text) || "customers"."email"))
 
 query insert:
 
@@ -199,7 +199,7 @@ let
   manipulation = insertInto_ #tab (Subquery (select Star (from (table #tab))))
 in printSQL manipulation
 :}
-INSERT INTO "tab" SELECT * FROM "tab" AS "tab"
+INSERT INTO "tab" AS "tab" SELECT * FROM "tab" AS "tab"
 
 update:
 
@@ -209,7 +209,7 @@ let
   manipulation = update_ #tab (Set 2 `as` #col1) (#col1 ./= #col2)
 in printSQL manipulation
 :}
-UPDATE "tab" SET "col1" = (2 :: int4) WHERE ("col1" <> "col2")
+UPDATE "tab" AS "tab" SET "col1" = (2 :: int4) WHERE ("col1" <> "col2")
 
 delete:
 
@@ -219,7 +219,7 @@ let
   manipulation = deleteFrom #tab NoUsing (#col1 .== #col2) (Returning Star)
 in printSQL manipulation
 :}
-DELETE FROM "tab" WHERE ("col1" = "col2") RETURNING *
+DELETE FROM "tab" AS "tab" WHERE ("col1" = "col2") RETURNING *
 
 delete and using clause:
 
@@ -240,7 +240,7 @@ let
     (Returning_ Nil)
 in printSQL manipulation
 :}
-DELETE FROM "tab" USING "other_tab" AS "other_tab", "third_tab" AS "third_tab" WHERE (("tab"."col2" = "other_tab"."col2") AND ("tab"."col2" = "third_tab"."col2"))
+DELETE FROM "tab" AS "tab" USING "other_tab" AS "other_tab", "third_tab" AS "third_tab" WHERE (("tab"."col2" = "other_tab"."col2") AND ("tab"."col2" = "third_tab"."col2"))
 
 with manipulation:
 
@@ -254,7 +254,7 @@ let
     (insertInto_ #products_deleted (Subquery (select Star (from (common #del)))))
 in printSQL manipulation
 :}
-WITH "del" AS (DELETE FROM "products" WHERE ("date" < ($1 :: date)) RETURNING *) INSERT INTO "products_deleted" SELECT * FROM "del" AS "del"
+WITH "del" AS (DELETE FROM "products" AS "products" WHERE ("date" < ($1 :: date)) RETURNING *) INSERT INTO "products_deleted" AS "products_deleted" SELECT * FROM "del" AS "del"
 -}
 type family Manipulation_ (db :: SchemasType) (params :: Type) (row :: Type) where
   Manipulation_ db params row = Manipulation '[] db (TuplePG params) (RowPG row)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation/Delete.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation/Delete.hs
@@ -55,17 +55,17 @@ DELETE statements
 deleteFrom
   :: ( SOP.SListI row
      , Has sch db schema
-     , Has tab schema ('Table table) )
-  => QualifiedAlias sch tab -- ^ table to delete from
+     , Has tab0 schema ('Table table) )
+  => Aliased (QualifiedAlias sch) (tab ::: tab0) -- ^ table to delete from
   -> UsingClause with db params from
   -> Condition  'Ungrouped '[] with db params (tab ::: TableToRow table ': from)
   -- ^ condition under which to delete a row
   -> ReturningClause with db params '[tab ::: TableToRow table] row
   -- ^ results to return
   -> Manipulation with db params row
-deleteFrom tab using wh returning = UnsafeManipulation $
+deleteFrom (tab0 `As` tab) using wh returning = UnsafeManipulation $
   "DELETE FROM"
-  <+> renderSQL tab
+  <+> renderSQL tab0 <+> "AS" <+> renderSQL tab
   <> case using of
     NoUsing -> ""
     Using tables -> " USING" <+> renderSQL tables
@@ -75,8 +75,8 @@ deleteFrom tab using wh returning = UnsafeManipulation $
 -- | Delete rows returning `Nil`.
 deleteFrom_
   :: ( Has sch db schema
-     , Has tab schema ('Table table) )
-  => QualifiedAlias sch tab -- ^ table to delete from
+     , Has tab0 schema ('Table table) )
+  => Aliased (QualifiedAlias sch) (tab ::: tab0) -- ^ table to delete from
   -> Condition  'Ungrouped '[] with db params '[tab ::: TableToRow table]
   -- ^ condition under which to delete a row
   -> Manipulation with db params '[]

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation/Insert.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation/Insert.hs
@@ -76,10 +76,10 @@ Even if you know only some column values, a complete row must be created.
 -}
 insertInto
   :: ( Has sch db schema
-     , Has tab schema ('Table table)
+     , Has tab0 schema ('Table table)
      , SOP.SListI (TableToColumns table)
      , SOP.SListI row )
-  => QualifiedAlias sch tab
+  => Aliased (QualifiedAlias sch) (tab ::: tab0)
   -- ^ table
   -> QueryClause with db params (TableToColumns table)
   -- ^ what to insert
@@ -88,8 +88,9 @@ insertInto
   -> ReturningClause with db params '[tab ::: TableToRow table] row
   -- ^ what to return
   -> Manipulation with db params row
-insertInto tab qry conflict ret = UnsafeManipulation $
-  "INSERT" <+> "INTO" <+> renderSQL tab
+insertInto (tab0 `As` tab) qry conflict ret = UnsafeManipulation $
+  "INSERT" <+> "INTO"
+  <+> renderSQL tab0 <+> "AS" <+> renderSQL tab
   <+> renderSQL qry
   <> renderSQL conflict
   <> renderSQL ret
@@ -97,9 +98,9 @@ insertInto tab qry conflict ret = UnsafeManipulation $
 -- | Like `insertInto` but with `OnConflictDoRaise` and no `ReturningClause`.
 insertInto_
   :: ( Has sch db schema
-     , Has tab schema ('Table table)
+     , Has tab0 schema ('Table table)
      , SOP.SListI (TableToColumns table) )
-  => QualifiedAlias sch tab
+  => Aliased (QualifiedAlias sch) (tab ::: tab0)
   -- ^ table
   -> QueryClause with db params (TableToColumns table)
   -- ^ what to insert


### PR DESCRIPTION
The table being manipulated in insertInto, update and deleteFrom can be re-aliased and then referenced by its new alias.