### PR TITLE
Expand user types to include tables and views

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Composite.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Composite.hs
@@ -81,13 +81,15 @@ rowStar tab = UnsafeExpression $ "ROW" <>
 -- >>> printSQL $ i & field #complex #imaginary
 -- (ROW((0.0 :: float8), (1.0 :: float8))::"complex")."imaginary"
 field
-  :: ( Has sch db schema
-     , Has tydef schema ('Typedef ('PGcomposite row))
-     , Has field row ty)
-  => QualifiedAlias sch tydef -- ^ row type
+  :: ( relss ~ DbRelations db
+     , Has sch relss rels
+     , Has rel rels row
+     , Has field row ty
+     )
+  => QualifiedAlias sch rel -- ^ row type
   -> Alias field -- ^ field name
   -> Expression grp lat with db params from ('NotNull ('PGcomposite row))
   -> Expression grp lat with db params from ty
-field td fld expr = UnsafeExpression $
-  parenthesized (renderSQL expr <> "::" <> renderSQL td)
+field rel fld expr = UnsafeExpression $
+  parenthesized (renderSQL expr <> "::" <> renderSQL rel)
     <> "." <> renderSQL fld

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Type.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Type.hs
@@ -377,13 +377,15 @@ instance PGTyped db ('PGrange 'PGtimestamp) where pgtype = tsrange
 instance PGTyped db ('PGrange 'PGtimestamptz) where pgtype = tstzrange
 instance PGTyped db ('PGrange 'PGdate) where pgtype = daterange
 instance
-  ( UserType db ('PGcomposite row) ~ '(sch,td)
+  ( rels ~ DbRelations db
+  , FindFullName "no composite found with relation: " rels row ~ '(sch,td)
   , Has sch db schema
   , Has td schema ('Typedef ('PGcomposite row))
   ) => PGTyped db ('PGcomposite row) where
     pgtype = typedef (QualifiedAlias @sch @td)
 instance
-  ( UserType db ('PGenum labels) ~ '(sch,td)
+  ( enums ~ DbEnums db
+  , FindFullName "no enum found with labels: " enums labels ~ '(sch,td)
   , Has sch db schema
   , Has td schema ('Typedef ('PGenum labels))
   ) => PGTyped db ('PGenum labels) where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Type.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Type.hs
@@ -173,6 +173,9 @@ newtype TypeExpression (db :: SchemasType) (ty :: NullType)
 instance RenderSQL (TypeExpression db ty) where
   renderSQL = renderTypeExpression
 
+-- | The composite type corresponding to a relation can be expressed
+-- by its alias. A relation is either a composite type, a table or a view.
+-- It subsumes `typetable` and `typeview` and partly overlaps `typedef`.
 typerow
   :: ( relss ~ DbRelations db
      , Has sch relss rels
@@ -391,12 +394,12 @@ instance
   ( relss ~ DbRelations db
   , Has sch relss rels
   , Has rel rels row
-  , FindFullName "no composite found with relation: " relss row ~ '(sch,rel)  
+  , FindQualified "no composite found with relation: " relss row ~ '(sch,rel)  
   ) => PGTyped db ('PGcomposite row) where
     pgtype = typerow (QualifiedAlias @sch @rel)
 instance
   ( enums ~ DbEnums db
-  , FindFullName "no enum found with labels: " enums labels ~ '(sch,td)
+  , FindQualified "no enum found with labels: " enums labels ~ '(sch,td)
   , Has sch db schema
   , Has td schema ('Typedef ('PGenum labels))
   ) => PGTyped db ('PGenum labels) where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Type.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Type.hs
@@ -394,7 +394,7 @@ instance
   ( relss ~ DbRelations db
   , Has sch relss rels
   , Has rel rels row
-  , FindQualified "no composite found with relation: " relss row ~ '(sch,rel)  
+  , FindQualified "no relation found with row: " relss row ~ '(sch,rel)  
   ) => PGTyped db ('PGcomposite row) where
     pgtype = typerow (QualifiedAlias @sch @rel)
 instance

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Oid.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Oid.hs
@@ -142,35 +142,38 @@ instance OidOfArray db ('PGrange 'PGtimestamptz) where oidOfArray = pure $ LibPQ
 instance OidOf db ('PGrange 'PGdate) where oidOf = pure $ LibPQ.Oid 3912
 instance OidOfArray db ('PGrange 'PGdate) where oidOfArray = pure $ LibPQ.Oid 3913
 instance
-  ( UserType db ('PGcomposite row) ~ '(sch,td)
-  , Has sch db schema
-  , Has td schema ('Typedef ('PGcomposite row)) )
-  => OidOf db ('PGcomposite row) where
-    oidOf = oidOfTypedef (QualifiedAlias @sch @td)
+  ( KnownSymbol sch
+  , KnownSymbol td
+  , rels ~ DbRelations db
+  , FindFullName "no composite found with relation: " rels row ~ '(sch,td)
+  ) => OidOf db ('PGcomposite row) where
+    oidOf = oidOfTypedef @sch @td
 instance
-  ( UserType db ('PGcomposite row) ~ '(sch,td)
-  , Has sch db schema
-  , Has td schema ('Typedef ('PGcomposite row)) )
-  => OidOfArray db ('PGcomposite row) where
-    oidOfArray = oidOfArrayTypedef (QualifiedAlias @sch @td)
+  ( KnownSymbol sch
+  , KnownSymbol td
+  , rels ~ DbRelations db
+  , FindFullName "no composite found with relation: " rels row ~ '(sch,td)
+  ) => OidOfArray db ('PGcomposite row) where
+    oidOfArray = oidOfArrayTypedef @sch @td
 instance
-  ( UserType db ('PGenum labels) ~ '(sch,td)
-  , Has sch db schema
-  , Has td schema ('Typedef ('PGenum labels)) )
-  => OidOf db ('PGenum labels) where
-    oidOf = oidOfTypedef (QualifiedAlias @sch @td)
+  ( enums ~ DbEnums db
+  , FindFullName "no enum found with labels: " enums labels ~ '(sch,td)
+  , KnownSymbol sch
+  , KnownSymbol td
+  ) => OidOf db ('PGenum labels) where
+    oidOf = oidOfTypedef @sch @td
 instance
-  ( UserType db ('PGenum labels) ~ '(sch,td)
-  , Has sch db schema
-  , Has td schema ('Typedef ('PGenum labels)) )
-  => OidOfArray db ('PGenum labels) where
-    oidOfArray = oidOfArrayTypedef (QualifiedAlias @sch @td)
+  ( enums ~ DbEnums db
+  , FindFullName "no enum found with labels: " enums labels ~ '(sch,td)
+  , KnownSymbol sch
+  , KnownSymbol td
+  ) => OidOfArray db ('PGenum labels) where
+    oidOfArray = oidOfArrayTypedef @sch @td
 
 oidOfTypedef
-  :: (Has sch db schema, Has ty schema pg)
-  => QualifiedAlias sch ty
-  -> ReaderT (SOP.K LibPQ.Connection db) IO LibPQ.Oid
-oidOfTypedef (_ :: QualifiedAlias sch ty) = ReaderT $ \(SOP.K conn) -> do
+  :: forall sch ty db. (KnownSymbol sch, KnownSymbol ty)
+  => ReaderT (SOP.K LibPQ.Connection db) IO LibPQ.Oid
+oidOfTypedef = ReaderT $ \(SOP.K conn) -> do
   resultMaybe <- LibPQ.execParams conn q [] LibPQ.Binary
   case resultMaybe of
     Nothing -> throwM $ ConnectionException oidErr
@@ -199,10 +202,9 @@ oidOfTypedef (_ :: QualifiedAlias sch ty) = ReaderT $ \(SOP.K conn) -> do
       , ";" ]
 
 oidOfArrayTypedef
-  :: (Has sch db schema, Has ty schema pg)
-  => QualifiedAlias sch ty
-  -> ReaderT (SOP.K LibPQ.Connection db) IO LibPQ.Oid
-oidOfArrayTypedef (_ :: QualifiedAlias sch ty) = ReaderT $ \(SOP.K conn) -> do
+  :: forall sch ty db. (KnownSymbol sch, KnownSymbol ty)
+  => ReaderT (SOP.K LibPQ.Connection db) IO LibPQ.Oid
+oidOfArrayTypedef = ReaderT $ \(SOP.K conn) -> do
   resultMaybe <- LibPQ.execParams conn q [] LibPQ.Binary
   case resultMaybe of
     Nothing -> throwM $ ConnectionException oidErr

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Oid.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Oid.hs
@@ -145,26 +145,26 @@ instance
   ( KnownSymbol sch
   , KnownSymbol td
   , rels ~ DbRelations db
-  , FindFullName "no composite found with relation: " rels row ~ '(sch,td)
+  , FindQualified "no composite found with relation: " rels row ~ '(sch,td)
   ) => OidOf db ('PGcomposite row) where
     oidOf = oidOfTypedef @sch @td
 instance
   ( KnownSymbol sch
   , KnownSymbol td
   , rels ~ DbRelations db
-  , FindFullName "no composite found with relation: " rels row ~ '(sch,td)
+  , FindQualified "no composite found with relation: " rels row ~ '(sch,td)
   ) => OidOfArray db ('PGcomposite row) where
     oidOfArray = oidOfArrayTypedef @sch @td
 instance
   ( enums ~ DbEnums db
-  , FindFullName "no enum found with labels: " enums labels ~ '(sch,td)
+  , FindQualified "no enum found with labels: " enums labels ~ '(sch,td)
   , KnownSymbol sch
   , KnownSymbol td
   ) => OidOf db ('PGenum labels) where
     oidOf = oidOfTypedef @sch @td
 instance
   ( enums ~ DbEnums db
-  , FindFullName "no enum found with labels: " enums labels ~ '(sch,td)
+  , FindQualified "no enum found with labels: " enums labels ~ '(sch,td)
   , KnownSymbol sch
   , KnownSymbol td
   ) => OidOfArray db ('PGenum labels) where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Oid.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Oid.hs
@@ -145,14 +145,14 @@ instance
   ( KnownSymbol sch
   , KnownSymbol td
   , rels ~ DbRelations db
-  , FindQualified "no composite found with relation: " rels row ~ '(sch,td)
+  , FindQualified "no relation found with row: " rels row ~ '(sch,td)
   ) => OidOf db ('PGcomposite row) where
     oidOf = oidOfTypedef @sch @td
 instance
   ( KnownSymbol sch
   , KnownSymbol td
   , rels ~ DbRelations db
-  , FindQualified "no composite found with relation: " rels row ~ '(sch,td)
+  , FindQualified "no relation found with row: " rels row ~ '(sch,td)
   ) => OidOfArray db ('PGcomposite row) where
     oidOfArray = oidOfArrayTypedef @sch @td
 instance

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
@@ -797,6 +797,16 @@ This is used to find the qualified name of a user defined type.
 FindQualified "my error message: " :: [(k1, [(k2, k3)])]
                                       -> k3 -> (k1, k2)
 = FindQualified "my error message: "
+
+>>> :kind! FindQualified "couldn't find type: " '[ "foo" ::: '["bar" ::: Double]] Double
+FindQualified "couldn't find type: " '[ "foo" ::: '["bar" ::: Double]] Double :: (Symbol,
+                                                                                  Symbol)
+= '("foo", "bar")
+
+>>> :kind! FindQualified "couldn't find type: " '[ "foo" ::: '["bar" ::: Double]] Bool
+FindQualified "couldn't find type: " '[ "foo" ::: '["bar" ::: Double]] Bool :: (Symbol,
+                                                                                Symbol)
+= (TypeError ...)
 -}
 type family FindQualified err xss x where
   FindQualified err '[] x = TypeError ('Text err ':<>: 'ShowType x)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
@@ -789,4 +789,3 @@ type family FindFullName err xss x where
   FindFullName err '[] x = TypeError ('Text err ':<>: 'ShowType x)
   FindFullName err ( '(nsp, xs) ': xss) x =
     FindNamespace err nsp (FindName xs x) xss x
-  

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
@@ -109,10 +109,10 @@ module Squeal.PostgreSQL.Type.Schema
   , Updatable
   , AllUnique
   , IsNotElem
-    -- * User Types
-  , UserType
-  , UserTypeName
-  , UserTypeNamespace
+    -- * User Type Lookup
+  , DbEnums
+  , DbRelations
+  , FindFullName
   ) where
 
 import Control.Category
@@ -750,24 +750,43 @@ type Updatable table columns =
   , AllUnique columns
   , SListI (TableToColumns table) )
 
--- | Calculate the name of a user defined type.
-type family UserTypeName (schema :: SchemaType) (ty :: PGType) where
-  UserTypeName '[] ty = 'Nothing
-  UserTypeName (td ::: 'Typedef ty ': _) ty = 'Just td
-  UserTypeName (_ ': schema) ty = UserTypeName schema ty
+type family SchemaEnums schema where
+  SchemaEnums '[] = '[]
+  SchemaEnums (enum ::: 'Typedef ('PGenum labels) ': schema) =
+    enum ::: labels ': SchemaEnums schema
+  SchemaEnums (_ ': schema) = SchemaEnums schema
 
--- | Helper to calculate the schema of a user defined type.
-type family UserTypeNamespace
-  (sch :: Symbol)
-  (td :: Maybe Symbol)
-  (schemas :: SchemasType)
-  (ty :: PGType) where
-    UserTypeNamespace sch 'Nothing schemas ty = UserType schemas ty
-    UserTypeNamespace sch ('Just td) schemas ty = '(sch, td)
+type family DbEnums db where
+  DbEnums '[] = '[]
+  DbEnums (sch ::: schema ': schemas) =
+    sch ::: SchemaEnums schema ': DbEnums schemas
 
--- | Calculate the schema and name of a user defined type.
-type family UserType (db :: SchemasType) (ty :: PGType) where
-  UserType '[] ty = TypeError
-    ('Text "No such user type: " ':<>: 'ShowType ty)
-  UserType (sch ::: schema ': schemas) ty =
-    UserTypeNamespace sch (UserTypeName schema ty) schemas ty
+type family SchemaRelations schema where
+  SchemaRelations '[] = '[]
+  SchemaRelations (tab ::: 'Table table ': schema) =
+    tab ::: TableToRow table ': SchemaRelations schema
+  SchemaRelations (vw ::: 'View row ': schema) =
+    vw ::: row ': SchemaRelations schema
+  SchemaRelations (ty ::: 'Typedef ('PGcomposite row) ': schema) =
+    ty ::: row ': SchemaRelations schema
+  SchemaRelations (_ ': schema) = SchemaRelations schema
+
+type family DbRelations db where
+  DbRelations '[] = '[]
+  DbRelations (sch ::: schema ': schemas) =
+    sch ::: SchemaRelations schema ': DbRelations schemas
+
+type family FindName xs x where
+  FindName '[] xs = 'Nothing
+  FindName ( '(name, x) ': _) x = 'Just name
+  FindName (_ ': xs) x = FindName xs x
+
+type family FindNamespace err nsp name xss x where
+  FindNamespace err _ 'Nothing xss x = FindFullName err xss x
+  FindNamespace _ nsp ('Just name) _ _ = '(nsp, name)
+
+type family FindFullName err xss x where
+  FindFullName err '[] x = TypeError ('Text err ':<>: 'ShowType x)
+  FindFullName err ( '(nsp, xs) ': xss) x =
+    FindNamespace err nsp (FindName xs x) xss x
+  


### PR DESCRIPTION
This PR broadens user defined row types to include table and view row types. Previously Squeal only truly supported composite row types. Collectively, these are known as relations. Other kinds of relations besides composites, tables and views are not yet supported. There are still some iffy corner cases but I think it's an improvement.