### PR TITLE
Add support for postgresql-binary-0.14

### DIFF
--- a/squeal-postgresql/squeal-postgresql.cabal
+++ b/squeal-postgresql/squeal-postgresql.cabal
@@ -99,6 +99,7 @@ library
     , free-categories >= 0.2.0.0
     , generics-sop >= 0.5.1.0
     , hashable >= 1.3.0.0
+    , iproute >= 1.7.0
     , mmorph >= 1.1.3
     , monad-control >= 1.0.2.3
     , mtl >= 2.2.2

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Decode.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Decode.hs
@@ -68,6 +68,11 @@ import Data.Bits
 import Data.Coerce (coerce)
 import Data.Functor.Constant (Constant(Constant))
 import Data.Int (Int16, Int32, Int64)
+#if MIN_VERSION_postgresql_binary(0, 14, 0)
+import Data.IP (IPRange)
+#else
+import Network.IP.Addr (NetAddr, IP)
+#endif
 import Data.Kind
 import Data.Scientific (Scientific)
 import Data.String (fromString)
@@ -78,7 +83,6 @@ import Data.Vector (Vector)
 import Database.PostgreSQL.LibPQ (Oid(Oid))
 import GHC.OverloadedLabels
 import GHC.TypeLits
-import Network.IP.Addr (NetAddr, IP)
 import PostgreSQL.Binary.Decoding hiding (Composite)
 import Unsafe.Coerce
 
@@ -200,8 +204,11 @@ instance FromPG Money where
   fromPG = devalue $  Money <$> int
 instance FromPG UUID where
   fromPG = devalue uuid
-instance FromPG (NetAddr IP) where
-  fromPG = devalue inet
+#if MIN_VERSION_postgresql_binary(0, 14, 0)
+instance FromPG IPRange where fromPG = devalue inet
+#else
+instance FromPG (NetAddr IP) where fromPG = devalue inet
+#endif
 instance FromPG Char where
   fromPG = devalue char
 instance FromPG Strict.Text where

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Session/Encode.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Session/Encode.hs
@@ -11,6 +11,7 @@ encoding of statement parameters
 {-# LANGUAGE
     AllowAmbiguousTypes
   , ConstraintKinds
+  , CPP
   , DataKinds
   , DefaultSignatures
   , FlexibleContexts
@@ -59,6 +60,11 @@ import Data.Functor.Const (Const(Const))
 import Data.Functor.Constant (Constant(Constant))
 import Data.Functor.Contravariant
 import Data.Int (Int16, Int32, Int64)
+#if MIN_VERSION_postgresql_binary(0, 14, 0)
+import Data.IP (IPRange)
+#else
+import Network.IP.Addr (NetAddr, IP)
+#endif
 import Data.Kind
 import Data.Scientific (Scientific)
 import Data.Text as Strict (Text)
@@ -69,7 +75,6 @@ import Data.Vector (Vector)
 import Data.Word (Word32)
 import Foreign.C.Types (CUInt(CUInt))
 import GHC.TypeLits
-import Network.IP.Addr (NetAddr, IP)
 import PostgreSQL.Binary.Encoding hiding (Composite, field)
 
 import qualified Data.Aeson as Aeson
@@ -121,7 +126,11 @@ instance ToPG db Double where toPG = pure . float8
 instance ToPG db Scientific where toPG = pure . numeric
 instance ToPG db Money where toPG = pure . int8_int64 . cents
 instance ToPG db UUID where toPG = pure . uuid
+#if MIN_VERSION_postgresql_binary(0, 14, 0)
+instance ToPG db IPRange where toPG = pure . inet
+#else
 instance ToPG db (NetAddr IP) where toPG = pure . inet
+#endif
 instance ToPG db Char where toPG = pure . char_utf8
 instance ToPG db Strict.Text where toPG = pure . text_strict
 instance ToPG db Lazy.Text where toPG = pure . text_lazy

--- a/squeal-postgresql/src/Squeal/PostgreSQL/Type/PG.hs
+++ b/squeal-postgresql/src/Squeal/PostgreSQL/Type/PG.hs
@@ -10,6 +10,7 @@ into corresponding Postgres types.
 -}
 {-# LANGUAGE
     AllowAmbiguousTypes
+  , CPP
   , DeriveAnyClass
   , DeriveFoldable
   , DeriveFunctor
@@ -57,12 +58,16 @@ import Data.Functor.Const (Const)
 import Data.Functor.Constant (Constant)
 import Data.Kind (Type)
 import Data.Int (Int16, Int32, Int64)
+#if MIN_VERSION_postgresql_binary(0, 14, 0)
+import Data.IP (IPRange)
+#else
+import Network.IP.Addr (NetAddr, IP)
+#endif
 import Data.Scientific (Scientific)
 import Data.Time (Day, DiffTime, LocalTime, TimeOfDay, TimeZone, UTCTime)
 import Data.Vector (Vector)
 import Data.UUID.Types (UUID)
 import GHC.TypeLits
-import Network.IP.Addr (NetAddr, IP)
 
 import qualified Data.ByteString.Lazy as Lazy (ByteString)
 import qualified Data.ByteString as Strict (ByteString)
@@ -166,7 +171,11 @@ instance IsPG DiffTime where type PG DiffTime = 'PGinterval
 -- | `PGuuid`
 instance IsPG UUID where type PG UUID = 'PGuuid
 -- | `PGinet`
+#if MIN_VERSION_postgresql_binary(0, 14, 0)
+instance IsPG IPRange where type PG IPRange = 'PGinet
+#else
 instance IsPG (NetAddr IP) where type PG (NetAddr IP) = 'PGinet
+#endif
 -- | `PGjson`
 instance IsPG Value where type PG Value = 'PGjson
 -- | `PGvarchar`


### PR DESCRIPTION
postgresql-binary-0.14, which is now in stackage nightlies, swaps out the type `NetAddr IP` from the `network-ip` package for its inet type with `IPRange` from the `iproute` package. This change adds CPP so that both build.