### PR TITLE
fixes

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Comparison.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Comparison.hs
@@ -150,7 +150,7 @@ notBetweenSymmetric = unsafeBetweenExpr "NOT BETWEEN SYMMETRIC"
 >>> printSQL $ true `isDistinctFrom` null_
 (TRUE IS DISTINCT FROM NULL)
 -}
-isDistinctFrom :: Operator (null0 ty) (null1 ty) ('Null 'PGbool)
+isDistinctFrom :: Operator (null0 ty) (null1 ty) (null 'PGbool)
 isDistinctFrom = unsafeBinaryOp "IS DISTINCT FROM"
 
 {- | equal, treating null like an ordinary value
@@ -158,7 +158,7 @@ isDistinctFrom = unsafeBinaryOp "IS DISTINCT FROM"
 >>> printSQL $ true `isNotDistinctFrom` null_
 (TRUE IS NOT DISTINCT FROM NULL)
 -}
-isNotDistinctFrom :: Operator (null0 ty) (null1 ty) ('NotNull 'PGbool)
+isNotDistinctFrom :: Operator (null0 ty) (null1 ty) (null 'PGbool)
 isNotDistinctFrom = unsafeBinaryOp "IS NOT DISTINCT FROM"
 
 {- | is true

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Subquery.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Subquery.hs
@@ -104,6 +104,7 @@ in_
   :: Expression grp lat with db params from ty -- ^ expression
   -> [Expression grp lat with db params from ty]
   -> Expression grp lat with db params from (null 'PGbool)
+_ `in_` [] = false
 expr `in_` exprs = UnsafeExpression $ renderSQL expr <+> "IN"
   <+> parenthesized (commaSeparated (renderSQL <$> exprs))
 
@@ -118,5 +119,6 @@ notIn
   :: Expression grp lat with db params from ty -- ^ expression
   -> [Expression grp lat with db params from ty]
   -> Expression grp lat with db params from (null 'PGbool)
+_ `notIn` [] = true
 expr `notIn` exprs = UnsafeExpression $ renderSQL expr <+> "NOT IN"
   <+> parenthesized (commaSeparated (renderSQL <$> exprs))


### PR DESCRIPTION
* generalize return type of `isDistinctFrom` and `isNotDistinctFrom` to a subtype of `Condition`s.
* bugfix: empty `in_` and `notIn` operators should not produce illegal SQL, instead produce `false` and `true` respectively.
* feature request: Add a field label to the exception thrown when an overloaded label for a field decoder has a parse error.