### PR TITLE
use Control.Monad.Catch instead of UnliftIO

### DIFF
--- a/squeal-postgresql-ltree/squeal-postgresql-ltree.cabal
+++ b/squeal-postgresql-ltree/squeal-postgresql-ltree.cabal
@@ -27,7 +27,6 @@ library
   build-depends:
       base >= 4.12.0.0 && < 5.0
     , bytestring >= 0.10.10.0
-    , exceptions >= 0.10.3
     , generics-sop >= 0.5.1.0
     , mtl >= 2.2.2
     , postgresql-binary >= 0.12.2

--- a/squeal-postgresql-ltree/squeal-postgresql-ltree.cabal
+++ b/squeal-postgresql-ltree/squeal-postgresql-ltree.cabal
@@ -27,10 +27,10 @@ library
   build-depends:
       base >= 4.12.0.0 && < 5.0
     , bytestring >= 0.10.10.0
+    , exceptions >= 0.10.3
     , generics-sop >= 0.5.1.0
     , mtl >= 2.2.2
     , postgresql-binary >= 0.12.2
     , postgresql-libpq >= 0.9.4.2
     , squeal-postgresql >= 0.7.0.1
     , text >= 1.2.3.2
-    , unliftio >= 0.2.12.1

--- a/squeal-postgresql-ltree/src/Squeal/PostgreSQL/LTree.hs
+++ b/squeal-postgresql-ltree/src/Squeal/PostgreSQL/LTree.hs
@@ -43,7 +43,7 @@ module Squeal.PostgreSQL.LTree
   , (?@>), (?<@), (?~), (?@)
   ) where
 
-import Control.Monad.Catch
+import Control.Exception
 import Control.Monad.Reader
 import Data.ByteString (ByteString)
 import Data.String
@@ -104,13 +104,13 @@ oidLookup
 oidLookup tyOrArr name = ReaderT $ \(SOP.K conn) -> do
   resultMaybe <- LibPQ.execParams conn q [] LibPQ.Binary
   case resultMaybe of
-    Nothing -> throwM $ ConnectionException "LibPQ.execParams"
+    Nothing -> throwIO $ ConnectionException "LibPQ.execParams"
     Just result -> do
       valueMaybe <- LibPQ.getvalue result 0 0
       case valueMaybe of
-        Nothing -> throwM $ ConnectionException "LibPQ.getvalue"
+        Nothing -> throwIO $ ConnectionException "LibPQ.getvalue"
         Just value -> case Decoding.valueParser Decoding.int value of
-          Left err -> throwM $ DecodingException "oidOfTy" err
+          Left err -> throwIO $ DecodingException "oidOfTy" err
           Right oid' -> return $ LibPQ.Oid oid'
   where
     q = "SELECT " <> tyOrArr <> " FROM pg_type WHERE typname = \'" <> name <> "\';"

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Exception.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Exception.hs
@@ -27,10 +27,9 @@ module Squeal.PostgreSQL.Session.Exception
   , throwSqueal
   ) where
 
-import Control.Exception (Exception)
+import Control.Monad.Catch
 import Data.ByteString (ByteString)
 import Data.Text (Text)
-import UnliftIO (MonadUnliftIO (..), catch, handle, try, throwIO)
 
 import qualified Database.PostgreSQL.LibPQ as LibPQ
 
@@ -79,23 +78,23 @@ pattern DeadlockDetected msg =
 
 -- | Catch `SquealException`s.
 catchSqueal
-  :: MonadUnliftIO io
-  => io a
-  -> (SquealException -> io a) -- ^ handler
-  -> io a
+  :: MonadCatch m
+  => m a
+  -> (SquealException -> m a) -- ^ handler
+  -> m a
 catchSqueal = catch
 
 -- | Handle `SquealException`s.
 handleSqueal
-  :: MonadUnliftIO io
-  => (SquealException -> io a) -- ^ handler
-  -> io a -> io a
+  :: MonadCatch m
+  => (SquealException -> m a) -- ^ handler
+  -> m a -> m a
 handleSqueal = handle
 
 -- | `Either` return a `SquealException` or a result.
-trySqueal :: MonadUnliftIO io => io a -> io (Either SquealException a)
+trySqueal :: MonadCatch m => m a -> m (Either SquealException a)
 trySqueal = try
 
 -- | Throw `SquealException`s.
-throwSqueal :: MonadUnliftIO io => SquealException -> io a
-throwSqueal = throwIO
+throwSqueal :: MonadThrow m => SquealException -> m a
+throwSqueal = throwM

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Migration.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Migration.hs
@@ -167,6 +167,7 @@ module Squeal.PostgreSQL.Session.Migration
 import Control.Category
 import Control.Category.Free
 import Control.Monad
+import Control.Monad.IO.Class
 import Data.ByteString (ByteString)
 import Data.Foldable (traverse_)
 import Data.Function ((&))
@@ -177,7 +178,6 @@ import Data.Text (Text)
 import Data.Time (UTCTime)
 import Prelude hiding ((.), id)
 import System.Environment
-import UnliftIO (MonadIO (..))
 
 import qualified Data.Text.IO as Text (putStrLn)
 import qualified Generics.SOP as SOP

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Oid.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Oid.hs
@@ -34,10 +34,10 @@ module Squeal.PostgreSQL.Session.Oid
   , OidOfField (..)
   ) where
 
+import Control.Monad.Catch
 import Control.Monad.Reader
 import Data.String
 import GHC.TypeLits
-import UnliftIO (throwIO)
 import PostgreSQL.Binary.Decoding (valueParser, int)
 
 import qualified Data.ByteString as ByteString
@@ -173,13 +173,13 @@ oidOfTypedef
 oidOfTypedef (_ :: QualifiedAlias sch ty) = ReaderT $ \(SOP.K conn) -> do
   resultMaybe <- LibPQ.execParams conn q [] LibPQ.Binary
   case resultMaybe of
-    Nothing -> throwIO $ ConnectionException "LibPQ.execParams"
+    Nothing -> throwM $ ConnectionException "LibPQ.execParams"
     Just result -> do
       valueMaybe <- LibPQ.getvalue result 0 0
       case valueMaybe of
-        Nothing -> throwIO $ ConnectionException "LibPQ.getvalue"
+        Nothing -> throwM $ ConnectionException "LibPQ.getvalue"
         Just value -> case valueParser int value of
-          Left err -> throwIO $ DecodingException "oidOfTypedef" err
+          Left err -> throwM $ DecodingException "oidOfTypedef" err
           Right oid -> return $ LibPQ.Oid oid
   where
     q = ByteString.intercalate " "
@@ -200,13 +200,13 @@ oidOfArrayTypedef
 oidOfArrayTypedef (_ :: QualifiedAlias sch ty) = ReaderT $ \(SOP.K conn) -> do
   resultMaybe <- LibPQ.execParams conn q [] LibPQ.Binary
   case resultMaybe of
-    Nothing -> throwIO $ ConnectionException "LibPQ.execParams"
+    Nothing -> throwM $ ConnectionException "LibPQ.execParams"
     Just result -> do
       valueMaybe <- LibPQ.getvalue result 0 0
       case valueMaybe of
-        Nothing -> throwIO $ ConnectionException "LibPQ.getvalue"
+        Nothing -> throwM $ ConnectionException "LibPQ.getvalue"
         Just value -> case valueParser int value of
-          Left err -> throwIO $ DecodingException "oidOfArray" err
+          Left err -> throwM $ DecodingException "oidOfArray" err
           Right oid -> return $ LibPQ.Oid oid
   where
     q = ByteString.intercalate " "

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Result.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Result.hs
@@ -28,12 +28,12 @@ module Squeal.PostgreSQL.Session.Result
 
 import Control.Exception (throw)
 import Control.Monad (when, (<=<))
+import Control.Monad.Catch
 import Control.Monad.IO.Class
 import Data.ByteString (ByteString)
 import Data.Text (Text)
 import Data.Traversable (for)
 import Text.Read (readMaybe)
-import UnliftIO (throwIO)
 
 import qualified Data.ByteString as ByteString
 import qualified Data.ByteString.Char8 as Char8
@@ -159,13 +159,13 @@ instance (Monad io, MonadIO io) => MonadResult io where
   cmdStatus = liftResult (getCmdStatus <=< LibPQ.cmdStatus)
     where
       getCmdStatus = \case
-        Nothing -> throwIO $ ConnectionException "LibPQ.cmdStatus"
+        Nothing -> throwM $ ConnectionException "LibPQ.cmdStatus"
         Just bytes -> return $ Text.decodeUtf8 bytes
 
   cmdTuples = liftResult (getCmdTuples <=< LibPQ.cmdTuples)
     where
       getCmdTuples = \case
-        Nothing -> throwIO $ ConnectionException "LibPQ.cmdTuples"
+        Nothing -> throwM $ ConnectionException "LibPQ.cmdTuples"
         Just bytes -> return $
           if ByteString.null bytes
           then Nothing

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Transaction.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Transaction.hs
@@ -49,7 +49,7 @@ import qualified Squeal.PostgreSQL.Session.Transaction.Unsafe as Unsafe
 
 {- | A type of "safe" `Transaction`s,
 do-blocks that permit only
-database operations, pure functions, and exception handling
+database operations, pure functions, and synchronous exception handling
 forbidding arbitrary `IO` operations.
 
 To permit arbitrary `IO`,


### PR DESCRIPTION
retain `UnliftIO` instance for `PQ` but use `Control.Monad.Catch` instead