### PR TITLE
Use properly short-circuiting conditional for type-level merge sort

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/List.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/List.hs
@@ -177,20 +177,19 @@ type family Twos (ls :: [k]) :: [[k]] where
 type family Merge (ls :: [Symbol]) (rs :: [Symbol]) :: [Symbol] where
   Merge '[] r = r
   Merge l '[] = l
-  Merge (l ': ls) (r ': rs) = If (Leq l r) (l ': Merge ls (r ': rs)) (r ': Merge (l ': ls) rs)
+  Merge (l ': ls) (r ': rs) = MergeHelper (l ': ls) (r ': rs) (CmpSymbol l r)
+
+-- | 'MergeHelper' decides whether to take an element from the right or left list next,
+-- depending on the result of their comparison
+type family MergeHelper (ls :: [Symbol]) (rs :: [Symbol]) (cmp :: Ordering) where
+  MergeHelper ls        (r ': rs) 'GT = r ': Merge ls rs
+  MergeHelper (l ': ls) rs        leq = l ': Merge ls rs
 
 -- | 'FoldMerge' folds over a list of sorted lists, merging them into a single sorted list
 type family FoldMerge (ls :: [[Symbol]]) :: [[Symbol]] where
   FoldMerge (x ': y ': rs) = (Merge x y ': FoldMerge rs)
   FoldMerge '[x]           = '[x]
   FoldMerge '[]            = '[]
-
-type Leq l r = OrderingIsLeq (CmpSymbol l r)
-
-type family OrderingIsLeq (o :: Ordering) :: Bool where
-  OrderingIsLeq 'LT = 'True
-  OrderingIsLeq 'EQ = 'True
-  OrderingIsLeq 'GT = 'False
 
 -- | 'MapFst' takes the first value of each tuple of a type level list of tuples. Useful for getting
 -- only the names in associatve lists


### PR DESCRIPTION
Previously, the sort done for pretty printing used [`If`](https://hackage.haskell.org/package/base-4.16.1.0/docs/Data-Type-Bool.html#t:If). Because of how type families work, this doesn't short circuit like value-level if, and always evaluates both branches, which made sorting very slow and run out of memory with a larger schema like in (credit @wyao-simspace ). Sorting only happens in the case of an error, so this didn't come up in normal testing.
```haskell
type Schema =
  '[ "public" ::: SomeTables
   ] :: Sq.SchemasType
type SomeTables =
  '[ "a" ::: 'Sq.Table SomeTable
   , "b" ::: 'Sq.Table SomeTable
   , "c" ::: 'Sq.Table SomeTable
   , "d" ::: 'Sq.Table SomeTable
   , "e" ::: 'Sq.Table SomeTable
   , "f" ::: 'Sq.Table SomeTable
   , "g" ::: 'Sq.Table SomeTable
   , "h" ::: 'Sq.Table SomeTable
   , "i" ::: 'Sq.Table SomeTable
   , "j" ::: 'Sq.Table SomeTable
   , "k" ::: 'Sq.Table SomeTable
   , "l" ::: 'Sq.Table SomeTable
   , "m" ::: 'Sq.Table SomeTable
   , "n" ::: 'Sq.Table SomeTable
   , "o" ::: 'Sq.Table SomeTable
   , "p" ::: 'Sq.Table SomeTable
   , "q" ::: 'Sq.Table SomeTable
   , "r" ::: 'Sq.Table SomeTable
   , "s" ::: 'Sq.Table SomeTable
   , "t" ::: 'Sq.Table SomeTable
   , "u" ::: 'Sq.Table SomeTable
   , "v" ::: 'Sq.Table SomeTable
   , "w" ::: 'Sq.Table SomeTable
   , "x" ::: 'Sq.Table SomeTable
   , "y" ::: 'Sq.Table SomeTable
   , "z" ::: 'Sq.Table SomeTable
   , "aa" ::: 'Sq.Table SomeTable
   , "bb" ::: 'Sq.Table SomeTable
   , "cc" ::: 'Sq.Table SomeTable
   , "dd" ::: 'Sq.Table SomeTable
   , "ee" ::: 'Sq.Table SomeTable
   , "ff" ::: 'Sq.Table SomeTable
   , "gg" ::: 'Sq.Table SomeTable
   , "hh" ::: 'Sq.Table SomeTable
   , "ii" ::: 'Sq.Table SomeTable
   , "jj" ::: 'Sq.Table SomeTable
   , "kk" ::: 'Sq.Table SomeTable
   , "ll" ::: 'Sq.Table SomeTable
   , "mm" ::: 'Sq.Table SomeTable
   , "nn" ::: 'Sq.Table SomeTable
   , "oo" ::: 'Sq.Table SomeTable
   , "pp" ::: 'Sq.Table SomeTable
   , "qq" ::: 'Sq.Table SomeTable
   , "rr" ::: 'Sq.Table SomeTable
   , "ss" ::: 'Sq.Table SomeTable
   , "tt" ::: 'Sq.Table SomeTable
   , "uu" ::: 'Sq.Table SomeTable
   ] :: Sq.SchemaType
type SomeTable = ('[] :=> SomeColumns) :: Sq.TableType
type SomeColumns =
  '[ "a" ::: 'Sq.NoDef :=> 'NotNull 'PGtext
   , "b" ::: 'Sq.NoDef :=> 'NotNull 'PGuuid
   ] :: Sq.ColumnsType
​
someQuery :: Sq.Query '[] '[] Schema '[] '[ "a" ::: 'NotNull 'PGtext ]
someQuery =
  Sq.select_
    (#table ! #a)
    (Sq.from (Sq.table #table))
```

This changes the sort logic to use a custom type family that does only evaluate one branch of the conditional. This improves the performance so that we can compile the above schema, up until it (as expected) reports a type error. Also tested was a schema with 250 entries, which also worked with `-freduction-depth=0` set. I don't have the above added as a test, because it by design throws a type error.
