### PR TITLE
make more things polymorphizable

### DIFF
--- a/squeal-postgresql/exe/Example.hs
+++ b/squeal-postgresql/exe/Example.hs
@@ -9,7 +9,7 @@
   , TypeOperators
 #-}
 
-module Main (main, main2) where
+module Main (main, main2, upsertUser) where
 
 import Control.Monad.IO.Class (MonadIO (..))
 import Data.Int (Int16, Int32)
@@ -112,6 +112,14 @@ getUsers = select_
   ( from (table ((#user ! #users) `as` #u)
     & innerJoin (table ((#user ! #emails) `as` #e))
       (#u ! #id .== #e ! #user_id)) )
+
+upsertUser :: Manipulation_ Schemas (Int32, String, VarArray [Maybe Int16]) ()
+upsertUser = insertInto (#user ! #users `as` #u)
+  (Values_ (Set (param @1) `as` #id :* setUser))
+  (OnConflict (OnConstraint #pk_users) (DoUpdate setUser [#u ! #id .== param @1]))
+  (Returning_ Nil)
+  where
+    setUser = Set (param @2) `as` #name :* Set (param @3) `as` #vec :* Nil
 
 data User
   = User

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation/Insert.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation/Insert.hs
@@ -112,9 +112,9 @@ insertInto_ tab qry =
 data QueryClause with db params columns where
   Values
     :: SOP.SListI columns
-    => NP (Aliased (Optional (Expression  'Ungrouped '[] with db params '[]))) columns
+    => NP (Aliased (Optional (Expression 'Ungrouped '[] with db params from))) columns
     -- ^ row of values
-    -> [NP (Aliased (Optional (Expression  'Ungrouped '[] with db params '[]))) columns]
+    -> [NP (Aliased (Optional (Expression 'Ungrouped '[] with db params from))) columns]
     -- ^ additional rows of values
     -> QueryClause with db params columns
   Select
@@ -164,7 +164,7 @@ instance RenderSQL (QueryClause with db params columns) where
 -- whose `ColumnsType` must match the tables'.
 pattern Values_
   :: SOP.SListI columns
-  => NP (Aliased (Optional (Expression  'Ungrouped '[] with db params '[]))) columns
+  => NP (Aliased (Optional (Expression  'Ungrouped '[] with db params from))) columns
   -- ^ row of values
   -> QueryClause with db params columns
 pattern Values_ vals = Values vals []

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation/Update.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Manipulation/Update.hs
@@ -70,13 +70,7 @@ update
      , Updatable table updates
      , SOP.SListI row )
   => Aliased (QualifiedAlias sch) (tab ::: tab0) -- ^ table to update
-  -> NP
-    ( Aliased
-      ( Optional
-        ( Expression 'Ungrouped '[] '[] db params (tab ::: TableToRow table ': from)
-        )
-      )
-    ) updates
+  -> NP (Aliased (Optional (Expression 'Ungrouped '[] with db params (tab ::: TableToRow table ': from)))) updates
   -- ^ update expressions, modified values to replace old values
   -> UsingClause with db params from
   -- ^ FROM A table expression allowing columns from other tables to appear
@@ -103,7 +97,7 @@ update_
      , KnownSymbol tab
      , Updatable table updates )
   => Aliased (QualifiedAlias sch) (tab ::: tab0) -- ^ table to update
-  -> NP (Aliased (Optional (Expression 'Ungrouped '[] '[] db params '[tab ::: TableToRow table]))) updates
+  -> NP (Aliased (Optional (Expression 'Ungrouped '[] with db params '[tab ::: TableToRow table]))) updates
   -- ^ modified values to replace old values
   -> Condition  'Ungrouped '[] with db params '[tab ::: TableToRow table]
   -- ^ condition under which to perform update on a row


### PR DESCRIPTION
By making the `from` type in `Values`s polymorphic, setting clauses should be sharable between `QueryClause`s and `ConflictClause`s in an `insertInto`.