### PR TITLE
Add a new `genericProductRow` combinator

### DIFF
--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Decode.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Decode.hs
@@ -592,19 +592,19 @@ genericProductRow
      )
   => DecodeRow row y
 genericProductRow
-    = DecodeRow
-    . ReaderT
-    $ fmap SOP.productTypeTo
-    . SOP.hsequence'
-    . SOP.htrans
-        (SOP.Proxy @FromAliasedValue)
-        (SOP.Comp . fmap SOP.I . runField)
-    where
-      runField
-        :: forall ty z. FromAliasedValue ty z
-        => SOP.K (Maybe Strict.ByteString) ty
-        -> Except Strict.Text z
-      runField = liftEither . fromAliasedValue @ty . SOP.unK
+  = DecodeRow
+  . ReaderT
+  $ fmap SOP.productTypeTo
+  . SOP.hsequence'
+  . SOP.htrans
+      (SOP.Proxy @FromAliasedValue)
+      (SOP.Comp . fmap SOP.I . runField)
+  where
+    runField
+      :: forall ty z. FromAliasedValue ty z
+      => SOP.K (Maybe Strict.ByteString) ty
+      -> Except Strict.Text z
+    runField = liftEither . fromAliasedValue @ty . SOP.unK
 
 {- |
 >>> :{

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Decode.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Decode.hs
@@ -589,6 +589,16 @@ instance FromValue ty y => FromAliasedValue (fld ::: ty) y where
 {- | Positionally `DecodeRow`. More general than `genericRow`,
 which matches records both positionally and by field name,
 `genericProductRow` matches records _or_ tuples purely positionally.
+
+>>> import qualified GHC.Generics as GHC
+>>> import qualified Generics.SOP as SOP
+>>> :{
+let
+  decode :: DecodeRow '[ "foo" ::: 'NotNull 'PGint2, "bar" ::: 'NotNull 'PGtext] (Int16, String)
+  decode = genericProductRow
+in runDecodeRow decode (SOP.K (Just "\NUL\STX") :* SOP.K (Just "two") :* Nil)
+:}
+Right (2,"two")
 -}
 genericProductRow
   :: ( SOP.IsProductType y ys

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Decode.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Decode.hs
@@ -596,7 +596,9 @@ genericProductRow
     . ReaderT
     $ fmap SOP.productTypeTo
     . SOP.hsequence'
-    . SOP.htrans (SOP.Proxy @FromAliasedValue) (SOP.Comp . fmap SOP.I . runField)
+    . SOP.htrans
+        (SOP.Proxy @FromAliasedValue)
+        (SOP.Comp . fmap SOP.I . runField)
     where
       runField
         :: forall ty z. FromAliasedValue ty z


### PR DESCRIPTION
Positionally decode rows into products, either records or tuples. Resolves #330