### PR TITLE
Null functions

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Array.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Array.hs
@@ -207,7 +207,7 @@ combinations of null values.
 arrAll
   :: Expression grp lat with db params from ty1 -- ^ expression
   -> Operator ty1 ty2 ('Null 'PGbool) -- ^ operator
-  -> Expression grp lat with db params from ('Null ('PGvararray ty2)) -- ^ array
+  -> Expression grp lat with db params from (null ('PGvararray ty2)) -- ^ array
   -> Condition grp lat with db params from
 arrAll x (?) xs = x ? (UnsafeExpression $ "ALL" <+> parenthesized (renderSQL xs))
 
@@ -237,6 +237,6 @@ Boolean combinations of null values.
 arrAny
   :: Expression grp lat with db params from ty1 -- ^ expression
   -> Operator ty1 ty2 ('Null 'PGbool) -- ^ operator
-  -> Expression grp lat with db params from ('Null ('PGvararray ty2)) -- ^ array
+  -> Expression grp lat with db params from (null ('PGvararray ty2)) -- ^ array
   -> Condition grp lat with db params from
 arrAny x (?) xs = x ? (UnsafeExpression $ "ANY" <+> parenthesized (renderSQL xs))

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Null.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Null.hs
@@ -56,10 +56,7 @@ null_ = UnsafeExpression "NULL"
 just_ :: 'NotNull ty --> 'Null ty
 just_ = UnsafeExpression . renderSQL
 
--- | analagous to `Just`
---
--- >>> printSQL $ notNull true
--- TRUE
+-- | Deprecated, use `just_` instead.
 {-# DEPRECATED notNull "use just_ instead" #-}
 notNull :: 'NotNull ty --> 'Null ty
 notNull = UnsafeExpression . renderSQL

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Null.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Null.hs
@@ -20,7 +20,7 @@ null expressions and handlers
 module Squeal.PostgreSQL.Expression.Null
   ( -- * Null
     null_
-  , notNull
+  , just_
   , unsafeNotNull
   , monoNotNull
   , coalesce
@@ -30,6 +30,8 @@ module Squeal.PostgreSQL.Expression.Null
   , matchNull
   , nullIf
   , CombineNullity
+    -- deprecated
+  , notNull
   ) where
 
 import Squeal.PostgreSQL.Expression
@@ -49,8 +51,16 @@ null_ = UnsafeExpression "NULL"
 
 -- | analagous to `Just`
 --
+-- >>> printSQL $ just_ true
+-- TRUE
+just_ :: 'NotNull ty --> 'Null ty
+just_ = UnsafeExpression . renderSQL
+
+-- | analagous to `Just`
+--
 -- >>> printSQL $ notNull true
 -- TRUE
+{-# DEPRECATED notNull "use just_ instead" #-}
 notNull :: 'NotNull ty --> 'Null ty
 notNull = UnsafeExpression . renderSQL
 

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Range.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Expression/Range.hs
@@ -147,11 +147,11 @@ whole :: Range x
 whole = NonEmpty Infinite Infinite
 
 -- | range is contained by
-(.<@) :: Operator ('NotNull ty) (null ('PGrange ty)) ('Null 'PGbool)
+(.<@) :: Operator (null0 ty) (null1 ('PGrange ty)) ('Null 'PGbool)
 (.<@) = unsafeBinaryOp "<@"
 
 -- | contains range
-(@>.) :: Operator (null ('PGrange ty)) ('NotNull ty) ('Null 'PGbool)
+(@>.) :: Operator (null0 ('PGrange ty)) (null1 ty) ('Null 'PGbool)
 (@>.) = unsafeBinaryOp "@>"
 
 -- | strictly left of,

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Query.hs
@@ -323,7 +323,7 @@ data Row = Row { col1 :: Maybe Int64, col2 :: String }
 >>> :{
 let
   qry :: Query_ (Public Schema) (Int64, Bool) Row
-  qry = select Star (from (table #tab) & where_ (#col1 .> param @1 .&& notNull (param @2)))
+  qry = select Star (from (table #tab) & where_ (#col1 .> param @1 .&& just_ (param @2)))
   stmt :: Statement (Public Schema) (Int64, Bool) Row
   stmt = query qry
 :}


### PR DESCRIPTION
* Relaxes the nullity of `(.<@)`, `(@>.)`, `arrAll`, and `arrAny`
* Adds a `just_` function which replaces `notNull`
* Deprecates `notNull` because it's a little unclearly named I think

Resolves #315 