### PR TITLE
more correct `in_` and `notIn`

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Subquery.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Subquery.hs
@@ -103,7 +103,7 @@ TRUE IN (TRUE, FALSE, NULL)
 in_
   :: Expression grp lat with db params from ty -- ^ expression
   -> [Expression grp lat with db params from ty]
-  -> Expression grp lat with db params from (null 'PGbool)
+  -> Expression grp lat with db params from ('Null 'PGbool)
 _ `in_` [] = false
 expr `in_` exprs = UnsafeExpression $ renderSQL expr <+> "IN"
   <+> parenthesized (commaSeparated (renderSQL <$> exprs))
@@ -118,7 +118,7 @@ TRUE NOT IN (FALSE, NULL)
 notIn
   :: Expression grp lat with db params from ty -- ^ expression
   -> [Expression grp lat with db params from ty]
-  -> Expression grp lat with db params from (null 'PGbool)
+  -> Expression grp lat with db params from ('Null 'PGbool)
 _ `notIn` [] = true
 expr `notIn` exprs = UnsafeExpression $ renderSQL expr <+> "NOT IN"
   <+> parenthesized (commaSeparated (renderSQL <$> exprs))


### PR DESCRIPTION
these should produce `Condition`s meaning nullable boolean values because e.g. `select NULL in (NULL)` is `NULL`.