### PR TITLE
Sublist & SubDB

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/List.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/List.hs
@@ -41,6 +41,7 @@ module Squeal.PostgreSQL.Type.List
   , Elem
   , In
   , Length
+  , Sublist
   ) where
 
 import Control.Category.Free
@@ -107,3 +108,9 @@ Length '[Char,String,Bool,Double] :: Nat
 type family Length (xs :: [k]) :: Nat where
   Length '[] = 0
   Length (_ : xs) = 1 + Length xs
+
+type family Sublist (xs :: [k]) (ys :: [k]) :: Bool where
+  Sublist '[] ys = 'True
+  Sublist (x ': xs) '[] = 'False
+  Sublist (x ': xs) (x ': ys) = Sublist xs ys
+  Sublist (x ': xs) (y ': ys) = Sublist (x ': xs) ys

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/List.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/List.hs
@@ -41,7 +41,8 @@ module Squeal.PostgreSQL.Type.List
   , Elem
   , In
   , Length
-  , Sublist
+  , SubList
+  , SubsetList
   ) where
 
 import Control.Category.Free
@@ -109,24 +110,47 @@ type family Length (xs :: [k]) :: Nat where
   Length '[] = 0
   Length (_ : xs) = 1 + Length xs
 
-{- | `Sublist` checks that one type level list is a sublist of another,
+{- | `SubList` checks that one type level list is a sublist of another,
 with the same ordering.
 
->>> :kind! Sublist '[1,2,3] '[4,5,6]
-Sublist '[1,2,3] '[4,5,6] :: Bool
+>>> :kind! SubList '[1,2,3] '[4,5,6]
+SubList '[1,2,3] '[4,5,6] :: Bool
 = 'False
->>> :kind! Sublist '[1,2,3] '[1,2,3,4]
-Sublist '[1,2,3] '[1,2,3,4] :: Bool
+>>> :kind! SubList '[1,2,3] '[1,2,3,4]
+SubList '[1,2,3] '[1,2,3,4] :: Bool
 = 'True
->>> :kind! Sublist '[1,2,3] '[0,1,0,2,0,3]
-Sublist '[1,2,3] '[0,1,0,2,0,3] :: Bool
+>>> :kind! SubList '[1,2,3] '[0,1,0,2,0,3]
+SubList '[1,2,3] '[0,1,0,2,0,3] :: Bool
 = 'True
->>> :kind! Sublist '[1,2,3] '[3,2,1]
-Sublist '[1,2,3] '[3,2,1] :: Bool
+>>> :kind! SubList '[1,2,3] '[3,2,1]
+SubList '[1,2,3] '[3,2,1] :: Bool
 = 'False
 -}
-type family Sublist (xs :: [k]) (ys :: [k]) :: Bool where
-  Sublist '[] ys = 'True
-  Sublist (x ': xs) '[] = 'False
-  Sublist (x ': xs) (x ': ys) = Sublist xs ys
-  Sublist (x ': xs) (y ': ys) = Sublist (x ': xs) ys
+type family SubList (xs :: [k]) (ys :: [k]) :: Bool where
+  SubList '[] ys = 'True
+  SubList (x ': xs) '[] = 'False
+  SubList (x ': xs) (x ': ys) = SubList xs ys
+  SubList (x ': xs) (y ': ys) = SubList (x ': xs) ys
+
+{- | `SubsetList` checks that one type level list is a subset of another,
+regardless of ordering and repeats.
+
+>>> :kind! SubsetList '[1,2,3] '[4,5,6]
+SubsetList '[1,2,3] '[4,5,6] :: Bool
+= 'False
+>>> :kind! SubsetList '[1,2,3] '[1,2,3,4]
+SubsetList '[1,2,3] '[1,2,3,4] :: Bool
+= 'True
+>>> :kind! SubsetList '[1,2,3] '[0,1,0,2,0,3]
+SubsetList '[1,2,3] '[0,1,0,2,0,3] :: Bool
+= 'True
+>>> :kind! SubsetList '[1,2,3] '[3,2,1]
+SubsetList '[1,2,3] '[3,2,1] :: Bool
+= 'True
+>>> :kind! SubsetList '[1,1,1] '[3,2,1]
+SubsetList '[1,1,1] '[3,2,1] :: Bool
+= 'True
+-}
+type family SubsetList (xs :: [k]) (ys :: [k]) :: Bool where
+  SubsetList '[] ys = 'True
+  SubsetList (x ': xs) ys = Elem x ys && SubsetList xs ys

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/List.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/List.hs
@@ -109,6 +109,22 @@ type family Length (xs :: [k]) :: Nat where
   Length '[] = 0
   Length (_ : xs) = 1 + Length xs
 
+{- | `Sublist` checks that one type level list is a sublist of another,
+with the same ordering.
+
+>>> :kind! Sublist '[1,2,3] '[4,5,6]
+Sublist '[1,2,3] '[4,5,6] :: Bool
+= 'False
+>>> :kind! Sublist '[1,2,3] '[1,2,3,4]
+Sublist '[1,2,3] '[1,2,3,4] :: Bool
+= 'True
+>>> :kind! Sublist '[1,2,3] '[0,1,0,2,0,3]
+Sublist '[1,2,3] '[0,1,0,2,0,3] :: Bool
+= 'True
+>>> :kind! Sublist '[1,2,3] '[3,2,1]
+Sublist '[1,2,3] '[3,2,1] :: Bool
+= 'False
+-}
 type family Sublist (xs :: [k]) (ys :: [k]) :: Bool where
   Sublist '[] ys = 'True
   Sublist (x ': xs) '[] = 'False

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
@@ -50,6 +50,7 @@ module Squeal.PostgreSQL.Type.Schema
   , SchemaType
   , SchemasType
   , Public
+  , SubDB
     -- * Constraint
   , (:=>)
   , Optionality (..)
@@ -439,6 +440,15 @@ type family SetSchema sch0 sch1 schema0 schema1 obj srt ty db where
   SetSchema sch0 sch1 schema0 schema1 obj srt ty db = Alter sch1
     (Create obj (srt ty) schema1)
     (Alter sch0 (DropSchemum obj srt schema0) db)
+
+type family SubDB (db0 :: SchemasType) (db1 :: SchemasType) :: Bool where
+  SubDB '[] db1 = 'True
+  SubDB (sch ': db0) '[] = 'False
+  SubDB (sch ::: schema0 ': db0) (sch ::: schema1 ': db1) =
+    If (Sublist schema0 schema1)
+      (SubDB db0 db1)
+      (SubDB (sch ::: schema0 ': db0) db1)
+  SubDB db0 (sch1 ': db1) = SubDB db0 db1
 
 -- | Check if a `TableConstraint` involves a column
 type family ConstraintInvolves column constraint where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
@@ -50,7 +50,10 @@ module Squeal.PostgreSQL.Type.Schema
   , SchemaType
   , SchemasType
   , Public
+    -- * Database Subsets
   , SubDB
+  , SubsetDB
+  , ElemDB
     -- * Constraint
   , (:=>)
   , Optionality (..)
@@ -452,10 +455,29 @@ type family SubDB (db0 :: SchemasType) (db1 :: SchemasType) :: Bool where
   SubDB '[] db1 = 'True
   SubDB (sch ': db0) '[] = 'False
   SubDB (sch ::: schema0 ': db0) (sch ::: schema1 ': db1) =
-    If (Sublist schema0 schema1)
+    If (SubList schema0 schema1)
       (SubDB db0 db1)
       (SubDB (sch ::: schema0 ': db0) db1)
   SubDB db0 (sch1 ': db1) = SubDB db0 db1
+
+{- | `SubsetDB` checks that one `SchemasType` is a subset of another,
+regardless of ordering.
+
+>>> :kind! SubsetDB '["a" ::: '["d" ::: 'Typedef 'PGint2, "b" ::: 'View '[]]] '["a" ::: '["b" ::: 'View '[], "c" ::: 'Typedef 'PGint4, "d" ::: 'Typedef 'PGint2]]
+SubsetDB '["a" ::: '["d" ::: 'Typedef 'PGint2, "b" ::: 'View '[]]] '["a" ::: '["b" ::: 'View '[], "c" ::: 'Typedef 'PGint4, "d" ::: 'Typedef 'PGint2]] :: Bool
+= 'True
+-}
+type family SubsetDB (db0 :: SchemasType) (db1 :: SchemasType) :: Bool where
+  SubsetDB '[] db1 = 'True
+  SubsetDB (sch ': db0) db1 = ElemDB sch db1 && SubsetDB db0 db1
+
+{- | `ElemDB` checks that a schema may be found as a subset of another in a database,
+regardless of ordering.
+-}
+type family ElemDB (sch :: (Symbol, SchemaType)) (db :: SchemasType) :: Bool where
+  ElemDB sch '[] = 'False
+  ElemDB (sch ::: schema0) (sch ::: schema1 ': _) = SubsetList schema0 schema1
+  ElemDB sch (_ ': schs) = ElemDB sch schs
 
 -- | Check if a `TableConstraint` involves a column
 type family ConstraintInvolves column constraint where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
@@ -441,6 +441,13 @@ type family SetSchema sch0 sch1 schema0 schema1 obj srt ty db where
     (Create obj (srt ty) schema1)
     (Alter sch0 (DropSchemum obj srt schema0) db)
 
+{- | `SubDB` checks that one `SchemasType` is a sublist of another,
+with the same ordering.
+
+>>> :kind! SubDB '["a" ::: '["b" ::: 'View '[]]] '["a" ::: '["b" ::: 'View '[], "c" ::: 'Typedef 'PGint4]]
+SubDB '["a" ::: '["b" ::: 'View '[]]] '["a" ::: '["b" ::: 'View '[], "c" ::: 'Typedef 'PGint4]] :: Bool
+= 'True
+-}
 type family SubDB (db0 :: SchemasType) (db1 :: SchemasType) :: Bool where
   SubDB '[] db1 = 'True
   SubDB (sch ': db0) '[] = 'False


### PR DESCRIPTION
`Sublist` & `SubDB` type families should unlock a new form of type safety. Because any SQL statement which is valid in the scope of a given set of schemas will be valid in the scope of a larger set of schemas, any Squeal code which is typechecked against a `db0 :: SchemasType`, should also work for a `db1` for which `SubDB db0 db1 ~ 'True`.