### PR TITLE
type error for binary instances for LTree and friends

### DIFF
--- a/squeal-postgresql-ltree/src/Squeal/PostgreSQL/LTree.hs
+++ b/squeal-postgresql-ltree/src/Squeal/PostgreSQL/LTree.hs
@@ -21,6 +21,7 @@ labels of data stored in a hierarchical tree-like structure.
   , TypeFamilies
   , TypeOperators
   , TypeSynonymInstances
+  , UndecidableInstances
 #-}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -43,11 +44,12 @@ module Squeal.PostgreSQL.LTree
   , (?@>), (?<@), (?~), (?@)
   ) where
 
-import Control.Exception
+import Control.Exception hiding (TypeError)
 import Control.Monad.Reader
 import Data.String
 import Data.Text
 import GHC.Generics
+import GHC.TypeLits (ErrorMessage(Text), TypeError)
 import Squeal.PostgreSQL
 import Squeal.PostgreSQL.Render
 
@@ -146,10 +148,12 @@ newtype LTree = UnsafeLTree {getLTree :: Text}
   deriving stock (Eq,Ord,Show,Read,Generic)
 -- | `PGltree`
 instance IsPG LTree where type PG LTree = PGltree
-instance FromPG LTree where
+instance TypeError ('Text "LTree binary instances not yet implemented.")
+  => FromPG LTree where
   fromPG = UnsafeLTree <$> devalue Decoding.text_strict
-instance ToPG db LTree where
-  toPG = pure . Encoding.text_strict . getLTree
+instance TypeError ('Text "LTree binary instances not yet implemented.")
+  => ToPG db LTree where
+    toPG = pure . Encoding.text_strict . getLTree
 instance Inline LTree where
   inline
     = UnsafeExpression
@@ -217,9 +221,11 @@ newtype LQuery = UnsafeLQuery {getLQuery :: Text}
   deriving stock (Eq,Ord,Show,Read,Generic)
 -- | `PGlquery`
 instance IsPG LQuery where type PG LQuery = PGlquery
-instance FromPG LQuery where
+instance TypeError ('Text "LQuery binary instances not yet implemented.")
+  => FromPG LQuery where
   fromPG = UnsafeLQuery <$> devalue Decoding.text_strict
-instance ToPG db LQuery where
+instance TypeError ('Text "LQuery binary instances not yet implemented.")
+  => ToPG db LQuery where
   toPG = pure . Encoding.text_strict . getLQuery
 instance Inline LQuery where
   inline
@@ -256,9 +262,11 @@ newtype LTxtQuery = UnsafeLTxtQuery {getLTxtQuery :: Text}
   deriving stock (Eq,Ord,Show,Read,Generic)
 -- | `PGltxtquery`
 instance IsPG LTxtQuery where type PG LTxtQuery = PGltxtquery
-instance FromPG LTxtQuery where
+instance TypeError ('Text "LTxtQuery binary instances not yet implemented.")
+  => FromPG LTxtQuery where
   fromPG = UnsafeLTxtQuery <$> devalue Decoding.text_strict
-instance ToPG db LTxtQuery where
+instance TypeError ('Text "LTxtQuery binary instances not yet implemented.")
+  => ToPG db LTxtQuery where
   toPG = pure . Encoding.text_strict . getLTxtQuery
 instance Inline LTxtQuery where
   inline


### PR DESCRIPTION
For now, just have a type error and use `inline` instead or cast to `text`. There is a real binary encoding but I couldn't get my tests to pass.