### PR TITLE
Combinators for hand rolling `ToPG` for `PGenum`s and `PGcomposite`s

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Encode.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Encode.hs
@@ -206,7 +206,7 @@ instance
   , SOP.All (OidOfField db) fields
   , RowPG x ~ fields
   ) => ToPG db (Composite x) where
-    toPG = rowParam @db @fields (contramap getComposite genericRowParams)
+    toPG = rowParam (contramap getComposite genericRowParams)
 instance ToPG db x => ToPG db (Range x) where
   toPG r = do
     payload <- case r of
@@ -546,7 +546,7 @@ instance ToPG db Dir where
 :}
 -}
 enumParam
-  :: forall db labels x. (PG x ~ 'PGenum labels, SOP.All KnownSymbol labels)
+  :: (PG x ~ 'PGenum labels, SOP.All KnownSymbol labels)
   => (x -> SOP.NS (SOP.K ()) labels)
   -> x -> ReaderT (SOP.K LibPQ.Connection db) IO Encoding
 enumParam casesOf
@@ -580,10 +580,10 @@ instance ToPG db Complex where
 :}
 -}
 rowParam
-  :: forall db row x. (PG x ~ 'PGcomposite row, SOP.All (OidOfField db) row)
+  :: (PG x ~ 'PGcomposite row, SOP.All (OidOfField db) row)
   => EncodeParams db row x
   -> x -> ReaderT (SOP.K LibPQ.Connection db) IO Encoding
-rowParam enc x = do
+rowParam (enc :: EncodeParams db row x) x = do
   let
     compositeSize
       = int4_int32

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Encode.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Encode.hs
@@ -547,7 +547,7 @@ instance ToPG db Dir where
 -}
 enumParam
   :: (PG x ~ 'PGenum labels, SOP.All KnownSymbol labels)
-  => (x -> SOP.NS (SOP.K ()) labels)
+  => (x -> SOP.NS PGlabel labels)
   -> x -> ReaderT (SOP.K LibPQ.Connection db) IO Encoding
 enumParam casesOf
   = return
@@ -558,10 +558,10 @@ enumParam casesOf
   where
     enumCases
       :: SOP.All KnownSymbol lbls
-      => SOP.NS (SOP.K ()) lbls
+      => SOP.NS PGlabel lbls
       -> String
     enumCases = \case
-      SOP.Z (SOP.K () :: SOP.K () label) -> symbolVal (SOP.Proxy @label)
+      SOP.Z (_ :: PGlabel lbl) -> symbolVal (SOP.Proxy @lbl)
       SOP.S cases -> enumCases cases
 
 {- |

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
@@ -715,12 +715,6 @@ instance labels ~ '[label]
   => IsPGlabel label (NP PGlabel labels) where label = PGlabel :* Nil
 instance IsPGlabel label (y -> K y label) where label = K
 instance IsPGlabel label (y -> NP (K y) '[label]) where label y = K y :* Nil
-instance {-# OVERLAPPING #-}
-  IsPGlabel label0 (NS (K ()) (label0 ': labels)) where
-    label = Z (K ())
-instance {-# OVERLAPPABLE #-} IsPGlabel label0 (NS (K ()) labels)
-  => IsPGlabel label0 (NS (K ()) (label1 ': labels)) where
-    label = S (label @label0)
 -- | A `PGlabel` unit type with an `IsPGlabel` instance
 data PGlabel (label :: Symbol) = PGlabel
 instance KnownSymbol label => RenderSQL (PGlabel label) where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
@@ -715,6 +715,12 @@ instance labels ~ '[label]
   => IsPGlabel label (NP PGlabel labels) where label = PGlabel :* Nil
 instance IsPGlabel label (y -> K y label) where label = K
 instance IsPGlabel label (y -> NP (K y) '[label]) where label y = K y :* Nil
+instance {-# OVERLAPPING #-}
+  IsPGlabel label0 (NS PGlabel (label0 ': labels)) where
+    label = Z PGlabel
+instance {-# OVERLAPPABLE #-} IsPGlabel label0 (NS PGlabel labels)
+  => IsPGlabel label0 (NS PGlabel (label1 ': labels)) where
+    label = S (label @label0)
 -- | A `PGlabel` unit type with an `IsPGlabel` instance
 data PGlabel (label :: Symbol) = PGlabel
 instance KnownSymbol label => RenderSQL (PGlabel label) where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/Schema.hs
@@ -715,6 +715,12 @@ instance labels ~ '[label]
   => IsPGlabel label (NP PGlabel labels) where label = PGlabel :* Nil
 instance IsPGlabel label (y -> K y label) where label = K
 instance IsPGlabel label (y -> NP (K y) '[label]) where label y = K y :* Nil
+instance {-# OVERLAPPING #-}
+  IsPGlabel label0 (NS (K ()) (label0 ': labels)) where
+    label = Z (K ())
+instance {-# OVERLAPPABLE #-} IsPGlabel label0 (NS (K ()) labels)
+  => IsPGlabel label0 (NS (K ()) (label1 ': labels)) where
+    label = S (label @label0)
 -- | A `PGlabel` unit type with an `IsPGlabel` instance
 data PGlabel (label :: Symbol) = PGlabel
 instance KnownSymbol label => RenderSQL (PGlabel label) where


### PR DESCRIPTION
Squeal had combinators for hand rolling `FromPG` instances for `PGenum`s and `PGcomposite`s. This PR adds combinators for hand rolling `ToPG` instances. To do this it loosens the `EncodeParams` type to be polykinded `newtype EncodeParams (db :: SchemasType) (tys :: [k]) (x :: Type)`. The type variable `tys` can be a list of any kind, where before it was `[NullType]`. We need to instantiate it for one other list, `RowType`. Then we define the following combinator to use these `RowType`d parameter encodings to define `toPG` methods.
```Haskell
rowParam
  :: forall db row x. (PG x ~ 'PGcomposite row, SOP.All (OidOfField db) row)
  => EncodeParams db row x
  -> x -> ReaderT (SOP.K LibPQ.Connection db) IO Encoding
```
To construct `RowType`d parameter encodings, we can use some old combinators like `nilParams` and `appendParams` but the rest like `.*`, `*.` and `genericParams` will be useless since they don't address field names. So similar combinators `.#`, `#.` and `genericRowParams` are provided.

Additionally, a combinator is provided to define `toPG` for `PGenum`s.
```Haskell
enumParam
  :: forall db labels x. (PG x ~ 'PGenum labels, SOP.All KnownSymbol labels)
  => (x -> SOP.NS PGlabel labels)
  -> x -> ReaderT (SOP.K LibPQ.Connection db) IO Encoding
```