### PR TITLE
New `Prepared` statement type and `prepare` functions

### DIFF
--- a/squeal-postgresql/exe/Example.hs
+++ b/squeal-postgresql/exe/Example.hs
@@ -137,7 +137,7 @@ users =
   , User "Carole" (Just "carole@hotmail.com") (VarArray [Just 3,Nothing, Just 4])
   ]
 
-session :: (MonadIO pq, MonadPQ Schemas pq) => pq ()
+session :: PQ Schemas Schemas IO ()
 session = do
   liftIO $ Char8.putStrLn "manipulating"
   idResults <- traversePrepared insertUser ([(userName user, userVec user) | user <- users])

--- a/squeal-postgresql/exe/Example.hs
+++ b/squeal-postgresql/exe/Example.hs
@@ -137,7 +137,7 @@ users =
   , User "Carole" (Just "carole@hotmail.com") (VarArray [Just 3,Nothing, Just 4])
   ]
 
-session :: PQ Schemas Schemas IO ()
+session :: (MonadIO pq, MonadPQ Schemas pq) => pq ()
 session = do
   liftIO $ Char8.putStrLn "manipulating"
   idResults <- traversePrepared insertUser ([(userName user, userVec user) | user <- users])

--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -98,7 +98,7 @@ library
     , exceptions >= 0.10.3
     , free-categories >= 0.2.0.0
     , generics-sop >= 0.5.1.0
-    , hashable
+    , hashable >= 1.3.5.0
     , mmorph >= 1.1.3
     , monad-control >= 1.0.2.3
     , mtl >= 2.2.2

--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -98,7 +98,7 @@ library
     , exceptions >= 0.10.3
     , free-categories >= 0.2.0.0
     , generics-sop >= 0.5.1.0
-    , hashable >= 1.3.5.0
+    , hashable >= 1.3.0.0
     , mmorph >= 1.1.3
     , monad-control >= 1.0.2.3
     , mtl >= 2.2.2

--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -98,6 +98,7 @@ library
     , exceptions >= 0.10.3
     , free-categories >= 0.2.0.0
     , generics-sop >= 0.5.1.0
+    , hashable
     , mmorph >= 1.1.3
     , monad-control >= 1.0.2.3
     , mtl >= 2.2.2

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session.hs
@@ -157,7 +157,11 @@ instance (MonadIO io, db0 ~ db, db1 ~ db) => MonadPQ db (PQ db0 db1 io) where
 
   prepare (Manipulation encode decode (UnsafeManipulation q :: Manipulation '[] db params row)) = do
     let
-      prep = "prepared_statement_" <> fromString (show (hash q))
+      statementNum = fromString $ case show (hash q) of
+        '-':num -> "negative_" <> num
+        num -> num
+
+      prep = "prepared_statement_" <> statementNum
 
       prepare' :: PQ db0 db1 io ()
       prepare' = PQ $ \ kconn@(K conn) -> liftIO $ do

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Monad.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Monad.hs
@@ -31,7 +31,6 @@ import Control.Category (Category (..))
 import Control.Monad
 import Control.Monad.Morph
 import Data.Foldable
-import Data.Profunctor
 import Data.Traversable
 import Prelude hiding (id, (.))
 
@@ -264,13 +263,6 @@ executePrepared_ statement list = do
   prepared <- prepare_ statement
   traverse_ (execPrepared prepared) list
   deallocate prepared
-
-data Prepared pq x y = Prepared
-  { execPrepared :: x -> pq y
-  , deallocate :: pq ()
-  } deriving Functor
-instance Functor pq => Profunctor (Prepared pq) where
-  dimap g f (Prepared e d) = Prepared (fmap f . e . g) d
 
 {- |
 `manipulateParams` runs a `Squeal.PostgreSQL.Manipulation.Manipulation`.

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Monad.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Monad.hs
@@ -363,8 +363,7 @@ executePrepared_
   -> list x
   -- ^ list of parameters
   -> pq ()
-executePrepared_ = withPrepared $ \p ->
-  Prepared (traverse_ (void . runPrepared p)) (deallocate p)
+executePrepared_ = withPrepared (wander traverse_)
 
 {- |
 `manipulateParams` runs a `Squeal.PostgreSQL.Manipulation.Manipulation`.

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Monad.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Monad.hs
@@ -180,9 +180,8 @@ class Monad pq => MonadPQ db pq | pq -> db where
   prepare statement = do
     prepared <- lift $ prepare statement
     return $ Prepared
-      { runPrepared = lift . runPrepared prepared
-      , deallocate = lift (deallocate prepared)
-      }
+      (lift . runPrepared prepared)
+      (lift (deallocate prepared))
 
   prepare_
     :: Statement db x ()
@@ -190,9 +189,8 @@ class Monad pq => MonadPQ db pq | pq -> db where
   prepare_ statement = do
     prepared <- prepare statement
     return $ Prepared
-      { runPrepared = void . runPrepared prepared
-      , deallocate = deallocate prepared
-      }
+      (void . runPrepared prepared)
+      (deallocate prepared)
 
 {- |
 `executePrepared` runs a `Statement` on a `Traversable`

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Monad.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Monad.hs
@@ -282,7 +282,7 @@ class Monad pq => MonadPQ db pq | pq -> db where
 >>> :type withPrepared traverse'
 withPrepared traverse'
   :: (MonadPQ db pq, Traversable f) =>
-     Statement db a y -> f a -> pq (f (Result y))
+     Statement db a b -> f a -> pq (f (Result b))
 -}
 withPrepared
   :: MonadPQ db pq

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
@@ -111,4 +111,7 @@ data Prepared f x y = Prepared
   } deriving Functor
 
 instance Functor f => Profunctor (Prepared f) where
-  dimap g f (Prepared e d) = Prepared (fmap f . e . g) d
+  dimap g f prepared = Prepared
+    { runPrepared = fmap f . runPrepared prepared . g
+    , deallocate = deallocate prepared
+    }

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
@@ -106,7 +106,7 @@ manipulation ::
 manipulation = Manipulation genericParams genericRow
 
 data Prepared f x y = Prepared
-  { execPrepared :: x -> f y
+  { runPrepared :: x -> f y
   , deallocate :: f ()
   } deriving Functor
 

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
@@ -128,13 +128,9 @@ while allowing the execution plan to
 depend on the specific parameter values supplied.
 
 `Prepared` statements only last for the duration
-of the current database session. When the session ends,
-the prepared statement is forgotten,
-so it must be recreated before being used again.
-This also means that a single prepared statement
-cannot be used by multiple simultaneous database clients;
-however, each client can create their own `Prepared` statement to use.
-Prepared statements can be manually cleaned up using the `deallocate` command.
+of the current database session.
+Prepared statements can be manually cleaned up
+using the `deallocate` command.
 -}
 data Prepared f x y = Prepared
   { runPrepared :: x -> f y -- ^ execute a prepared statement

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
@@ -22,9 +22,11 @@ together with an `EncodeParams` and a `DecodeRow`.
 #-}
 
 module Squeal.PostgreSQL.Session.Statement
-  ( Statement (..)
+  ( -- * Statement
+    Statement (..)
   , query
   , manipulation
+    -- * Prepared
   , Prepared (..)
   ) where
 
@@ -52,7 +54,7 @@ import Squeal.PostgreSQL.Render hiding ((<+>))
 -- or a `Squeal.PostgreSQL.Session.Statement.Query` that can be run
 -- in a `Squeal.PostgreSQL.Session.Monad.MonadPQ`.
 data Statement db x y where
-  -- | Constructor for a data manipulation language statement
+  -- | Constructor for a data manipulation language `Statement`
   Manipulation
     :: (SOP.All (OidOfNull db) params, SOP.SListI row)
     => EncodeParams db params x -- ^ encoding of parameters
@@ -62,7 +64,7 @@ data Statement db x y where
     -- `Squeal.PostgreSQL.Manipulation.Update.update`,
     -- or `Squeal.PostgreSQL.Manipulation.Delete.deleteFrom`, ...
     -> Statement db x y
-  -- | Constructor for a structured query language statement
+  -- | Constructor for a structured query language `Statement`
   Query
     :: (SOP.All (OidOfNull db) params, SOP.SListI row)
     => EncodeParams db params x -- ^ encoding of parameters
@@ -92,7 +94,7 @@ instance RenderSQL (Statement db x y) where
   renderSQL (Manipulation _ _ q) = renderSQL q
   renderSQL (Query _ _ q) = renderSQL q
 
--- | Smart constructor for a structured query language statement
+-- | Smart constructor for a structured query language `Statement`
 query ::
   ( GenericParams db params x xs
   , GenericRow row y ys
@@ -102,7 +104,7 @@ query ::
     -> Statement db x y
 query = Query genericParams genericRow
 
--- | Smart constructor for a data manipulation language statement
+-- | Smart constructor for a data manipulation language `Statement`
 manipulation ::
   ( GenericParams db params x xs
   , GenericRow row y ys

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
@@ -162,8 +162,8 @@ instance Monad f => Strong (Prepared f) where
   second' p = Prepared (kleisliRun1 second' p) (deallocate p)
 
 instance Monad f => Choice (Prepared f) where
-  left' x = Prepared (kleisliRun1 left' x) (deallocate x)
-  right' x = Prepared (kleisliRun1 right' x) (deallocate x)
+  left' p = Prepared (kleisliRun1 left' p) (deallocate p)
+  right' p = Prepared (kleisliRun1 right' p) (deallocate p)
 
 instance Monad f => Category (Prepared f) where
   id = Prepared return (return ())
@@ -183,9 +183,7 @@ instance Monad f => Arrow (Prepared f) where
 instance Monad f => ArrowChoice (Prepared f) where
   left = left'
   right = right'
-  ab +++ cd = Prepared
-    (kleisliRun2 (+++) ab cd)
-    (deallocate ab >> deallocate cd)
+  ab +++ cd = left ab >>> right cd
   bd ||| cd = Prepared
     (kleisliRun2 (|||) bd cd)
     (deallocate bd >> deallocate cd)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
@@ -25,6 +25,7 @@ module Squeal.PostgreSQL.Session.Statement
   ( Statement (..)
   , query
   , manipulation
+  , Prepared (..)
   ) where
 
 import Data.Functor.Contravariant
@@ -103,3 +104,11 @@ manipulation ::
     -- or `Squeal.PostgreSQL.Manipulation.Delete.deleteFrom`, ...
     -> Statement db x y
 manipulation = Manipulation genericParams genericRow
+
+data Prepared f x y = Prepared
+  { execPrepared :: x -> f y
+  , deallocate :: f ()
+  } deriving Functor
+
+instance Functor f => Profunctor (Prepared f) where
+  dimap g f (Prepared e d) = Prepared (fmap f . e . g) d

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
@@ -112,6 +112,5 @@ data Prepared f x y = Prepared
 
 instance Functor f => Profunctor (Prepared f) where
   dimap g f prepared = Prepared
-    { runPrepared = fmap f . runPrepared prepared . g
-    , deallocate = deallocate prepared
-    }
+    (fmap f . runPrepared prepared . g)
+    (deallocate prepared)

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
@@ -153,7 +153,7 @@ instance Alternative m => Alternative (Prepared m x) where
     (deallocate p1 *> deallocate p2)
 
 instance Functor m => Profunctor (Prepared m) where
-  dimap g m prepared = Prepared
+  dimap g f prepared = Prepared
     (fmap f . runPrepared prepared . g)
     (deallocate prepared)
 

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
@@ -129,7 +129,7 @@ depend on the specific parameter values supplied.
 
 `Prepared` statements only last for the duration
 of the current database session.
-Prepared statements can be manually cleaned up
+`Prepared` statements can be manually cleaned up
 using the `deallocate` command.
 -}
 data Prepared f x y = Prepared

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
@@ -119,10 +119,10 @@ A `Prepared` statement is a server-side object
 that can be used to optimize performance.
 When `Squeal.PostgreSQL.Session.Monad.prepare`
 or `Squeal.PostgreSQL.Session.Monad.prepare_` is executed,
-the specified statement is parsed, analyzed, and rewritten.
+the specified `Statement` is parsed, analyzed, and rewritten.
 
 When the `runPrepared` command is subsequently issued,
-the prepared statement is planned and executed.
+the `Prepared` statement is planned and executed.
 This division of labor avoids repetitive parse analysis work,
 while allowing the execution plan to
 depend on the specific parameter values supplied.

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
@@ -75,18 +75,18 @@ data Statement db x y where
     -> Statement db x y
 
 instance Profunctor (Statement db) where
-  lmap m (Manipulation encode decode q) =
-    Manipulation (contramap m encode) decode q
-  lmap m (Query encode decode q) =
-    Query (contramap m encode) decode q
-  rmap m (Manipulation encode decode q) =
-    Manipulation encode (fmap m decode) q
-  rmap m (Query encode decode q) =
-    Query encode (fmap m decode) q
-  dimap m g (Manipulation encode decode q) =
-    Manipulation (contramap m encode) (fmap g decode) q
-  dimap m g (Query encode decode q) =
-    Query (contramap m encode) (fmap g decode) q
+  lmap f (Manipulation encode decode q) =
+    Manipulation (contramap f encode) decode q
+  lmap f (Query encode decode q) =
+    Query (contramap f encode) decode q
+  rmap f (Manipulation encode decode q) =
+    Manipulation encode (fmap f decode) q
+  rmap f (Query encode decode q) =
+    Query encode (fmap f decode) q
+  dimap f g (Manipulation encode decode q) =
+    Manipulation (contramap f encode) (fmap g decode) q
+  dimap f g (Query encode decode q) =
+    Query (contramap f encode) (fmap g decode) q
 
 instance Functor (Statement db x) where fmap = rmap
 
@@ -154,7 +154,7 @@ instance Alternative m => Alternative (Prepared m x) where
 
 instance Functor m => Profunctor (Prepared m) where
   dimap g m prepared = Prepared
-    (fmap m . runPrepared prepared . g)
+    (fmap f . runPrepared prepared . g)
     (deallocate prepared)
 
 instance Monad m => Strong (Prepared m) where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Statement.hs
@@ -117,7 +117,8 @@ manipulation = Manipulation genericParams genericRow
 `Squeal.PostgreSQL.Session.Monad.prepare_` create a `Prepared` statement.
 A `Prepared` statement is a server-side object
 that can be used to optimize performance.
-When the PREPARE statement is executed,
+When `Squeal.PostgreSQL.Session.Monad.prepare`
+or `Squeal.PostgreSQL.Session.Monad.prepare_` is executed,
 the specified statement is parsed, analyzed, and rewritten.
 
 When the `runPrepared` command is subsequently issued,


### PR DESCRIPTION
Introduces new `Prepared` statement type as well as new functions `prepare` and `prepare_` to construct `Prepared` statements in a `MonadPQ`. This generalizes and factors out of `executePrepared` from earlier.

`Prepared` has many instances, notably `Functor`, `Profunctor`, `Traversing`, `Category` and `Arrow`.

The PR also adds `MonadFix`, `Alternative` and `MonadPlus` instances to `PQ`.