### PR TITLE
CI coverage for GHC 9.0; update coverage for GHC 8.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,58 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
+  ghc9_0:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:11
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: exampledb
+        ports:
+        - 5432:5432
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      - uses: haskell/actions/setup@v1
+        with:
+          ghc-version: '9.0.2' # Exact version of ghc to use
+          # cabal-version: 'latest'. Omitted, but defalts to 'latest'
+          enable-stack: true
+          stack-version: 'latest'
+
+      - name: build
+        run: stack build --fast
+
+      - name: test
+        run: stack test --fast
+        env:
+          PG_USER: postgres
+          PG_HOST: localhost
+          PG_DATABASE: exampledb
+          PG_PASSWORD: postgres
+          PG_PORT: ${{ job.services.postgres.ports['5432'] }}
+
+      - name: benchmark
+        run: stack bench --fast
+
+      - name: documentation
+        run: stack haddock --fast
+
+      - name: cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ".stack-work"
+            "/root/.stack/"
+          key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
   ghc8_10:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
@@ -33,7 +85,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: haskell/actions/setup@v1
         with:
-          ghc-version: '8.10.5' # Exact version of ghc to use
+          ghc-version: '8.10.7' # Exact version of ghc to use
           # cabal-version: 'latest'. Omitted, but defalts to 'latest'
           enable-stack: true
           stack-version: 'latest'


### PR DESCRIPTION
CI covers GHC 9.0.2, and 8.10.7