### PR TITLE
Add in functions: strpos, CombineNullity

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Json.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Json.hs
@@ -61,7 +61,9 @@ module Squeal.PostgreSQL.Expression.Json
   , jsonEach
   , jsonbEach
   , jsonEachText
+  , jsonArrayElementsText
   , jsonbEachText
+  , jsonbArrayElementsText
   , jsonObjectKeys
   , jsonbObjectKeys
   , JsonPopulateFunction
@@ -361,6 +363,16 @@ jsonEachText
     ("json_each_text" ::: '["key" ::: 'NotNull 'PGtext, "value" ::: 'NotNull 'PGtext])
 jsonEachText = unsafeSetFunction "json_each_text"
 
+{- | Returns a set of text values from a JSON array
+
+>>> printSQL (select Star (from (jsonArrayElementsText (inline (Json (toJSON ["monkey", "pony", "bear"] ))))))
+SELECT * FROM json_array_elements_text(('["monkey","pony","bear"]' :: json))
+-}
+jsonArrayElementsText
+  :: null 'PGjson -|->
+    ("json_array_elements_text" ::: '["value" ::: 'NotNull 'PGtext])
+jsonArrayElementsText = unsafeSetFunction "json_array_elements_text"
+
 {- | Expands the outermost binary JSON object into a set of key/value pairs.
 
 >>> printSQL (select Star (from (jsonbEachText (inline (Jsonb (object ["a" .= "foo", "b" .= "bar"]))))))
@@ -390,6 +402,16 @@ jsonbObjectKeys
   :: null 'PGjsonb -|->
     ("jsonb_object_keys" ::: '["jsonb_object_keys" ::: 'NotNull 'PGtext])
 jsonbObjectKeys = unsafeSetFunction "jsonb_object_keys"
+
+{- | Returns a set of text values from a binary JSON array
+
+>>> printSQL (select Star (from (jsonbArrayElementsText (inline (Jsonb (toJSON ["red", "green", "cyan"] ))))))
+SELECT * FROM jsonb_array_elements_text(('["red","green","cyan"]' :: jsonb))
+-}
+jsonbArrayElementsText
+  :: null 'PGjsonb -|->
+    ("jsonb_array_elements_text" ::: '["value" ::: 'NotNull 'PGtext])
+jsonbArrayElementsText = unsafeSetFunction "jsonb_array_elements_text"
 
 -- | Build rows from Json types.
 type JsonPopulateFunction fun json

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Null.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Null.hs
@@ -10,8 +10,10 @@ null expressions and handlers
 
 {-# LANGUAGE
     DataKinds
+  , KindSignatures
   , OverloadedStrings
   , RankNTypes
+  , TypeFamilies
   , TypeOperators
 #-}
 
@@ -27,6 +29,7 @@ module Squeal.PostgreSQL.Expression.Null
   , isNotNull
   , matchNull
   , nullIf
+  , CombineNullity
   ) where
 
 import Squeal.PostgreSQL.Expression
@@ -121,3 +124,11 @@ NULLIF(FALSE, ($1 :: bool))
 -}
 nullIf :: '[ 'NotNull ty, 'NotNull ty] ---> 'Null ty
 nullIf = unsafeFunctionN "NULLIF"
+
+{-| Make the return type of the type family `NotNull` if both arguments are,
+   or `Null` otherwise.
+-}
+type family CombineNullity
+      (lhs :: PGType -> NullType) (rhs :: PGType -> NullType) :: PGType -> NullType where
+  CombineNullity 'NotNull 'NotNull = 'NotNull
+  CombineNullity _ _ = 'Null

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Text.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Text.hs
@@ -11,6 +11,8 @@ text functions and operators
 {-# LANGUAGE
     DataKinds
   , OverloadedStrings
+  , RankNTypes
+  , ScopedTypeVariables
   , TypeOperators
 #-}
 
@@ -21,6 +23,8 @@ module Squeal.PostgreSQL.Expression.Text
   , charLength
   , like
   , ilike
+  , replace
+  , strpos
   ) where
 
 import Squeal.PostgreSQL.Expression
@@ -63,3 +67,22 @@ like = unsafeBinaryOp "LIKE"
 -- ((E'abc' :: text) ILIKE (E'a%' :: text))
 ilike :: Operator (null 'PGtext) (null 'PGtext) ('Null 'PGbool)
 ilike = unsafeBinaryOp "ILIKE"
+
+-- | Determines the location of the substring match using the `strpos`
+-- function. Returns the 1-based index of the first match, if no
+-- match exists the function returns (0).
+--
+-- >>> printSQL $ strpos ("string" *: "substring")
+-- strpos((E'string' :: text), (E'substring' :: text))
+strpos
+  :: '[null 'PGtext, null 'PGtext] ---> null 'PGint4
+strpos = unsafeFunctionN "strpos"
+
+-- | Over the string in the first argument, replace all occurrences of
+-- the second argument with the third and return the modified string.
+--
+-- >>> printSQL $ replace ("string" :* "from" *: "to")
+-- replace((E'string' :: text), (E'from' :: text), (E'to' :: text))
+replace
+  :: '[ null 'PGtext, null 'PGtext, null 'PGtext ] ---> null 'PGtext
+replace = unsafeFunctionN "replace"


### PR DESCRIPTION
Adds a type family to combine nullity of two arguments, and two functions for determining if a string is a substring of another string. 
I've wrote a version `strpos` a few of times while writing application code, and think it'd be a useful addition to `squeal`, as it directly mirrors an existing Postgresql.