### PR TITLE
For ghc >= 9.4 use a fork of records-sop with relaxed bounds.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,8 +3,14 @@ packages:
     , squeal-postgresql-ltree
     , squeal-postgresql-uuid-ossp
 
-if impl(ghc >= 9.2)
+if impl(ghc >= 9.4)
     source-repository-package
         type: git
-        location: https://github.com/kosmikus/records-sop.git
+        location: https://github.com/space-vacuum/records-sop
+        tag: db2d052a1dfa6feed27c46db8dc401ff9e55685e
+
+elif impl(ghc >= 9.2)
+    source-repository-package
+        type: git
+        location: https://github.com/kosmikus/records-sop
         tag: abab99b4b870fce55e81dd03d4e41fb50502ca4e

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Monad.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Monad.hs
@@ -16,12 +16,13 @@ typeclass `MonadPQ`.
   , FlexibleInstances
   , FunctionalDependencies
   , GADTs
-  , PolyKinds
   , MultiParamTypeClasses
+  , PolyKinds
   , QuantifiedConstraints
   , RankNTypes
   , TypeApplications
   , TypeFamilies
+  , TypeOperators
   , UndecidableInstances
 #-}
 


### PR DESCRIPTION
A follow on from #335 for `ghc-9.4.5`.

Use a couple of alternate source-repository-package dependencies until records-sop is updated and published to hackage, see https://github.com/kosmikus/records-sop/issues/12.

```
$ cabal build all --enable-tests --enable-benchmarks
Cloning into '/.../dist-newstyle/src/records-s_-cc0a9700f9cd5a00'...
remote: Enumerating objects: 321, done.
remote: Counting objects: 100% (87/87), done.
remote: Compressing objects: 100% (46/46), done.
remote: Total 321 (delta 31), reused 63 (delta 20), pack-reused 234
Receiving objects: 100% (321/321), 61.90 KiB | 2.38 MiB/s, done.
Resolving deltas: 100% (137/137), done.
HEAD is now at db2d052 Bump stackage resolver to lts-20.18 for ghc-9.2.7.
Resolving dependencies...
Build profile: -w ghc-9.4.5 -O1
In order, the following will be built (use -v for more details):
 - squeal-postgresql-0.9.1.0 (lib) (first run)
 - squeal-postgresql-uuid-ossp-0.1.0.1 (lib) (first run)
 - squeal-postgresql-ltree-0.1.0.1 (lib) (first run)
 - squeal-postgresql-0.9.1.0 (test:spec) (first run)
 - squeal-postgresql-0.9.1.0 (test:properties) (first run)
 - squeal-postgresql-0.9.1.0 (bench:gauge) (first run)
 - squeal-postgresql-0.9.1.0 (exe:example) (first run)
Configuring library for squeal-postgresql-0.9.1.0..
Preprocessing library for squeal-postgresql-0.9.1.0..
Building library for squeal-postgresql-0.9.1.0..
...
[43 of 64] Compiling Squeal.PostgreSQL.Session.Monad

src/Squeal/PostgreSQL/Session/Monad.hs:112:40: warning: [-Wtype-equality-requires-operators]
    The use of ‘~’ without TypeOperators
    will become an error in a future GHC release.
    Suggested fix: Perhaps you intended to use TypeOperators
    |
112 |     :: (MonadTrans t, MonadPQ db m, pq ~ t m)
    |                                        ^

src/Squeal/PostgreSQL/Session/Monad.hs:222:40: warning: [-Wtype-equality-requires-operators]
    The use of ‘~’ without TypeOperators
    will become an error in a future GHC release.
    Suggested fix: Perhaps you intended to use TypeOperators
    |
222 |     :: (MonadTrans t, MonadPQ db m, pq ~ t m)
    | 
 ...
[53 of 64] Compiling Squeal.PostgreSQL.Session

src/Squeal/PostgreSQL/Session/Pool.hs:86:12: warning: [-Wdeprecations]
    In the use of ‘createPool’ (imported from Data.Pool):
    Deprecated: "Use newPool instead"
   |
86 |   liftIO $ createPool (connectdb conninfo) finish stripes idle maxResrc
   |
...
```